### PR TITLE
Starts adding some systematic runtime torture tests.

### DIFF
--- a/examples/runtime_torture/README.md
+++ b/examples/runtime_torture/README.md
@@ -1,0 +1,4 @@
+# Runtime torture tests
+
+These examples aim to stress the torch<->iree runtime in various ways both as a
+tool for developing and in order to find low-rate issues.

--- a/examples/runtime_torture/launchable_torture.py
+++ b/examples/runtime_torture/launchable_torture.py
@@ -35,14 +35,14 @@ class TestLinearModel(nn.Module):
         return nn.functional.tanh(result)
 
 
-def test_sequential(nreps, device):
+def test_sequential(nreps, device, dtype):
     print("*** run test_sequential:")
     print("------------------------")
     print("*** compiling model")
     torch.manual_seed(42)
-    initial_input = torch.rand([512, 512], dtype=torch.float16)
-    weight = torch.rand([512, 512], dtype=torch.float16)
-    bias = torch.rand([512], dtype=torch.float16)
+    initial_input = torch.rand([512, 512], dtype=dtype)
+    weight = torch.rand([512, 512], dtype=dtype)
+    bias = torch.rand([512], dtype=dtype)
     eo = aot.export(TestLinearModel(), args=(initial_input, weight, bias))
     launcher = Launchable.jit_compile(str(eo.mlir_module))
     launcher.preload(device)
@@ -81,11 +81,14 @@ def main(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--nreps", type=int, default=100)
     parser.add_argument("--device", type=str, default="cpu")
+    parser.add_argument("--dtype", type=str, default="float16")
     args = parser.parse_args(argv)
 
+    dtype = getattr(torch, args.dtype)
     device = torch.device(args.device)
     print("Running on device:", device)
-    test_sequential(nreps=args.nreps, device=device)
+    print("Using dtype:", dtype)
+    test_sequential(nreps=args.nreps, device=device, dtype=dtype)
 
 
 if __name__ == "__main__":

--- a/examples/runtime_torture/launchable_torture.py
+++ b/examples/runtime_torture/launchable_torture.py
@@ -1,0 +1,92 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+from contextlib import contextmanager
+import sys
+from time import perf_counter
+
+import torch
+import torch.nn as nn
+
+import shark_turbine.aot as aot
+
+from shark_turbine.runtime import (
+    Launchable,
+)
+
+
+@contextmanager
+def report_time(banner):
+    t1 = perf_counter()
+    yield
+    t2 = perf_counter()
+    print(f"{banner}: {(t2 - t1) * 1000}ms")
+
+
+class TestLinearModel(nn.Module):
+    def forward(self, input, weight, bias):
+        result = nn.functional.linear(input, weight, bias)
+        scale = 1 / 256.0
+        result = result * scale
+        return nn.functional.tanh(result)
+
+
+def test_sequential(nreps, device):
+    print("*** run test_sequential:")
+    print("------------------------")
+    print("*** compiling model")
+    torch.manual_seed(42)
+    initial_input = torch.rand([512, 512], dtype=torch.float16)
+    weight = torch.rand([512, 512], dtype=torch.float16)
+    bias = torch.rand([512], dtype=torch.float16)
+    eo = aot.export(TestLinearModel(), args=(initial_input, weight, bias))
+    launcher = Launchable.jit_compile(str(eo.mlir_module))
+    launcher.preload(device)
+    print("*** preloaded")
+
+    # Compute reference.
+    ref_model = TestLinearModel()
+    ref_input = initial_input.to(device)
+    ref_weight = weight.to(device)
+    ref_bias = bias.to(device)
+    print("*** moved ref inputs to device")
+    with report_time("reference total time"):
+        for i in range(nreps):
+            ref_output = ref_model(ref_input, ref_weight, ref_bias)
+            ref_input = ref_output
+        ref_output = ref_output.to(device="cpu").clone()
+    print(ref_output)
+
+    # Compute test.
+    test_input = initial_input.to(device)
+    test_weight = weight.to(device)
+    test_bias = bias.to(device)
+    print("*** moved inputs to device")
+
+    with report_time("turbine total time"):
+        for i in range(nreps):
+            test_output = launcher(test_input, test_weight, test_bias)
+            test_input = test_output
+        test_output = test_output.to(device="cpu").clone()
+    print(test_output)
+
+    torch.testing.assert_close(ref_output, test_output)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--nreps", type=int, default=100)
+    parser.add_argument("--device", type=str, default="cpu")
+    args = parser.parse_args(argv)
+
+    device = torch.device(args.device)
+    print("Running on device:", device)
+    test_sequential(nreps=args.nreps, device=device)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/shark_turbine/runtime/launch.py
+++ b/shark_turbine/runtime/launch.py
@@ -212,7 +212,7 @@ def _export_torch_tensor(bv: HalBufferView, turbine_device: Device) -> Tensor:
     # But since the whole purpose of this is for interfacing a blackbox, we
     # just infer from IREE type -> torch type. This may be lossy on dtypes
     # that are not an exact match, and the user is expected to bitcast.
-    dtype = _INFERRED_ELEMENT_TYPE_TO_DTYPE[bv.element_type]
+    dtype = _INFERRED_ELEMENT_TYPE_TO_DTYPE[int(bv.element_type)]
     if dtype is None:
         raise NotImplementedError(
             f"HalBufferView.element_type({bv.element_type}) has no mapping to dtype"
@@ -226,23 +226,23 @@ def _export_torch_tensor(bv: HalBufferView, turbine_device: Device) -> Tensor:
 # signed/unsigned distinctions at this layer, so we do the best we can.
 # If this becomes less special purpose, move it to conversions.py
 _INFERRED_ELEMENT_TYPE_TO_DTYPE: dict[HalElementType, torch.dtype] = {
-    HalElementType.BFLOAT_16: torch.bfloat16,
-    HalElementType.BOOL_8: torch.bool,
-    HalElementType.COMPLEX_64: torch.complex64,
-    HalElementType.COMPLEX_128: torch.complex128,
-    HalElementType.FLOAT_16: torch.float16,
-    HalElementType.FLOAT_32: torch.float32,
-    HalElementType.FLOAT_64: torch.float64,
-    HalElementType.INT_8: torch.int8,
-    HalElementType.INT_16: torch.int16,
-    HalElementType.INT_32: torch.int32,
-    HalElementType.INT_64: torch.int64,
-    HalElementType.SINT_8: torch.int8,
-    HalElementType.SINT_16: torch.int16,
-    HalElementType.SINT_32: torch.int32,
-    HalElementType.SINT_64: torch.int64,
-    HalElementType.UINT_8: torch.uint8,
-    HalElementType.UINT_16: torch.uint16,
-    HalElementType.UINT_32: torch.uint32,
-    HalElementType.UINT_64: torch.uint64,
+    int(HalElementType.BFLOAT_16): torch.bfloat16,
+    int(HalElementType.BOOL_8): torch.bool,
+    int(HalElementType.COMPLEX_64): torch.complex64,
+    int(HalElementType.COMPLEX_128): torch.complex128,
+    int(HalElementType.FLOAT_16): torch.float16,
+    int(HalElementType.FLOAT_32): torch.float32,
+    int(HalElementType.FLOAT_64): torch.float64,
+    int(HalElementType.INT_8): torch.int8,
+    int(HalElementType.INT_16): torch.int16,
+    int(HalElementType.INT_32): torch.int32,
+    int(HalElementType.INT_64): torch.int64,
+    int(HalElementType.SINT_8): torch.int8,
+    int(HalElementType.SINT_16): torch.int16,
+    int(HalElementType.SINT_32): torch.int32,
+    int(HalElementType.SINT_64): torch.int64,
+    int(HalElementType.UINT_8): torch.uint8,
+    int(HalElementType.UINT_16): torch.uint16,
+    int(HalElementType.UINT_32): torch.uint32,
+    int(HalElementType.UINT_64): torch.uint64,
 }


### PR DESCRIPTION
Previously we've only had unit tests and live use. Adding some systematic examples aimed at stressing the torch<->iree runtime layer.

Also fixed an enum issue that is at IREE head (fallout from the nanobind update).

CPU results:

```
reference total time: 4570.794267579913ms
tensor([[0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1888, 0.1885],
        ...,
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1885],
        [0.1936, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1990, 0.1912,  ..., 0.1970, 0.1888, 0.1885]],
       dtype=torch.float16)
*** moved inputs to device
turbine total time: 128.97808896377683ms
tensor([[0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1888, 0.1885],
        ...,
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1885],
        [0.1936, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1990, 0.1912,  ..., 0.1970, 0.1888, 0.1885]],
       dtype=torch.float16)
```

W7900 Pro results:

```
reference total time: 165.0672871619463ms
tensor([[0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1888, 0.1885],
        ...,
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1885],
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1990, 0.1912,  ..., 0.1970, 0.1888, 0.1885]],
       dtype=torch.float16)
*** moved inputs to device
turbine total time: 10.792724788188934ms
tensor([[0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1936, 0.1991, 0.1913,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1888, 0.1885],
        ...,
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1885],
        [0.1935, 0.1991, 0.1912,  ..., 0.1971, 0.1890, 0.1886],
        [0.1935, 0.1990, 0.1912,  ..., 0.1970, 0.1888, 0.1885]],
       dtype=torch.float16)
```