### PR TITLE
TKW: Add support for representing python operators as CustomOps

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -7,10 +7,12 @@ import shark_turbine.kernel.lang as tkl
 import shark_turbine.kernel.wave as tkw
 import torch
 
-
 M = tkl.sym.M
 N = tkl.sym.N
 K = tkl.sym.K
+BLOCK_M = tkl.sym.BLOCK_M
+BLOCK_N = tkl.sym.BLOCK_N
+BLOCK_K = tkl.sym.BLOCK_K
 ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
 
 
@@ -25,6 +27,9 @@ def launch(func: Callable[[], None]) -> Callable[[], None]:
                 M: 16,
                 N: 16,
                 K: 16,
+                BLOCK_M: 16,
+                BLOCK_N: 16,
+                BLOCK_K: 16,
                 ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
             }
         ):
@@ -37,6 +42,8 @@ def test_read():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
 
     @tkw.wave(constraints)
     def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
@@ -45,6 +52,86 @@ def test_read():
     a = torch.randn(16, 16, dtype=torch.float16)
     with pytest.raises(
         NotImplementedError, match="Read: Currently only stub implementation"
+    ):
+        test(a)
+
+
+@launch
+def test_add():
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+
+    @tkw.wave(constraints)
+    def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        res = a + a
+        tkw.write(res, a, elements_per_thread=4)
+
+    a = torch.randn(16, 16, dtype=torch.float16)
+    with pytest.raises(
+        NotImplementedError, match="add: Currently only stub implementation"
+    ):
+        test(a)
+
+
+@launch
+def test_neg():
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+
+    @tkw.wave(constraints)
+    def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        res = -a
+        tkw.write(res, a, elements_per_thread=4)
+
+    a = torch.randn(16, 16, dtype=torch.float16)
+    with pytest.raises(
+        NotImplementedError, match="neg: Currently only stub implementation"
+    ):
+        test(a)
+
+
+@launch
+def test_sub():
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+
+    @tkw.wave(constraints)
+    def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        res = a - a
+        tkw.write(res, a, elements_per_thread=4)
+
+    a = torch.randn(16, 16, dtype=torch.float16)
+    with pytest.raises(
+        NotImplementedError, match="sub: Currently only stub implementation"
+    ):
+        test(a)
+
+
+@launch
+def test_get_item():
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+
+    @tkw.wave(constraints)
+    def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        res = a[0]
+        tkw.write(res, a, elements_per_thread=4)
+
+    a = torch.randn(16, 16, dtype=torch.float16)
+    with pytest.raises(
+        NotImplementedError, match="getitem: Currently only stub implementation"
     ):
         test(a)
 

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass, field, fields
+import operator
 import sys
 from typing import (
     TYPE_CHECKING,
@@ -86,6 +87,48 @@ def define_op(op_name: str) -> Callable[[T], T]:
         setattr(current_module, op_name, new_function)
         cls._tracing_function = new_function
 
+        return cls
+
+    return decorator
+
+
+def define_py_op(py_op: Callable) -> Callable[[T], T]:
+    """
+    Register python internal operators as custom ops.
+    This overloads python operator specific functions such as __add__ of
+    fx.Proxy with a handler in order to control the tracing of the operator and
+    map it to a dynamically created sublclass of UnaryPyOp or BinaryPyOp.
+    """
+    op_name = py_op.__name__
+
+    def decorator(cls: T) -> T:
+        # define new subclass of cls to represent this op
+        @dataclass
+        class NewSubclass(cls):
+            pass
+
+        NewSubclass.tkw_op_name = op_name
+        NewSubclass.__name__ = f"{op_name.capitalize()}"
+        NewSubclass.__module__ = cls.__module__
+        current_module = sys.modules[cls.__module__]
+        setattr(current_module, NewSubclass.__name__, NewSubclass)
+
+        def new_function(*args: Any, **kwargs: dict[str, Any]):
+            dispatcher = OpDispatcher.current()
+            try:
+                handler = getattr(dispatcher, f"handle_{op_name}")
+            except AttributeError:
+                raise AttributeError(
+                    f"The current OpDispatcher ({dispatcher}) does not register a handler for {op_name}"
+                )
+
+            return handler(*args, **kwargs)
+
+        new_function.__name__ = op_name
+        NewSubclass._tracing_function = new_function
+        setattr(fx.Proxy, f"__{op_name}__", new_function)
+
+        # Return cls unchanged so we can reuse the decorator to register more ops
         return cls
 
     return decorator
@@ -253,6 +296,52 @@ class CustomOp(ABC):
     @property
     def indexing_dims(self) -> list[IndexSymbol]:
         return []
+
+
+@define_py_op(operator.getitem)
+@define_py_op(operator.add)
+@define_py_op(operator.sub)
+@dataclass
+class BinaryPyOp(CustomOp, ABC):
+    """
+    Represents a binary python operator.
+    """
+
+    lhs: Any
+    rhs: Any
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        combined_dims = []
+        if isinstance(self.lhs, fx.Node):
+            combined_dims += get_custom(self.lhs).indexing_dims
+        if isinstance(self.rhs, fx.Node):
+            combined_dims += get_custom(self.rhs).indexing_dims
+
+        unique_dims = list(dict.fromkeys(combined_dims))
+        return unique_dims
+
+    @property
+    def py_operator(self) -> str:
+        return self.tkw_op_name
+
+
+@define_py_op(operator.neg)
+@dataclass
+class UnaryPyOp(CustomOp, ABC):
+    """
+    Represents a unary python operator.
+    """
+
+    arg: fx.Node
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        return get_custom(self.arg).indexing_dims
+
+    @property
+    def py_operator(self) -> str:
+        return self.tkw_op_name
 
 
 @final

--- a/shark_turbine/kernel/wave/codegen.py
+++ b/shark_turbine/kernel/wave/codegen.py
@@ -1,3 +1,4 @@
+import operator
 from typing import Any, Callable, ClassVar, Optional
 from dataclasses import dataclass
 import torch.fx as fx
@@ -81,6 +82,26 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
 @handle_op(mma)
 def handle_mma(emitter: WaveEmitter, node: fx.Node):
     raise NotImplementedError("MMA: Currently only stub implementation")
+
+
+@handle_op(operator.add)
+def handle_add(emitter: WaveEmitter, node: fx.Node):
+    raise NotImplementedError("add: Currently only stub implementation")
+
+
+@handle_op(operator.getitem)
+def handle_getitem(emitter: WaveEmitter, node: fx.Node):
+    raise NotImplementedError("getitem: Currently only stub implementation")
+
+
+@handle_op(operator.neg)
+def handle_neg(emitter: WaveEmitter, node: fx.Node):
+    raise NotImplementedError("neg: Currently only stub implementation")
+
+
+@handle_op(operator.sub)
+def handle_sub(emitter: WaveEmitter, node: fx.Node):
+    raise NotImplementedError("sub: Currently only stub implementation")
 
 
 ###############################################################################


### PR DESCRIPTION
This overloads python operators we are interested in in the fx.Proxy class to control their tracing.
Registering a python operator using the new `define_py_op` ensures that it is mapped to a corresponding subclass of e.g. `BinaryPyOp` for `+`. These subclasses are created on the fly for the operators we register. Adding new operators requires simply adding an additional decorator to `BinaryPyOp` or `UnaryPyOp` (depending on number of args) and writing the appropriate codegen handler. 
These operations are then properly handled by the rest of the system (e.g. expansion).

This PR also adds tests for tracing, expansion and preliminary codegen tests (to check that the codegen handlers link up properly).