### PR TITLE
[Export] Expose non strict mode for user

### DIFF
--- a/shark_turbine/aot/exporter.py
+++ b/shark_turbine/aot/exporter.py
@@ -170,6 +170,7 @@ def export(
     dynamic_shapes: Dict[str, Any] | Tuple[Any] | List[Any] | None = None,
     module_name: Optional[str] = None,
     function_name: Optional[str] = None,
+    strict_export: bool = True,
 ) -> ExportOutput:
     """Exports a torch.nn.Module.
 
@@ -217,6 +218,7 @@ def export(
     dynamic_shapes: Dict[str, Any] | Tuple[Any] | List[Any] | None = None,
     module_name: Optional[str] = None,
     function_name: Optional[str] = None,
+    strict_export: bool = True,
 ) -> ExportOutput:
     """Generic export of supported entities.
 
@@ -273,7 +275,11 @@ def export(
             )
         nn_module = mdl
         exported_program = torch.export.export(
-            nn_module, args=args, kwargs=kwargs, dynamic_shapes=dynamic_shapes
+            nn_module,
+            args=args,
+            kwargs=kwargs,
+            dynamic_shapes=dynamic_shapes,
+            strict=strict_export,
         )
         if current_decomps:
             from .decompositions import _patch_op_dispatch_for_export

--- a/tests/aot/non_strict_export_test.py
+++ b/tests/aot/non_strict_export_test.py
@@ -1,0 +1,38 @@
+import logging
+import unittest
+from torch import nn
+import torch
+
+from shark_turbine.aot import *
+
+logger = logging.getLogger(__file__)
+
+
+class NonStrictExportTest(unittest.TestCase):
+    def testNonStrictExport(self):
+        mdl = SimpleParams()
+        random_input = torch.randn((20))
+        exported = export(mdl, args=(random_input,), strict_export=False)
+        mlir_str = str(exported.mlir_module)
+        self.assertIn("func.func", mlir_str)
+
+    def testStrictExportFailure(self):
+        mdl = SimpleParams()
+        random_input = torch.randn((20))
+        with self.assertRaises(Exception):
+            export(mdl, args=(random_input,), strict_export=True)
+
+
+class SimpleParams(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.classifier = nn.Linear(20, 30)
+
+    def forward(self, x):
+        logger.warning(f"This will fail without disabling strict export mode")
+        return self.classifier(x)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
This exposes the option described in https://pytorch.org/tutorials/intermediate/torch_export_tutorial.html#non-strict-export to the user. This leads to way less graph breaks when using the export API. This is set to False by default because it is still experimental.

Fixes https://github.com/iree-org/iree-turbine/issues/12