### PR TITLE
Add attention example in tracing test

### DIFF
--- a/shark_turbine/kernel/_support/dtype.py
+++ b/shark_turbine/kernel/_support/dtype.py
@@ -10,10 +10,14 @@ __all__ = [
     "f32",
     "f64",
     "index",
+    "f8E5M2",
+    "f8E5M2FNUZ",
+    "f8E4M3FN",
+    "f8E4M3FNUZ",
 ]
 
 _INT_TYPES = ["i1", "i4", "i8", "i16", "i32", "i64"]
-_FLOAT_TYPES = ["f16", "f32", "f64"]
+_FLOAT_TYPES = ["f16", "f32", "f64", "f8E5M2", "f8E5M2FNUZ", "f8E4M3FN", "f8E4M3FNUZ"]
 _INDEX_TYPES = ["index"]
 
 
@@ -56,4 +60,8 @@ f64 = DataType("f64")
 f16 = DataType("f16")
 f32 = DataType("f32")
 f64 = DataType("f64")
+f8e5m2 = DataType("f8E5M2")
+f8e5m2fnuz = DataType("f8E5M2FNUZ")
+f8e4m3fn = DataType("f8E4M3FN")
+f8e4m3fnuz = DataType("f8E4M3FNUZ")
 index = DataType("index")

--- a/shark_turbine/kernel/lang/__init__.py
+++ b/shark_turbine/kernel/lang/__init__.py
@@ -22,5 +22,9 @@ from .._support.dtype import (
     f16,
     f32,
     f64,
+    f8e5m2,
+    f8e5m2fnuz,
+    f8e4m3fn,
+    f8e4m3fnuz,
     index,
 )

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -38,6 +38,26 @@ def allocate(
     ...
 
 
+def cast(register: "Register", type: DataType) -> "Register":
+    ...
+
+
+def div(lhs: "Register", rhs: "Register") -> "Register":
+    ...
+
+
+def exp2(register: "Register") -> "Register":
+    ...
+
+
+def max(register: "Register", dim: tuple[IndexExpr] | "Register") -> "Register":
+    ...
+
+
+def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register":
+    ...
+
+
 def read(
     memory: "Memory", elements_per_thread: Optional[IndexExpr] = None
 ) -> "Register":
@@ -54,7 +74,7 @@ def register(shape: tuple[IndexExpr, ...], dtype: DataType, value: float) -> "Re
     ...
 
 
-def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register":
+def sum(register: "Register", dim: tuple[IndexExpr]) -> "Register":
     ...
 
 


### PR DESCRIPTION
This PR adds an FP8 attention kernel to the
tracing test to validate that it traces correctly.