### PR TITLE
Add workaround for roundtripping 0d tensors in parameter archive.

### DIFF
--- a/shark_turbine/aot/params.py
+++ b/shark_turbine/aot/params.py
@@ -267,10 +267,14 @@ class ParameterArchiveBuilder:
     def add_tensor(self, name: str, tensor: torch.Tensor):
         """Adds an named tensor to the archive."""
         metadata = _make_tensor_metadata(tensor)
+        # 0d arrays are special in both torch/numpy in different ways that makes
+        # it hard to reliably get a memory view of their contents. Since we
+        # know that 0d is always small, we just force a copy when in numpy
+        # land and that seems to get it on the happy path.
         # See: https://github.com/iree-org/iree-turbine/issues/29
         if len(tensor.shape) == 0:
-            flat_array = tensor.detach().cpu().numpy()
-            host_array = bytes(flat_array)
+            flat_array = tensor.detach().cpu().numpy().copy()
+            host_array = flat_array
         else:
             flat_array = tensor.detach().flatten().contiguous().cpu().view(torch.uint8)
             host_array = flat_array.numpy()

--- a/tests/aot/params_test.py
+++ b/tests/aot/params_test.py
@@ -63,6 +63,19 @@ class ParamsTest(unittest.TestCase):
             scalar = items["scalar"].as_tensor()
             torch.testing.assert_close(orig_scalar, scalar)
 
+    def testRoundtripScalarUint8(self):
+        # See: https://github.com/iree-org/iree-turbine/issues/29
+        with tempfile.TemporaryDirectory() as td:
+            file_path = Path(td) / "archive.irpa"
+            orig_scalar = torch.tensor(8, dtype=torch.uint8)
+            builder = ParameterArchiveBuilder()
+            builder.add_tensor("scalar", orig_scalar)
+            builder.save(file_path)
+            archive = ParameterArchive(file_path, mmap=False)
+            items = dict(archive.items())
+            scalar = items["scalar"].as_tensor()
+            torch.testing.assert_close(orig_scalar, scalar)
+
     def testCreateArchiveWithPrefixScope(self):
         with tempfile.TemporaryDirectory() as td:
             file_path = Path(td) / "archive.irpa"

--- a/tests/aot/params_test.py
+++ b/tests/aot/params_test.py
@@ -18,6 +18,7 @@ from shark_turbine.aot import (
     save_module_parameters,
     ExternalTensorTrait,
     ParameterArchive,
+    ParameterArchiveBuilder,
 )
 
 
@@ -48,6 +49,19 @@ class ParamsTest(unittest.TestCase):
             bias = items["classifier.bias"].as_tensor()
             torch.testing.assert_close(weight, m.classifier.weight)
             torch.testing.assert_close(bias, m.classifier.bias)
+
+    def testRoundtripScalarTensor(self):
+        # See: https://github.com/iree-org/iree-turbine/issues/29
+        with tempfile.TemporaryDirectory() as td:
+            file_path = Path(td) / "archive.irpa"
+            orig_scalar = torch.tensor(0.5, dtype=torch.float32)
+            builder = ParameterArchiveBuilder()
+            builder.add_tensor("scalar", orig_scalar)
+            builder.save(file_path)
+            archive = ParameterArchive(file_path, mmap=False)
+            items = dict(archive.items())
+            scalar = items["scalar"].as_tensor()
+            torch.testing.assert_close(orig_scalar, scalar)
 
     def testCreateArchiveWithPrefixScope(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Fixes #29