### PR TITLE
Add ops.iree.transfer_to_logical_device() custom op.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-cache-dir -r iree-requirements.txt
+          pip install --no-cache-dir -r iree-requirements-ci.txt
           pip install -r requirements.txt -e .
 
       - name: Run unit tests

--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -1,0 +1,7 @@
+# Meant for CI jobs. We want to pin to a specific nightly version.
+# A normal user is supposed to install from iree-requirements.txt where we are
+# more forgiving on the exact version.
+
+--find-links https://iree.dev/pip-release-links.html
+iree-compiler==20240808.979
+iree-runtime==20240808.979

--- a/shark_turbine/ops/iree.py
+++ b/shark_turbine/ops/iree.py
@@ -8,6 +8,7 @@
 from typing import cast
 
 from ..support.ir_imports import (
+    Attribute,
     RankedTensorType,
     StringAttr,
     Value,
@@ -29,23 +30,12 @@ __all__ = [
 
 IREE_LIBRARY = def_library("iree")
 
-
 ################################################################################
 # trace_tensor / trace_tensors
 # See the flow.tensor_trace op for details. In essence:
 #   * trace_key is a name to label tensors with (intended for log filtering)
 #   * tensor or tensors are values to log a value for
 ################################################################################
-
-
-def _emit_tensor_trace(kb: KernelBuilder, key: str, ts: list[Value]):
-    dynamic_dims = []
-    for t in ts:
-        rtt = RankedTensorType(t.type)
-        for i in range(rtt.rank):
-            if rtt.is_dynamic_dim(i):
-                dynamic_dims.append(tensor_d.dim(t, kb.constant_index(i)))
-    flow_d.TensorTraceOp(StringAttr.get(key), ts, dynamic_dims)
 
 
 @CustomOp.register(library=IREE_LIBRARY)
@@ -60,3 +50,68 @@ class trace_tensor(CustomOp):
         key = cast(AttrArg, ksel.arg_descs[0])
         _emit_tensor_trace(kb, cast(str, key.v), [kb.arg_bindings[1]])
         kb.yield_results(kb.arg_bindings[1])
+
+
+################################################################################
+# transfer_to_logical_device
+# This is a graph-mode meta-data op which transfers a tensor to a local, logical
+# device managed by the runtime. In this context, there may or may not be any
+# correspondence between such local devices and Torch devices: they may be
+# shards of a CPU/GPU, otherwise unaddressable NPU device, abacus, etc.
+# The actual device assignment is late bound at compilation time, and the
+# reference here is just a logical name.
+#
+# All Turbine programs have a logical device "0" that is used for anything not
+# otherwise annotated. This means that for common use cases like sharding across
+# homogenous devices, there can easily be a "1", "2", etc. However, note that
+# there is nothing at this level that requires devices to be homogenous or
+# named in such a way. Internal to the module, this will require that a symbol
+# with the name "__device.{moniker}" is provided in some fashion (spec file,
+# command line flags, etc).
+#
+# Within a graph, transfering tensors to a device causes partitioning and
+# optimization of placement of consuming compute operations. Under the covers,
+# this maps to:
+#   flow.tensor.transfer %t to #hal.device.promise<@moniker>
+################################################################################
+
+
+@CustomOp.register(library=IREE_LIBRARY)
+class transfer_to_logical_device(CustomOp):
+    signature = "transfer_to_logical_device(str moniker, Tensor tensor) -> Tensor"
+
+    def select(self, ksel: KernelSelection):
+        ksel.attr_str(0)
+        ta = ksel.arg_tensor(1)
+        ksel.return_tensor(ta.t)
+
+    def eager_execute(self, device_moniker, tensor):
+        return tensor
+
+    def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+        moniker = cast(AttrArg, ksel.arg_descs[0]).v
+        t = kb.arg_bindings[1]
+        dynamic_dims: list[Value] = []
+        _append_dynamic_dims(kb, dynamic_dims, t)
+        target = Attribute.parse(f'#hal.device.promise<@"__device.{moniker}">')
+        result = flow_d.TensorTransferOp(t, dynamic_dims, target).result
+        kb.yield_results(result)
+
+
+################################################################################
+# Emission utilities
+################################################################################
+
+
+def _append_dynamic_dims(kb: KernelBuilder, dynamic_dims: list[Value], tensor: Value):
+    rtt = RankedTensorType(tensor.type)
+    for i in range(rtt.rank):
+        if rtt.is_dynamic_dim(i):
+            dynamic_dims.append(tensor_d.dim(tensor, kb.constant_index(i)))
+
+
+def _emit_tensor_trace(kb: KernelBuilder, key: str, ts: list[Value]):
+    dynamic_dims: list[Value] = []
+    for t in ts:
+        _append_dynamic_dims(kb, dynamic_dims, t)
+    flow_d.TensorTraceOp(StringAttr.get(key), ts, dynamic_dims)

--- a/shark_turbine/ops/iree.py
+++ b/shark_turbine/ops/iree.py
@@ -93,7 +93,7 @@ class transfer_to_logical_device(CustomOp):
         t = kb.arg_bindings[1]
         dynamic_dims: list[Value] = []
         _append_dynamic_dims(kb, dynamic_dims, t)
-        target = Attribute.parse(f'#hal.device.promise<@"__device.{moniker}">')
+        target = Attribute.parse(f'#hal.device.promise<@"__device_{moniker}">')
         result = flow_d.TensorTransferOp(t, dynamic_dims, target).result
         kb.yield_results(result)
 

--- a/tests/ops/iree_test.py
+++ b/tests/ops/iree_test.py
@@ -8,14 +8,48 @@ import logging
 import unittest
 
 import torch
+import torch.nn as nn
 
+import shark_turbine.aot as aot
 import shark_turbine.ops as ops
 
 
-class KernelRegTest(unittest.TestCase):
-    def testTrace(self):
+# See runtime/op_reg/kernel_aot_test.py for additional tests of the trace
+# op.
+class TraceTensorTest(unittest.TestCase):
+    def testEager(self):
         t = torch.randn(3, 4)
         ops.iree.trace_tensor("TEST", t)
+
+    def testAOT(self):
+        class MyModule(nn.Module):
+            def forward(self, x):
+                ops.iree.trace_tensor("TEST", x)
+                return x + 1
+
+        cm = aot.export(MyModule(), args=(torch.empty(9, 8),))
+        asm = str(cm.mlir_module)
+        self.assertIn('flow.tensor.trace "TEST" =', asm)
+
+
+class TransferToLogicalDeviceTest(unittest.TestCase):
+    def testEager(self):
+        t1 = torch.randn(3, 4)
+        t2 = ops.iree.transfer_to_logical_device("1", t1)
+        self.assertIs(t1, t2)
+
+    def testAOT(self):
+        class MyModule(nn.Module):
+            def forward(self, x):
+                y = x + 1
+                z = ops.iree.transfer_to_logical_device("1", y)
+                return z + 1
+
+        cm = aot.export(MyModule(), args=(torch.empty(9, 8),))
+        asm = str(cm.mlir_module)
+        self.assertRegex(
+            asm, "flow.tensor.transfer %.+ to #hal.device.promise<@__device.1>"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This exposes IREE's multi-device capabilities to PyTorch programs, allowing them to transfer parts of the computation to other devices. This will be used as part of the sharding work in sharktank to do auto placement of sharded tensors (i.e. across GPU devices, etc). But it is also available for heterogenous/ad-hoc offload to other devices (GPU slices, CPU slices, NPU, etc).

Since this is the first op we have that has different eager vs graph mode semantics, add a new CustomOp.eager_execute() hook which allows the eager execution semantics to be specified separately from graph compilation. Since these local device transfers are only meaningful within an IREE program, they are no-ops during eager execution.

(requires a WIP branch on IREE)