### PR TITLE
Load pins from iree-requirements.txt in setup.py.

### DIFF
--- a/iree-requirements.txt
+++ b/iree-requirements.txt
@@ -1,3 +1,3 @@
---extra-index-url https://iree.dev/pip-release-links.html
+--find-links https://iree.dev/pip-release-links.html
 iree-compiler==20240514.893
 iree-runtime==20240514.893

--- a/iree-requirements.txt
+++ b/iree-requirements.txt
@@ -1,3 +1,3 @@
---index-url https://iree.dev/pip-release-links.html
+--extra-index-url https://iree.dev/pip-release-links.html
 iree-compiler==20240514.893
 iree-runtime==20240514.893

--- a/iree-requirements.txt
+++ b/iree-requirements.txt
@@ -1,3 +1,3 @@
---find-links https://iree.dev/pip-release-links.html
+--index-url https://iree.dev/pip-release-links.html
 iree-compiler==20240514.893
 iree-runtime==20240514.893

--- a/iree-requirements.txt
+++ b/iree-requirements.txt
@@ -1,2 +1,3 @@
+--find-links https://iree.dev/pip-release-links.html
 iree-compiler==20240514.893
 iree-runtime==20240514.893

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ def load_requirement_pins(requirements_file: str):
 
 
 load_requirement_pins("requirements.txt")
+load_requirement_pins("iree-requirements.txt")
 
 
 def get_version_spec(dep: str):


### PR DESCRIPTION
Without this, pip installs require the unqualified `iree-compiler` package.
With this, pip installs require the `iree-compiler>=[version pin]` package (note that `get_version_spec` here is inserting the `>=`, even if the requirements file has `==`)

This helps for https://github.com/nod-ai/sharktank/tree/main?tab=readme-ov-file#install-development-packages with these instructions:
```
# Clone and install editable iree-turbine dep in deps/
pip install -f https://iree.dev/pip-release-links.html --src deps \
  -e "git+https://github.com/iree-org/iree-turbine.git#egg=shark-turbine"
```