### PR TITLE
Add TKW graph expansion

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -34,7 +34,11 @@ def launch(func: Callable[[], None]) -> Callable[[], None]:
 
 @launch
 def test_read():
-    @tkw.wave()
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1, 1])
+    ]
+
+    @tkw.wave(constraints)
     def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
         tkw.read(a)
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -35,7 +35,7 @@ def launch(func: Callable[[], None]) -> Callable[[], None]:
 @launch
 def test_read():
     constraints: list[tkw.Constraint] = [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1, 1])
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
 
     @tkw.wave(constraints)

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -1,0 +1,93 @@
+# RUN: python %s | FileCheck %s
+
+import logging
+from typing import Callable
+import unittest
+import shark_turbine.kernel as tk
+import shark_turbine.kernel.lang as tkl
+import shark_turbine.kernel.wave as tkw
+from shark_turbine.kernel.wave.expansion import expand_graph
+from shark_turbine.kernel._support.tracing import CapturedTrace
+from shark_turbine.kernel.ops.wave_ops import get_custom
+
+
+def run(func: Callable[[], None]) -> Callable[[], None]:
+    """Run a function as part of the test suite."""
+    if __name__ == "__main__":
+        func()
+
+    return func
+
+
+def print_trace(trace: CapturedTrace):
+    """
+    Prints all subgraphs of a trace starting with the root graph.
+    The graphs are printed first in the torch printing format and then using
+    our custom node format.
+    """
+    # The root graph is at the back so we print the subgraphs in reverse order
+    for subgraph in reversed(list(trace.region_graph.subgraphs.values())):
+        print(subgraph)
+        for node in subgraph.nodes:
+            print(get_custom(node))
+
+
+# Input sizes
+M = tkl.sym.M
+N = tkl.sym.N
+K = tkl.sym.K
+
+# Workgroup tile sizes
+BLOCK_M = tkl.sym.BLOCK_M
+BLOCK_N = tkl.sym.BLOCK_N
+BLOCK_K = tkl.sym.BLOCK_L
+
+# Address space (for GPU, shared(1) or global(0))
+ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+
+@tkw.wave_trace_only()
+def read_write(
+    a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    c: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f32],
+):
+    a_reg = tkw.read(a, elements_per_thread=4)
+    tkw.write(a_reg, c, elements_per_thread=4)
+
+
+def test_read_write():
+    with tk.gen.TestLaunchContext({}):
+        graph = read_write()
+        expand_graph(graph)
+        print_trace(graph)
+
+
+@tkw.wave_trace_only()
+def gemm(
+    a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+    b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+    c: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f32],
+):
+    c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+    @tkw.reduction(K, init_args=[c_reg])
+    def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+        a_reg = tkw.read(a, elements_per_thread=4)
+        b_reg = tkw.read(b, elements_per_thread=4)
+        acc = tkw.mma(a_reg, b_reg, acc)
+        return acc
+
+    tkw.write(repeat, c, elements_per_thread=4)
+
+
+@run
+def test_gemm():
+    with tk.gen.TestLaunchContext({}):
+        graph = gemm()
+        expand_graph(graph)
+        print_trace(graph)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -77,22 +77,22 @@ def test_read_write_equal_sizes():
         expand_graph(graph, constraints)
         print_trace(graph)
         # CHECK: %a
-        # CHECK: %c
-        # CHECK: %read
+        # CHECK-NEXT: %c
+        # CHECK-NEXT: %read
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_1_1
+        # CHECK-NEXT: %read_1_1
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_1_0
+        # CHECK-NEXT: %read_1_0
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_0_1
+        # CHECK-NEXT: %read_0_1
         # CHECK-SAME: (%a, 4)
-        # CHECK: %write_0_0
+        # CHECK-NEXT: %write_0_0
         # CHECK-SAME: (%read, %c, 4)
-        # CHECK: %write_1_1
+        # CHECK-NEXT: %write_1_1
         # CHECK-SAME: (%read_1_1, %c, 4)
-        # CHECK: %write_1_0
+        # CHECK-NEXT: %write_1_0
         # CHECK-SAME: (%read_1_0, %c, 4)
-        # CHECK: %write_0_1
+        # CHECK-NEXT: %write_0_1
         # CHECK-SAME: (%read_0_1, %c, 4)
 
         # CHECK: -----
@@ -127,18 +127,18 @@ def test_read_write():
         expand_graph(graph, constraints)
         print_trace(graph)
         # CHECK: %a
-        # CHECK: %c
-        # CHECK: %read_0_0_0
+        # CHECK-NEXT: %c
+        # CHECK-NEXT: %read_0_0_0
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_1_0_0
+        # CHECK-NEXT: %read_1_0_0
         # CHECK-SAME: (%a, 4)
-        # CHECK: %write_0_0_0
+        # CHECK-NEXT: %write_0_0_0
         # CHECK-SAME: (%read_0_0_0, %c, 4)
-        # CHECK: %write_1_0_1
+        # CHECK-NEXT: %write_1_0_1
         # CHECK-SAME: (%read_1_0_0, %c, 4)
-        # CHECK: %write_1_0_0
+        # CHECK-NEXT: %write_1_0_0
         # CHECK-SAME: (%read_1_0_0, %c, 4)
-        # CHECK: %write_0_0_1
+        # CHECK-NEXT: %write_0_0_1
         # CHECK-SAME: (%read_0_0_0, %c, 4)
 
         # CHECK: -----
@@ -183,73 +183,73 @@ def test_gemm():
         print_trace(graph)
         # Root graph:
         # CHECK: %a
-        # CHECK: %b
-        # CHECK: %c
-        # CHECK: %register_0_0_0
-        # CHECK: %register_1_1_0
-        # CHECK: %register_1_0_0
-        # CHECK: %register_0_1_0
-        # CHECK: %reduction
-        # CHECK: %getresult_1_1_0
-        # CHECK: %getresult_1_0_0
-        # CHECK: %getresult_0_1_0
-        # CHECK: %getresult_0_0_0
-        # CHECK: %write_0_0_0
+        # CHECK-NEXT: %b
+        # CHECK-NEXT: %c
+        # CHECK-NEXT: %register_0_0_0
+        # CHECK-NEXT: %register_1_1_0
+        # CHECK-NEXT: %register_1_0_0
+        # CHECK-NEXT: %register_0_1_0
+        # CHECK-NEXT: %reduction
+        # CHECK-NEXT: %getresult_1_1_0
+        # CHECK-NEXT: %getresult_1_0_0
+        # CHECK-NEXT: %getresult_0_1_0
+        # CHECK-NEXT: %getresult_0_0_0
+        # CHECK-NEXT: %write_0_0_0
         # TODO: This link-up is not yet correct!
         # CHECK-SAME: (%reduction, %c, 4)
-        # CHECK: %write_1_1_0
+        # CHECK-NEXT: %write_1_1_0
         # CHECK-SAME: (%get_result_1_1_0, %c, 4)
-        # CHECK: %write_1_0_0
+        # CHECK-NEXT: %write_1_0_0
         # CHECK-SAME: (%get_result_1_0_0, %c, 4)
-        # CHECK: %write_0_1_0
+        # CHECK-NEXT: %write_0_1_0
         # CHECK-SAME: (%get_result_0_1_0, %c, 4)
 
         # Reduction subgraph:
 
         # CHECK: %acc_0_0_0
-        # CHECK: %acc_1_1_0
-        # CHECK: %acc_1_0_0
-        # CHECK: %acc_0_1_0
+        # CHECK-NEXT: %acc_1_1_0
+        # CHECK-NEXT: %acc_1_0_0
+        # CHECK-NEXT: %acc_0_1_0
 
-        # CHECK: %a
-        # CHECK: %read_0_0_0
+        # CHECK-NEXT: %a
+        # CHECK-NEXT: %read_0_0_0
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_0_0_1
+        # CHECK-NEXT: %read_0_0_1
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_1_0_0
+        # CHECK-NEXT: %read_1_0_0
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_1_0_1
+        # CHECK-NEXT: %read_1_0_1
         # CHECK-SAME: (%a, 4)
 
-        # CHECK: %b
-        # CHECK: %read_0_0_0
+        # CHECK-NEXT: %b
+        # CHECK-NEXT: %read_0_0_0
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_0_1
+        # CHECK-NEXT: %read_0_0_1
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_1_0
+        # CHECK-NEXT: %read_0_1_0
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_1_1
+        # CHECK-NEXT: %read_0_1_1
         # CHECK-SAME: (%b, 4)
 
-        # CHECK: %mma_0_0_0
+        # CHECK-NEXT: %mma_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc)
-        # CHECK: %mma_0_0_1
+        # CHECK-NEXT: %mma_0_0_1
         # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0)
-        # CHECK: %mma_1_1_0
+        # CHECK-NEXT: %mma_1_1_0
         # CHECK-SAME: (%read_1_0_0, %read_0_1_0, %acc_1_1_0)
-        # CHECK: %mma_1_1_1
+        # CHECK-NEXT: %mma_1_1_1
         # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_1_1_0)
-        # CHECK: %mma_1_0_0
+        # CHECK-NEXT: %mma_1_0_0
         # CHECK-SAME: (%read_1_0_0, %read_0_0_0, %acc_1_0_0)
-        # CHECK: %mma_1_0_1
+        # CHECK-NEXT: %mma_1_0_1
         # CHECK-SAME: (%read_1_0_1, %read_0_0_1, %mma_1_0_0)
-        # CHECK: %mma_0_1_0
+        # CHECK-NEXT: %mma_0_1_0
         # CHECK-SAME: (%read_0_0_0, %read_0_1_0, %acc_0_1_0)
-        # CHECK: %mma_0_1_1
+        # CHECK-NEXT: %mma_0_1_1
         # CHECK-SAME: (%read_0_0_1, %read_0_1_1, %mma_0_1_0)
-        # CHECK: return [mma_0_0_1, mma_1_1_1, mma_1_0_1, mma_0_1_1]
+        # CHECK-NEXT: return [mma_0_0_1, mma_1_1_1, mma_1_0_1, mma_0_1_1]
 
-        # CHECK: -----
+        # CHECK-NEXT: -----
 
 
 @run
@@ -275,72 +275,72 @@ def test_gemm_reduction_expansion_only():
         print_trace(graph)
         # Root graph:
         # CHECK: %a
-        # CHECK: %b
-        # CHECK: %c
-        # CHECK: %register_0_0_0
-        # CHECK: %register_0_1_0
-        # CHECK: %reduction
-        # CHECK: %getresult_0_1_0
-        # CHECK: %getresult_0_0_0
-        # CHECK: %write_0_0_0
+        # CHECK-NEXT: %b
+        # CHECK-NEXT: %c
+        # CHECK-NEXT: %register_0_0_0
+        # CHECK-NEXT: %register_0_1_0
+        # CHECK-NEXT: %reduction
+        # CHECK-NEXT: %getresult_0_1_0
+        # CHECK-NEXT: %getresult_0_0_0
+        # CHECK-NEXT: %write_0_0_0
         # TODO: This link-up is not yet correct!
         # CHECK-SAME: (%reduction, %c, 4)
-        # CHECK: %write_0_1_0
+        # CHECK-NEXT: %write_0_1_0
         # CHECK-SAME: (%get_result_0_1_0, %c, 4)
 
         # Reduction subgraph:
 
         # CHECK: %acc_0_0_0
-        # CHECK: %acc_0_1_0
+        # CHECK-NEXT: %acc_0_1_0
 
-        # CHECK: %a
-        # CHECK: %read_0_0_0
+        # CHECK-NEXT: %a
+        # CHECK-NEXT: %read_0_0_0
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_0_0_1
+        # CHECK-NEXT: %read_0_0_1
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_0_0_2
+        # CHECK-NEXT: %read_0_0_2
         # CHECK-SAME: (%a, 4)
-        # CHECK: %read_0_0_3
+        # CHECK-NEXT: %read_0_0_3
         # CHECK-SAME: (%a, 4)
 
-        # CHECK: %b
-        # CHECK: %read_0_0_0
+        # CHECK-NEXT: %b
+        # CHECK-NEXT: %read_0_0_0
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_0_1
+        # CHECK-NEXT: %read_0_0_1
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_0_2
+        # CHECK-NEXT: %read_0_0_2
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_0_3
+        # CHECK-NEXT: %read_0_0_3
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_1_0
+        # CHECK-NEXT: %read_0_1_0
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_1_1
+        # CHECK-NEXT: %read_0_1_1
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_1_2
+        # CHECK-NEXT: %read_0_1_2
         # CHECK-SAME: (%b, 4)
-        # CHECK: %read_0_1_3
+        # CHECK-NEXT: %read_0_1_3
         # CHECK-SAME: (%b, 4)
 
-        # CHECK: %mma_0_0_0
+        # CHECK-NEXT: %mma_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
-        # CHECK: %mma_0_0_1
+        # CHECK-NEXT: %mma_0_0_1
         # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0)
-        # CHECK: %mma_0_0_2
+        # CHECK-NEXT: %mma_0_0_2
         # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_1)
-        # CHECK: %mma_0_0_3
+        # CHECK-NEXT: %mma_0_0_3
         # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_2)
-        # CHECK: %mma_0_1_0
+        # CHECK-NEXT: %mma_0_1_0
         # CHECK-SAME: (%read_1_0_0, %read_0_1_0, %acc_0_1_0)
-        # CHECK: %mma_0_1_1
+        # CHECK-NEXT: %mma_0_1_1
         # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_0_1_0)
-        # CHECK: %mma_0_1_2
+        # CHECK-NEXT: %mma_0_1_2
         # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_0_1_1)
-        # CHECK: %mma_0_1_3
+        # CHECK-NEXT: %mma_0_1_3
         # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_0_1_2)
 
-        # CHECK: return [mma_0_0_3, mma_0_1_3]
+        # CHECK-NEXT: return [mma_0_0_3, mma_0_1_3]
 
-        # CHECK: -----
+        # CHECK-NEXT: -----
 
 
 if __name__ == "__main__":

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -39,7 +39,7 @@ K = tkl.sym.K
 # Workgroup tile sizes
 BLOCK_M = tkl.sym.BLOCK_M
 BLOCK_N = tkl.sym.BLOCK_N
-BLOCK_K = tkl.sym.BLOCK_L
+BLOCK_K = tkl.sym.BLOCK_K
 
 # Address space (for GPU, shared(1) or global(0))
 ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
@@ -58,7 +58,13 @@ def read_write_same_size(
 def test_read_write_equal_sizes():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1])]
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        )
+    ]
 
     with tk.gen.TestLaunchContext(
         {
@@ -107,7 +113,7 @@ def test_read_write():
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
     constraints += [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1, 1])
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
     with tk.gen.TestLaunchContext(
         {
@@ -162,7 +168,7 @@ def test_gemm():
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
     constraints += [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1, 1])
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
     with tk.gen.TestLaunchContext(
         {
@@ -254,7 +260,7 @@ def test_gemm_reduction_expansion_only():
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
     constraints += [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1, 1])
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
     with tk.gen.TestLaunchContext(
         {

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -78,7 +78,7 @@ def test_read_write_equal_sizes():
         print_trace(graph)
         # CHECK: %a
         # CHECK-NEXT: %c
-        # CHECK-NEXT: %read
+        # CHECK-NEXT: %read_0_0
         # CHECK-SAME: (%a, 4)
         # CHECK-NEXT: %read_1_1
         # CHECK-SAME: (%a, 4)
@@ -190,13 +190,13 @@ def test_gemm():
         # CHECK-NEXT: %register_1_0_0
         # CHECK-NEXT: %register_0_1_0
         # CHECK-NEXT: %reduction
+        # CHECK-SAME: %register_0_0_0, %register_0_1_0, %register_1_0_0, %register_1_1_0
         # CHECK-NEXT: %getresult_1_1_0
         # CHECK-NEXT: %getresult_1_0_0
         # CHECK-NEXT: %getresult_0_1_0
         # CHECK-NEXT: %getresult_0_0_0
         # CHECK-NEXT: %write_0_0_0
-        # TODO: This link-up is not yet correct!
-        # CHECK-SAME: (%reduction, %c, 4)
+        # CHECK-SAME: (%get_result_0_0_0, %c, 4)
         # CHECK-NEXT: %write_1_1_0
         # CHECK-SAME: (%get_result_1_1_0, %c, 4)
         # CHECK-NEXT: %write_1_0_0
@@ -283,8 +283,7 @@ def test_gemm_reduction_expansion_only():
         # CHECK-NEXT: %getresult_0_1_0
         # CHECK-NEXT: %getresult_0_0_0
         # CHECK-NEXT: %write_0_0_0
-        # TODO: This link-up is not yet correct!
-        # CHECK-SAME: (%reduction, %c, 4)
+        # CHECK-SAME: (%get_result_0_0_0, %c, 4)
         # CHECK-NEXT: %write_0_1_0
         # CHECK-SAME: (%get_result_0_1_0, %c, 4)
 

--- a/lit_tests/kernel/wave/tracing.py
+++ b/lit_tests/kernel/wave/tracing.py
@@ -47,7 +47,7 @@ def test_trace_empty():
     # Custom format:
     # CHECK: placeholder
     # CHECK-SAME: MemoryType[M, N].of(f16)
-    # CHECK: unknown: output
+    # CHECK: output
 
 
 @run
@@ -80,7 +80,7 @@ def test_trace_empty_then_add_nodes():
     # CHECK-SAME: MemoryType[M, N].of(f16)
     # CHECK: read(memory=a
     # CHECK: write(register_=read, memory=a
-    # CHECK: unknown: output
+    # CHECK: output
 
 
 @run
@@ -98,7 +98,7 @@ def test_trace_read():
     # Custom format:
     # CHECK: placeholder
     # CHECK: read(memory=a
-    # CHECK: unknown: output
+    # CHECK: output
 
 
 @run
@@ -119,7 +119,7 @@ def test_trace_register():
     # CHECK: placeholder
     # CHECK: register
     # CHECK-SAME: shape=[M, N], dtype=f16
-    # CHECK: unknown: output
+    # CHECK: output
 
 
 @run
@@ -142,7 +142,7 @@ def test_trace_write():
     # CHECK: placeholder
     # CHECK: register
     # CHECK: write
-    # CHECK: unknown: output
+    # CHECK: output
 
 
 @run
@@ -171,7 +171,7 @@ def test_trace_mma():
     # CHECK: read
     # CHECK: register
     # CHECK: mma
-    # CHECK: unknown: output
+    # CHECK: output
 
 
 @run
@@ -212,7 +212,7 @@ def test_trace_gemm():
     # CHECK: register
     # CHECK: reduction
     # CHECK: write
-    # CHECK: unknown: output
+    # CHECK: output
 
     # Subgraph:
     # CHECK: %acc
@@ -232,4 +232,4 @@ def test_trace_gemm():
     # CHECK: read
     # CHECK: register
     # CHECK: mma
-    # CHECK: unknown: output
+    # CHECK: output

--- a/lit_tests/kernel/wave/tracing.py
+++ b/lit_tests/kernel/wave/tracing.py
@@ -42,12 +42,12 @@ def test_trace_empty():
     trace = test()
     print_trace(trace)
     # CHECK: %a
-    # CHECK: return None
+    # CHECK-NEXT: return None
 
     # Custom format:
-    # CHECK: placeholder
+    # CHECK-NEXT: placeholder
     # CHECK-SAME: MemoryType[M, N].of(f16)
-    # CHECK: output
+    # CHECK-NEXT: output
 
 
 @run
@@ -71,16 +71,16 @@ def test_trace_empty_then_add_nodes():
 
     print_trace(trace)
     # CHECK: %a
-    # CHECK: %read
-    # CHECK: %write
-    # CHECK: return None
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
 
     # Custom format:
-    # CHECK: placeholder
+    # CHECK-NEXT: placeholder
     # CHECK-SAME: MemoryType[M, N].of(f16)
-    # CHECK: read(memory=a
-    # CHECK: write(register_=read, memory=a
-    # CHECK: output
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: write(register_=read, memory=a
+    # CHECK-NEXT: output
 
 
 @run
@@ -92,13 +92,13 @@ def test_trace_read():
     trace = test()
     print_trace(trace)
     # CHECK: %a
-    # CHECK: %read
-    # CHECK: return None
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: return None
 
     # Custom format:
-    # CHECK: placeholder
-    # CHECK: read(memory=a
-    # CHECK: output
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read(memory=a
+    # CHECK-NEXT: output
 
 
 @run
@@ -112,14 +112,14 @@ def test_trace_register():
     trace = test()
     print_trace(trace)
     # CHECK: %a
-    # CHECK: %register
-    # CHECK: return None
+    # CHECK-NEXT: %register
+    # CHECK-NEXT: return None
 
     # Custom format:
-    # CHECK: placeholder
-    # CHECK: register
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: register
     # CHECK-SAME: shape=[M, N], dtype=f16
-    # CHECK: output
+    # CHECK-NEXT: output
 
 
 @run
@@ -134,15 +134,15 @@ def test_trace_write():
     trace = test()
     print_trace(trace)
     # CHECK: %a
-    # CHECK: %register
-    # CHECK: %write
-    # CHECK: return None
+    # CHECK-NEXT: %register
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
 
     # Custom format:
-    # CHECK: placeholder
-    # CHECK: register
-    # CHECK: write
-    # CHECK: output
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: register
+    # CHECK-NEXT: write
+    # CHECK-NEXT: output
 
 
 @run
@@ -159,19 +159,19 @@ def test_trace_mma():
     trace = test()
     print_trace(trace)
     # CHECK: %a
-    # CHECK: %read
-    # CHECK: %read
-    # CHECK: %register
-    # CHECK: %mma
-    # CHECK: return None
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %register
+    # CHECK-NEXT: %mma
+    # CHECK-NEXT: return None
 
     # Custom format:
-    # CHECK: placeholder
-    # CHECK: read
-    # CHECK: read
-    # CHECK: register
-    # CHECK: mma
-    # CHECK: output
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read
+    # CHECK-NEXT: read
+    # CHECK-NEXT: register
+    # CHECK-NEXT: mma
+    # CHECK-NEXT: output
 
 
 @run
@@ -198,38 +198,38 @@ def test_trace_gemm():
     print_trace(trace)
     # Root graph:
     # CHECK: %a
-    # CHECK: %b
-    # CHECK: %c
-    # CHECK: %register
-    # CHECK: %reduction
-    # CHECK: %write
-    # CHECK: return None
+    # CHECK-NEXT: %b
+    # CHECK-NEXT: %c
+    # CHECK-NEXT: %register
+    # CHECK-NEXT: %reduction
+    # CHECK-NEXT: %write
+    # CHECK-NEXT: return None
 
     # Root graph in custom format:
-    # CHECK: placeholder
-    # CHECK: placeholder
-    # CHECK: placeholder
-    # CHECK: register
-    # CHECK: reduction
-    # CHECK: write
-    # CHECK: output
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: register
+    # CHECK-NEXT: reduction
+    # CHECK-NEXT: write
+    # CHECK-NEXT: output
 
     # Subgraph:
     # CHECK: %acc
-    # CHECK: %a
-    # CHECK: %read
-    # CHECK: %b
-    # CHECK: %read_1
-    # CHECK: %register
-    # CHECK: %mma
-    # CHECK: return register
+    # CHECK-NEXT: %a
+    # CHECK-NEXT: %read
+    # CHECK-NEXT: %b
+    # CHECK-NEXT: %read_1
+    # CHECK-NEXT: %register
+    # CHECK-NEXT: %mma
+    # CHECK-NEXT: return register
 
     # Subgraph in custom format:
-    # CHECK: placeholder
-    # CHECK: placeholder
-    # CHECK: read
-    # CHECK: placeholder
-    # CHECK: read
-    # CHECK: register
-    # CHECK: mma
-    # CHECK: output
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read
+    # CHECK-NEXT: placeholder
+    # CHECK-NEXT: read
+    # CHECK-NEXT: register
+    # CHECK-NEXT: mma
+    # CHECK-NEXT: output

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -31,32 +31,29 @@ PlaceholderT = TypeVar("PlaceholderT", bound="Placeholder")
 
 # Stubs to enable type checking of the custom ops:
 # This is currently hand-written and should in future be generated from the custom ops
-def register(shape: tuple[IndexExpr, ...], dtype: DataType, value: float) -> "Register":
-    ...
+def register(
+    shape: tuple[IndexExpr, ...], dtype: DataType, value: float
+) -> "Register": ...
 
 
 def read(
     memory: "Memory", elements_per_thread: Optional[IndexExpr] = None
-) -> "Register":
-    ...
+) -> "Register": ...
 
 
-def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register":
-    ...
+def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register": ...
 
 
 def reduction(
     axis: IndexExpr, args: Sequence["Register"]
-) -> Callable[[Callable[[AccT], AccT]], AccT]:
-    ...
+) -> Callable[[Callable[[AccT], AccT]], AccT]: ...
 
 
 def write(
     register_: "Register",
     memory: "Memory",
     elements_per_thread: Optional[IndexExpr | int] = None,
-):
-    ...
+): ...
 
 
 def define_op(op_name: str) -> Callable[[T], T]:
@@ -169,11 +166,12 @@ class CustomOp(ABC):
         Update the value of an argument in the node while keeping the
         underlying fx.Node consistent.
         """
-
+        if isinstance(value, CustomOp):
+            value = value.fx_node
         # Skip the fields defined by the abstract base class
-        dataclass_fields = fields(self)[3:]
+        dataclass_fields = fields(self)[5:]
         if 0 <= idx < len(dataclass_fields):
-            self.node_args[idx] = value
+            self.node_args[idx] = value  # TODO: Does this make sense?
             field_name = dataclass_fields[idx].name
             # Set the new value for the field
             setattr(self, field_name, value)

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -31,29 +31,32 @@ PlaceholderT = TypeVar("PlaceholderT", bound="Placeholder")
 
 # Stubs to enable type checking of the custom ops:
 # This is currently hand-written and should in future be generated from the custom ops
-def register(
-    shape: tuple[IndexExpr, ...], dtype: DataType, value: float
-) -> "Register": ...
+def register(shape: tuple[IndexExpr, ...], dtype: DataType, value: float) -> "Register":
+    ...
 
 
 def read(
     memory: "Memory", elements_per_thread: Optional[IndexExpr] = None
-) -> "Register": ...
+) -> "Register":
+    ...
 
 
-def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register": ...
+def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register":
+    ...
 
 
 def reduction(
     axis: IndexExpr, args: Sequence["Register"]
-) -> Callable[[Callable[[AccT], AccT]], AccT]: ...
+) -> Callable[[Callable[[AccT], AccT]], AccT]:
+    ...
 
 
 def write(
     register_: "Register",
     memory: "Memory",
     elements_per_thread: Optional[IndexExpr | int] = None,
-): ...
+):
+    ...
 
 
 def define_op(op_name: str) -> Callable[[T], T]:
@@ -189,7 +192,7 @@ class CustomOp(ABC):
             raise IndexError("Index out of range")
 
     def copy(self, new_name: Optional[str] = None) -> Self:
-        """Returns a duplicate of this node in order to expand the graph."""
+        """Returns a duplicate of this node."""
         self.graph.inserting_after(self.fx_node)
         new_node = self.graph.node_copy(self.fx_node)
         new_node.tkw_op = self
@@ -261,6 +264,7 @@ class Output(CustomOp):
     """
 
     return_vals: Sequence[Any]
+    tkw_op_name: str = field(default="output", init=False)
 
     @classmethod
     def from_fx_node(cls: Type[CustomOpT], node: fx.Node) -> CustomOpT:
@@ -373,7 +377,7 @@ class Read(CustomOp):
 @define_op("reduction")
 @dataclass
 class Reduction(CustomOp):
-    axis: IndexExpr
+    axis: IndexSymbol
     init_args: Sequence[Any]
     subgraph_name: str
     implicit_captures: Sequence[fx.Proxy]

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -446,9 +446,18 @@ class Write(CustomOp):
 @define_op("get_result")
 @dataclass
 class GetResult(CustomOp):
-    value: fx.Proxy
+    value: fx.Node
     res_idx: int
 
     @property
     def type(self) -> "Memory":
         return self.value.type
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        expand_dims: list[IndexSymbol] = []
+        for user in self.users:
+            for indexing_dim in user.indexing_dims:
+                if indexing_dim not in expand_dims:
+                    expand_dims.append(indexing_dim)
+        return expand_dims

--- a/shark_turbine/kernel/wave/constraints.py
+++ b/shark_turbine/kernel/wave/constraints.py
@@ -44,7 +44,7 @@ class HardwareConstraint(Constraint):
     """
 
     threads_per_wave: int
-    waves_per_block: Optional[Sequence[int]] = None
+    waves_per_block: Optional[tuple[int, int, int]] = None
     mma_type: Optional[MMAType] = MMAType.F32_16x16x16_F16
 
     @property

--- a/shark_turbine/kernel/wave/constraints.py
+++ b/shark_turbine/kernel/wave/constraints.py
@@ -43,10 +43,11 @@ class HardwareConstraint(Constraint):
     This translates to a hardware specific index constraint.
     """
 
-    mma_type: MMAType
     threads_per_wave: int
-    waves_per_block: Optional[Sequence[int]]
+    waves_per_block: Optional[Sequence[int]] = None
+    mma_type: Optional[MMAType] = MMAType.F32_16x16x16_F16
 
+    @property
     def mma_matrix_shapes(self):
         # TODO: Eventually the shapes and indices should be provided by a tool
         match self.mma_type:
@@ -54,6 +55,8 @@ class HardwareConstraint(Constraint):
                 return (16, 16, 16)
             case MMAType.F32_32x32x8_F16:
                 return (32, 32, 8)
+            case _:
+                return ()
 
     def apply(self) -> IndexExpr:
         raise NotImplementedError("Not yet implemented")

--- a/shark_turbine/kernel/wave/expansion.py
+++ b/shark_turbine/kernel/wave/expansion.py
@@ -1,0 +1,330 @@
+from typing import Any, Optional
+
+
+import itertools
+from ..compiler.ir import Context, Operation
+from .constraints import (
+    Constraint,
+    WorkgroupConstraint,
+    get_grid_shape,
+)
+from .codegen import WaveEmitter
+from ..lang import Grid, sym
+from ..ops.wave_ops import *
+from .._support.tracing import (
+    CapturedTrace,
+    CompiledContext,
+    KernelRegionGraph,
+    Launchable,
+)
+from ..lang.wave_types import Memory, Register, is_memory_meta_derived
+import torch.fx as fx
+
+from sympy import Symbol
+
+
+# Get the last element of the fx node_list structure
+def get_last(node_list: fx.graph._node_list) -> fx.Node:
+    return next(iter(reversed(node_list)))
+
+
+def is_expandable(arg: Any) -> bool:
+    # Special case for the init args of a reduction node
+    if isinstance(arg, Placeholder) and hasattr(arg.fx_node, "reduction_init_arg"):
+        return True
+    return isinstance(arg, CustomOp) and not isinstance(arg, Placeholder)
+
+
+dim_scaling = {
+    sym.M: 2,
+    sym.N: 2,
+    sym.K: 2,
+}
+# sym.BLOCK_M: 2,
+# sym.BLOCK_N: 2,
+# sym.BLOCK_K: 2,
+
+
+def get_dim_combinations(all_dims: dict[Symbol, int], selection: Sequence[Symbol]):
+    """
+    Returns all combinations of sizes for the selected dimensions.
+    Other dimensions are clamped to 0.
+    """
+    adjusted_dimension_sizes = [
+        list(range(dim_scaling[dim])) if dim in selection else [0]
+        for dim in dim_scaling
+    ]
+    return itertools.product(*adjusted_dimension_sizes)
+
+
+def expansion_needed(dims: dict[Symbol, int], selection: Sequence[Symbol]) -> bool:
+    return any(dim[1] != 0 and dim[0] in selection for dim in dims.items())
+
+
+def indexing_dims(all_dims: dict[Symbol, int], nodeOrDims: CustomOp | Sequence[Symbol]):
+    if isinstance(nodeOrDims, CustomOp):
+        nodeOrDims = nodeOrDims.indexing_dims
+    return tuple((key, all_dims[key]) for key in nodeOrDims)
+
+
+def expand_graph(trace: CapturedTrace, constraints: Optional[list[Constraint]] = None):
+    """
+    Create a graph that represents the expanded version of the wave function
+    """
+
+    # Determine how many nodes there are in the final graph.
+
+    # Start from the back and always expand in the corresponding indexing dimensions
+    # Then proceed to the operands
+
+    for node in (
+        get_custom(fx_node) for fx_node in reversed(list(trace.get_root_graph().nodes))
+    ):
+        expansion_context: dict[Any, Any] = {}
+        # Start expansion with leaf nodes
+        if isinstance(node, Write):
+            for dim_vals in get_dim_combinations(dim_scaling, node.indexing_dims):
+                dims = {dim: val for dim, val in zip(dim_scaling.keys(), dim_vals)}
+                print(f"leaf: {dims}")
+                if not expansion_needed(dims, node.indexing_dims):
+                    print("skipping cloning")
+                    new_node = node
+                else:
+                    node.graph.inserting_after(node.fx_node)
+                    new_node = node.copy()
+                    for arg_idx, arg in enumerate(node.node_args):
+                        if is_expandable(arg):
+                            new_arg = _expand_node(arg, trace, dims, expansion_context)
+                            new_node.update_arg(arg_idx, new_arg)
+                new_node.fx_node.name = get_suffixed_name(node, dims)
+                expansion_context[(node, indexing_dims(dims, node))] = new_node
+
+
+def get_suffixed_name(node: CustomOp, dims: dict[Symbol, int]) -> str:
+    separated = node.fx_node.name.split("_")
+    node_name = separated[0]
+    if node_name == "get":
+        node_name = node_name + separated[1]
+    for val in dims.values():
+        node_name += f"_{val}"
+    return node_name
+
+
+def _expand_node(
+    node: CustomOp,
+    trace: CapturedTrace,
+    dims: dict[Symbol, int],
+    context: dict[tuple[CustomOp, dict[Symbol, int]], CustomOp],
+) -> CustomOp:
+    """Expand a single node in specific dimensions and recursively proceed to its inputs."""
+
+    if (node, indexing_dims(dims, node)) in context:
+        print(f"Already expanded node: {node} in {dims}")
+        return context[(node, indexing_dims(dims, node))]
+
+    print(f"Expanding node: {node} in {dims}")
+    if (
+        isinstance(node, Reduction)
+        or hasattr(node, "indexing_dims")
+        or hasattr(node, "type")
+        # and is_memory_meta_derived(node.type)
+    ):
+        pass
+        # Expand in the corresponding dimensions
+        if isinstance(node, Reduction):
+            return _expand_reduction(node, trace, dims, context)
+        else:
+            # Do not duplicate the node if it does not index in the expanded dim.
+            # We create a duplicate node and reuse the initial node instead of the last copy
+            new_node = (
+                node.copy() if expansion_needed(dims, node.indexing_dims) else node
+            )
+            new_node.fx_node.name = get_suffixed_name(node, dims)
+
+            # TODO: adjust indexing when that is modeled
+
+            # TODO: for debugging only
+            if new_node == node:
+                print(f"did not clone node: {node} in {dims}")
+                # new_node.fx_node.name = f"{node.fx_node.name}_{dim[0].name}"
+            # TODO: This special case should be handled better
+            if isinstance(node, Placeholder) and hasattr(
+                node.fx_node, "reduction_init_arg"
+            ):
+                new_node.fx_node.reduction_init_arg = True
+
+        for i, arg in enumerate(node.node_args):
+            if is_expandable(arg):
+                new_arg = _expand_node(arg, trace, dims, context)
+                new_node.update_arg(i, new_arg)
+
+        context[(node, indexing_dims(dims, node))] = new_node
+        return new_node
+
+    print(f"aborted expanding node:{node}, no type info.")
+    return node
+
+
+def _expand_reduction(
+    reduction: Reduction,
+    trace: CapturedTrace,
+    initial_dims: dict[Symbol, int],
+    context: dict[tuple[CustomOp, Symbol, int], CustomOp],
+) -> CustomOp:
+    """Expand a reduction in a specific dimension and recursively proceed to its inputs."""
+    # TODO: Okay, rework this to expand the reduction completely, not in individual dimensions.
+
+    # Find out in which dimensions to expand this.
+    users = reduction.users
+    expand_dims: list[Symbol] = []
+    for user in users:
+        for indexing_dim in user.indexing_dims:
+            if indexing_dim not in expand_dims:
+                expand_dims.append(indexing_dim)
+    print(f"expand dims: {expand_dims}")
+
+    # Get the output node of the reduction
+    reduction_subgraph = trace.get_subgraph(reduction.subgraph_name)
+    output = get_custom(get_last(reduction_subgraph.nodes))
+
+    return_node = None
+    new_output_args = []
+    new_init_args = []
+    for dim_idx, dim_vals in enumerate(get_dim_combinations(dim_scaling, expand_dims)):
+        for arg_idx, arg in enumerate(output.node_args):
+            dims = {dim: val for dim, val in zip(dim_scaling.keys(), dim_vals)}
+            # Add GetResult nodes for the corresponding dimensions
+            result_idx = dim_idx * len(expand_dims) + arg_idx
+            reduction.graph.inserting_after(reduction.fx_node)
+            new_node = GetResult(reduction.fx_node, result_idx)
+            new_node.add_to_graph(reduction.graph)
+            if return_node is None:
+                return_node = new_node
+            new_node.fx_node.name = get_suffixed_name(new_node, dims)
+            context[(reduction, indexing_dims(dims, expand_dims))] = new_node
+
+            # Proceed with expansion inside the reduction
+            new_output_args.append(_expand_node(arg, trace, dims, context))
+
+            # Proceed with expansion outside the reduction
+            for init_arg in reduction.init_args:
+                new_init_args.append(
+                    _expand_node(
+                        get_custom(init_arg),
+                        trace,
+                        dims,
+                        context,
+                    )
+                )
+
+    # Update output node
+    output.graph.inserting_before(output.fx_node)
+    new_output = output.graph.create_node(
+        "output", "output", tuple([node.fx_node for node in new_output_args])
+    )
+    output.graph.erase_node(output.fx_node)
+    # Note: The custom printing of torch.fx does not print the output of multiple args correctly!
+
+    # Update reduction node
+    reduction.args = new_init_args
+    # TODO: have init_args as property that I can update more easily
+    reduction.fx_node.args = (
+        reduction.axis,
+        [new_init_arg.fx_node for new_init_arg in new_init_args],
+        reduction.subgraph_name,
+        reduction.implicit_captures,
+    )
+
+    _handle_reduction_dim(reduction, get_custom(new_output), trace, context)
+
+    # TODO: Next: What is conceptually missing is the semantics of the reduction.
+    # The reduction tells us that for the gemm example the return val of the region
+    # is the input to the next iteration of the region. This is not yet captured.
+    # Question: Is it always the case that this is done once, i.e. going from 4 MMAs to 8?
+    # If not, on which constraints does it depend?
+    # So TODO: Build a generic way of doing this, from this function. Possibly
+    # simply triggering expansion again from the output.
+    # This will only do expansion of the nodes that use the accumulator, as that is the value
+    # that in the second go is replaced with the output of the reduction, i.e. the 4 MMAs
+    # SO! In the second go this feels like normal expansion where the args of `output`
+    # are simply replaced? Not quite sure
+
+    # TODO: New note: the reduction node has a reduction dimension!
+    # Does that help us get to the 8 MMAs?
+
+    # TODO: When expanding along the reduction axis, I think we need to remap the accumulator values.
+    # I will try first without that and see.
+
+    # TODO: I think the outputs are all the expansions in dimension K?
+
+    return context[(reduction, indexing_dims(initial_dims, expand_dims))]
+
+
+def _handle_reduction_dim(
+    reduction: Reduction,
+    output: Placeholder,
+    trace: CapturedTrace,
+    context: dict[tuple[CustomOp, Symbol, int], CustomOp],
+):
+    print("Reduction Dim not handled yet.")
+    return
+    # iter_arg_mapping: dict[CustomOp, CustomOp] = {}
+    # Map iter args to output args
+
+    # for idx, arg in enumerate(output.node_args):
+    #     iter_arg_mapping[reduction.args[idx]] = arg
+
+    # TODO: Find a better way of getting to the iter args
+    iter_args: list[CustomOp] = []
+    reduction_subgraph = trace.get_subgraph(reduction.subgraph_name)
+    for node in reduction_subgraph.nodes:
+        if hasattr(node, "reduction_init_arg"):
+            iter_args.append(get_custom(node))
+
+    for idx, iter_arg in enumerate(iter_args):
+        for user in iter_arg.users:
+
+            new_node = _expand_node(user, trace, dim_scaling, context)
+            # Adjust the arg
+            new_node.node_args.index(iter_arg)
+            # Brittle: The correct order of the iterargs is not guaranteed
+
+            new_node.update_arg(
+                new_node.node_args.index(iter_arg), output.node_args[idx]
+            )
+            # Updating the output args is not yet handled nicely
+            output.fx_node.update_arg(idx, new_node.fx_node)
+
+    # for iter_arg in reduction.iter_args:
+    #     for user in iter_arg.users:
+    #         pass
+
+    # Users of the iter arg will be duplicated
+
+    # TODO: This will be factored out into its own thing.
+    # Expand in the reduction dimension if not already done:
+    # if not (reduction, reduction.axis, 0) in context:
+    #     for dim_idx in range(dim_scaling[reduction.axis]):
+    #         for i, arg in enumerate(output.node_args):
+    #             if is_expandable(arg):
+    #                 new_arg = _expand_node(
+    #                     arg, trace, (reduction.axis, dim_idx), dim_scaling, context
+    #                 )
+    #                 # Update args of the output node
+    #         context[(reduction, reduction.axis, dim_idx)] = reduction
+
+
+# Currently not needed because we branch for Reduction above
+# elif isinstance(arg, list):
+#     new_arg = []
+#     for sub_arg in arg:
+#         # subargs are not CustomOps yet
+#         if isinstance(sub_arg, CustomOp):
+#             custom_sub_arg = get_custom(sub_arg)
+#             new_sub_arg = _expand_node(
+#                 custom_sub_arg, trace, dim, dim_scaling, context
+#             )
+#             new_arg.append(new_sub_arg)
+#         else:
+#             new_arg.append(sub_arg)
+#     new_node.update_arg(i, new_arg)

--- a/shark_turbine/kernel/wave/expansion.py
+++ b/shark_turbine/kernel/wave/expansion.py
@@ -1,5 +1,4 @@
 import itertools
-from sympy import Symbol
 import torch.fx as fx
 from typing import Any, TypeAlias
 

--- a/shark_turbine/kernel/wave/wave.py
+++ b/shark_turbine/kernel/wave/wave.py
@@ -13,6 +13,7 @@ from .codegen import WaveEmitter
 from .expansion import expand_graph
 from ..lang import Grid
 from ..ops import wave_ops
+from .._support.indexing import IndexingContext
 from .._support.tracing import (
     CapturedTrace,
     CompiledContext,
@@ -92,11 +93,11 @@ class LaunchableWave(Launchable):
         # Trace the function.
         graph = self._trace()
 
+        idxc = IndexingContext.current()
+        idxc.finalize()
+
         # Expansion
         expand_graph(graph, self.constraints)
-
-        print(f"Expanded:\n{graph.get_root_graph()}")
-        print(f"Expanded Reduce:\n{graph.get_subgraph('region_0')}")
 
         kernel_sig = kernel_codegen.KernelSignature()
         # Fixed values for now, will be determined through constraints

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -45,7 +45,7 @@ class Test(unittest.TestCase):
             # This microkernel encodes the fact that if the reduction
             # dimension were tiled, then we would need to materialize a loop.
             @tkw.reduction(K, init_args=[c_reg])
-            def repeat(acc: tkl.Register) -> tkl.Register[M, N, tkl.f32]:
+            def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
                 # a_reg: tkw.Register[M, K, tkl.f16]
                 a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
                 # b_reg: tkw.Register[N, K, tkl.f16]

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -27,6 +27,11 @@ class Test(unittest.TestCase):
         # Expose user-constraints
         constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
         constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+        constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+
+        constraints += [
+            tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1, 1])
+        ]
 
         # Wave-level micro-kernel.
         # Since warps are not directly addressable, there is no

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -30,7 +30,7 @@ class Test(unittest.TestCase):
         constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
 
         constraints += [
-            tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=[1, 1, 1])
+            tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
         ]
 
         # Wave-level micro-kernel.


### PR DESCRIPTION
This adds the expansion of the original program depending on workgroup and hardware constraints.
The exact semantics can be seen well in the new [tests](https://github.com/iree-org/iree-turbine/blob/dedd438641072ac9e5f47dc60212a9306de55a00/lit_tests/kernel/wave/expansion.py).

Additionally, this introduces:
- `HardwareConstraint` that specifies the number of waves per block, number of threads per wave and mma instruction sizes. 
- New custom nodes for:
`Output`, `IterArg`
- Some new convenience features like updating the args of a node through the custom interface. (Ideally this would be accomplished through intercepting dataclass setters, but that interferes with the tracing and I did not yet find a workaround.)

In particular the handling of iterArgs should be improved in follow-up PRs. For instance, accessing them currently requires iteration over all nodes in a subgraph. We probably want to provide access to them through the corresponding `Reduction` node.