### PR TITLE
Update mm_group_quant.py template for MLIR upstream change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-cache-dir -r iree-requirements.txt
+          pip install --no-cache-dir -r iree-requirements.txt -f https://iree.dev/pip-release-links.html
           pip install -r requirements.txt -e .
 
       - name: Run unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
+          pip install --no-cache-dir -r iree-requirements.txt
           pip install -r requirements.txt -e .
 
       - name: Run unit tests

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -43,6 +43,7 @@ jobs:
       - name: "Install SHARK"
         run: |
           cd $GITHUB_WORKSPACE/SHARK
+          sed -i 's/iree-turbine#/iree-turbine.git@${{github.sha}}#/g' requirements.txt
           ./setup_venv.sh
           source shark.venv/bin/activate
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -44,8 +44,5 @@ jobs:
       - name: "Install SHARK"
         run: |
           cd $GITHUB_WORKSPACE/SHARK
-          python${{ matrix.version }} -m venv shark.venv
-          source shark.venv/bin/activate
-          pip install -r requirements.txt --no-cache-dir
-          pip install -e .
+          ./setup_venv.sh
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -49,8 +49,4 @@ jobs:
           sed -i 's/iree-turbine#/iree-turbine.git@${{github.sha}}#/g' requirements.txt
           pip install -r requirements.txt --no-cache-dir
           pip install -e .
-          pip uninstall -y torch
-          pip install torch==2.1.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip uninstall -y mpmath
-          pip install mpmath==1.3.0
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -45,4 +45,5 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/SHARK
           ./setup_venv.sh
+          source shark.venv/bin/activate
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -45,4 +45,5 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/SHARK
           ./setup_venv.sh
+          pip install -e $GITHUB_WORKSPACE -r $GITHUB_WORKSPACE/requirements.txt
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -46,7 +46,6 @@ jobs:
           cd $GITHUB_WORKSPACE/SHARK
           python${{ matrix.version }} -m venv shark.venv
           source shark.venv/bin/activate
-          sed -i 's/iree-turbine#/iree-turbine.git@${{github.sha}}#/g' requirements.txt
           pip install -r requirements.txt --no-cache-dir
           pip install -e .
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -45,5 +45,4 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/SHARK
           ./setup_venv.sh
-          pip install -e $GITHUB_WORKSPACE -r $GITHUB_WORKSPACE/requirements.txt
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -40,7 +40,6 @@ jobs:
           path: SHARK
           ref: "iree-turbine-switch"
 
-      # TODO: Replace with a sh script from shark repo
       - name: "Install SHARK"
         run: |
           cd $GITHUB_WORKSPACE/SHARK

--- a/shark_turbine/transforms/quantization/mm_group_quant.py
+++ b/shark_turbine/transforms/quantization/mm_group_quant.py
@@ -91,12 +91,12 @@ module {{
     %empty_0 = tensor.empty() : tensor<{k}x{group0}x{group1}x{element_type}>
     %weight_cast = linalg.generic {{
         indexing_maps = [
-            affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
-            affine_map<(d0, d1, d2) -> (d0, d1)>, 
-            affine_map<(d0, d1, d2) -> (d0, d1)>, 
-            affine_map<(d0, d1, d2) -> (d0, d1, d2)>], 
-        iterator_types = ["parallel", "parallel", "parallel"] }} 
-        ins(%weight_exp, %scale, %zp : tensor<{k}x{group0}x{group1}x{lowp_type}>, tensor<{k}x{group0}x{element_type}>, tensor<{k}x{group0}x{element_type}>) 
+            affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+            affine_map<(d0, d1, d2) -> (d0, d1)>,
+            affine_map<(d0, d1, d2) -> (d0, d1)>,
+            affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+        iterator_types = ["parallel", "parallel", "parallel"] }}
+        ins(%weight_exp, %scale, %zp : tensor<{k}x{group0}x{group1}x{lowp_type}>, tensor<{k}x{group0}x{element_type}>, tensor<{k}x{group0}x{element_type}>)
         outs(%empty_0 : tensor<{k}x{group0}x{group1}x{element_type}>) {{
     ^bb0(%in: {lowp_type}, %in_1: {element_type}, %in_2: {element_type}, %out: {element_type}):
         %16 = arith.extui %in : {lowp_type} to i32
@@ -112,10 +112,10 @@ module {{
     %result = linalg.generic {{
         indexing_maps = [
             affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>,
-            affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>, 
-            affine_map<(d0, d1, d2, d3) -> (d0, d1)>], 
-        iterator_types = ["parallel", "parallel", "reduction", "reduction"] }} 
-        ins(%a_exp, %weight_cast : tensor<{m}x{group0}x{group1}x{element_type}>, tensor<{k}x{group0}x{group1}x{element_type}>) 
+            affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>,
+            affine_map<(d0, d1, d2, d3) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel", "reduction", "reduction"] }}
+        ins(%a_exp, %weight_cast : tensor<{m}x{group0}x{group1}x{element_type}>, tensor<{k}x{group0}x{group1}x{element_type}>)
         outs(%zero_init : tensor<{m}x{k}x{element_type}>) {{
     ^bb0(%in: {element_type}, %in_1: {element_type}, %out: {element_type}):
         %16 = arith.mulf %in, %in_1 : {element_type}

--- a/shark_turbine/transforms/quantization/mm_group_quant.py
+++ b/shark_turbine/transforms/quantization/mm_group_quant.py
@@ -75,7 +75,7 @@ module {{
   util.global private @{param_name}.quant.zero_point {{noinline}} = #stream.parameter.named<"model"::"{param_name}_zp"> : tensor<{k}x{group0}x{element_type}>
 
   func.func private @compute_mm_group_quant(%a : tensor<{m}x{n}x{element_type}>) -> tensor<{m}x{k}x{element_type}> {{
-    %c0 = arith.constant 0 : index        
+    %c0 = arith.constant 0 : index
     %weight_raw = util.global.load @{param_name} : tensor<{k}x{n_div}xi8>
     %m = tensor.dim %a, %c0 : tensor<{m}x{n}x{element_type}>
     %k = tensor.dim %weight_raw, %c0 : tensor<{k}x{n_div}xi8>


### PR DESCRIPTION
Must feed in output shape to the tensor.expand_shape op after an upstream change. This allows us to patch IR for quantized llama2.