### PR TITLE
Add device bridge support for HIP and CUDA.

### DIFF
--- a/shark_turbine/ops/iree.py
+++ b/shark_turbine/ops/iree.py
@@ -72,12 +72,13 @@ class _test_add(CustomOp):
         t1_desc.specialize_all_dims()
         t2_desc = ksel.arg_tensor(1)
         t2_desc.specialize_all_dims()
-        result_desc = ksel.return_new_tensor(t1_desc.t.shape, t1_desc.t.dtype)
+        result_desc = ksel.return_new_tensor(list(t1_desc.t.shape), t1_desc.t.dtype)
         result_desc.specialize_all_dims()
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         t1, t2 = kb.arg_bindings
+        result_type = t1.type  # type: ignore
         result = Operation.create(
-            "tosa.add", results=[t1.type], operands=[t1, t2]
+            "tosa.add", results=[result_type], operands=[t1, t2]
         ).result
         kb.yield_results(result)

--- a/shark_turbine/ops/iree.py
+++ b/shark_turbine/ops/iree.py
@@ -8,6 +8,7 @@
 from typing import cast
 
 from ..support.ir_imports import (
+    Operation,
     RankedTensorType,
     StringAttr,
     Value,
@@ -60,3 +61,23 @@ class trace_tensor(CustomOp):
         key = cast(AttrArg, ksel.arg_descs[0])
         _emit_tensor_trace(kb, cast(str, key.v), [kb.arg_bindings[1]])
         kb.yield_results(kb.arg_bindings[1])
+
+
+@CustomOp.register(library=IREE_LIBRARY)
+class _test_add(CustomOp):
+    signature = "_test_add(Tensor t1, Tensor t2) -> (Tensor)"
+
+    def select(self, ksel: KernelSelection):
+        t1_desc = ksel.arg_tensor(0)
+        t1_desc.specialize_all_dims()
+        t2_desc = ksel.arg_tensor(1)
+        t2_desc.specialize_all_dims()
+        result_desc = ksel.return_new_tensor(t1_desc.t.shape, t1_desc.t.dtype)
+        result_desc.specialize_all_dims()
+
+    def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+        t1, t2 = kb.arg_bindings
+        result = Operation.create(
+            "tosa.add", results=[t1.type], operands=[t1, t2]
+        ).result
+        kb.yield_results(result)

--- a/shark_turbine/runtime/device.py
+++ b/shark_turbine/runtime/device.py
@@ -106,14 +106,14 @@ class DeviceState:
     @property
     def enumerated_path(self) -> str:
         try:
-            return self.enumerated_device_id["path"]
+            return self.enumerated_info["path"]
         except KeyError as e:
             raise RuntimeError("No enumerated path for device") from e
 
     @property
     def enumerated_name(self) -> str:
         try:
-            return self.enumerated_device_id["name"]
+            return self.enumerated_info["name"]
         except KeyError as e:
             raise RuntimeError("No enumerated name for device") from e
 
@@ -351,7 +351,9 @@ def _device_export_torch_tensor_cuda_hip(
     state = device._s
     device_type_code = state.dlpack_device_type_code
     assert device_type_code > 0
-    device_index = state.torch_device.index
+    torch_device = state.torch_device
+    assert torch_device is not None
+    device_index = torch_device.index
     t = torch.from_dlpack(
         device.hal_device.create_dlpack_capsule(bv, device_type_code, device_index)
     )

--- a/shark_turbine/runtime/device.py
+++ b/shark_turbine/runtime/device.py
@@ -334,6 +334,9 @@ def _device_export_torch_tensor_cpu(
 def _device_import_torch_tensor_cuda_hip(
     device: Device, t: torch.Tensor
 ) -> HalBufferView:
+    # We currently only support contiguous, so ensure that.
+    if not t.is_contiguous():
+        t = t.contiguous()
     # TODO: The 'None' here tells the producer to synchronize on the default
     # stream. For async, we should advance our timeline and signal when an
     # event is raised on Torch's stream at the current position.

--- a/shark_turbine/runtime/op_reg/base.py
+++ b/shark_turbine/runtime/op_reg/base.py
@@ -74,11 +74,10 @@ def def_library(ns) -> torch.library.Library:
 
 
 def default_dispatch_keys() -> list[str]:
-    # TODO: Dynamically determine what devices to register against.
-    # Note that we have to register against specific keys instead of the
-    # fallback, as fallback is too broad and breaks certain elements of
-    # fx tracing.
-    return ["CPU"]
+    keys = ["CPU"]
+    if torch.cuda.is_available():
+        keys.append("CUDA")
+    return keys
 
 
 # All such custom kernels are registered in the 'turbine' library/namespace.

--- a/shark_turbine/runtime/op_reg/compiler.py
+++ b/shark_turbine/runtime/op_reg/compiler.py
@@ -100,8 +100,10 @@ def compile_standalone_kernel(
     with kb.ip, Location.unknown():
         ksel.op.generate(ksel, kb)
     kb.module_op.verify()
+    # DO NOT SUBMIT: https://github.com/iree-org/iree/issues/17132
+    enable_debug_info = False
     module_asm = kb.module_op.get_asm(
-        binary=True, enable_debug_info=True, print_generic_op_form=False
+        binary=True, enable_debug_info=enable_debug_info, print_generic_op_form=False
     )
     generation_time = default_timer() - start
 

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -155,7 +155,7 @@ class TorchCUDAInterop(unittest.TestCase):
 
         t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0")
         result = iree_ops._test_add(t, t)
-        expected = torch.tensor([ 2.,  4.,  6.,  8., 10.], device="cpu")
+        expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu")
         torch.testing.assert_close(result.cpu(), expected)
 
 
@@ -165,7 +165,7 @@ class TorchCPUInterop(unittest.TestCase):
 
         t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cpu")
         result = iree_ops._test_add(t, t)
-        expected = torch.tensor([ 2.,  4.,  6.,  8., 10.], device="cpu")
+        expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu")
         torch.testing.assert_close(result, expected)
 
 

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -7,6 +7,7 @@
 import logging
 import unittest
 import threading
+import warnings
 
 import torch
 
@@ -120,6 +121,40 @@ class TorchCPUInterop(unittest.TestCase):
     def testCompilerFlags(self):
         d = get_device_from_torch(torch.device("cpu"))
         self.assertIn("--iree-hal-target-backends=llvm-cpu", d.compile_target_flags)
+
+
+# Make CUDA testing conditional.
+test_cuda_device = None
+if torch.cuda.is_available():
+    try:
+        test_cuda_device = torch.device("cuda:0")
+    except:
+        ...
+if test_cuda_device is None:
+    warnings.warn("Not testing CUDA interop (device not available)")
+
+
+@unittest.skipUnless(test_cuda_device, "CUDA not available")
+class TorchCUDAInterop(unittest.TestCase):
+    def setUp(self):
+        self._cuda_props = torch.cuda.get_device_properties(test_cuda_device)
+        print(self._cuda_props)
+        print(dir(self._cuda_props))
+        self._is_hip = False
+        if hasattr(self._cuda_props, "gcnArchName"):
+            print("Detected HIP device as CUDA")
+            self._is_hip = True
+
+    def testFromTorchDevice(self):
+        torch_device = torch.device("cuda:0")
+        device = get_device_from_torch(torch_device)
+        print(device.dump_device_info())
+
+    def testJit(self):
+        t = torch.tensor([1, 2, 3, 4, 5]).to("cuda:0")
+        from shark_turbine.ops import iree as iree_ops
+
+        iree_ops.trace_tensor("FOO", t)
 
 
 if __name__ == "__main__":

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -151,10 +151,10 @@ class TorchCUDAInterop(unittest.TestCase):
         print(device.dump_device_info())
 
     def testJit(self):
-        t = torch.tensor([1, 2, 3, 4, 5]).to("cuda:0")
         from shark_turbine.ops import iree as iree_ops
 
-        iree_ops.trace_tensor("FOO", t)
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0]).to("cuda:0")
+        print(iree_ops._test_add(t, t))
 
 
 if __name__ == "__main__":

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -153,8 +153,20 @@ class TorchCUDAInterop(unittest.TestCase):
     def testJit(self):
         from shark_turbine.ops import iree as iree_ops
 
-        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0]).to("cuda:0")
-        print(iree_ops._test_add(t, t))
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0")
+        result = iree_ops._test_add(t, t)
+        expected = torch.tensor([ 2.,  4.,  6.,  8., 10.], device="cpu")
+        torch.testing.assert_close(result.cpu(), expected)
+
+
+class TorchCPUInterop(unittest.TestCase):
+    def testJit(self):
+        from shark_turbine.ops import iree as iree_ops
+
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cpu")
+        result = iree_ops._test_add(t, t)
+        expected = torch.tensor([ 2.,  4.,  6.,  8., 10.], device="cpu")
+        torch.testing.assert_close(result, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Adds a custom IREE "_test_add" op which exercises actual code generation.
* Reworks the device management layer to:
  * Initialize our `Device` wrapper to maintain the correspondence between IREE HalDevice and PyTorch device.
  * Annotated Device with dlpack_device_type_code.
  * Detects whether the Torch device is for real-CUDA or AMDGPU/HIP CUDA and interfaces to the outside world correctly based on this.
  * Auto-detects the AMDGPU chip and the CUDA SM version and arranges for the JIT compiler to use that.
  * Dynamically enables custom kernel registration for CUDA if it is available.

Limitations (for now):

* IREE's dlpack interop only supports contiguous tensors. Lifting this requires further interfacing with the compiler to specialize on different strided layouts.
* Device synchronization is using dlpack's implicit default-stream synchronization. Since we are currently still JIT compiling in synchronous mode, we are skating by on this. Some additional hooks and APIs are needed to properly place stream events to do it for real.
* ROCM builds of torch seem to not have an easy way to map a device back to its UUID, and I didn't have a CUDA device handy to test the ways this is done on CUDA, so both are just relying on enumeration order on multi device systems. I kept the correspondence to a single place in the code and think I know how to fix this, but it will require some poking.


Depends on an IREE bump that includes: https://github.com/iree-org/iree/pull/17131 (but can go in without it since that only unblocks HIP/CUDA, which were not supported yet anyway)