### PR TITLE
[WIP] TK.wave simulator

### DIFF
--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -1,0 +1,179 @@
+import inspect
+import types
+import typing
+import functools
+import copy
+import torch
+from typing import Any, Callable, Optional
+from .constraints import (
+    Constraint,
+    WorkgroupConstraint,
+    get_grid_shape,
+)
+from sympy import Symbol
+from sympy.core.expr import Expr
+from .._support.shaped_type import ShapedType
+
+from .. import lang as tkl
+from .. import wave as tkw
+
+
+def _get_shaped_handler(arg_idx, shape, prev_handler):
+    def handler(args, subs):
+        if prev_handler:
+            prev_handler(args, subs)
+
+        arg = args[arg_idx]
+        for i, sym in enumerate(shape):
+            if isinstance(sym, Symbol):
+                subs[sym] = arg.shape[i]
+
+    return handler
+
+
+def _visit_annotation(ann, arg_idx, prev_handler):
+    def istypingtype(a, typ):
+        return typing.get_origin(ann) == typ or isinstance(ann, typ)
+
+    if istypingtype(ann, ShapedType):
+        return _get_shaped_handler(arg_idx, ann.symbolic_shape, prev_handler)
+
+    return None
+
+
+def _process_func_annotations(func):
+    handler = None
+    ann = inspect.get_annotations(func)
+    for i, arg in enumerate(inspect.signature(func).parameters):
+        arg_ann = ann.get(arg, None)
+        if arg_ann is None:
+            continue
+
+        new_handler = _visit_annotation(arg_ann, i, handler)
+        if new_handler is not None:
+            handler = new_handler
+
+    return handler
+
+
+def _resolve_symbols(func, symbols):
+    old_closure = func.__closure__
+    new_closure = None
+
+    def resolve_impl(val):
+        if isinstance(val, Symbol):
+            return symbols.get(val, None)
+        elif isinstance(val, Expr):
+            return val.subs(symbols)
+
+        try:
+            return symbols.get(val, None)
+        except:
+            return None
+
+    if old_closure is not None:
+        cell_cls = type(old_closure[0])
+
+        def resolve_cell(cell):
+            res = resolve_impl(cell.cell_contents)
+            if res is None:
+                res = cell
+            else:
+                res = cell_cls(res)
+
+            return res
+
+        new_closure = tuple(resolve_cell(cell) for cell in old_closure)
+
+    def resolve_global(val):
+        res = resolve_impl(val)
+        if res is None:
+            res = val
+
+        return res
+
+    new_globals = {key: resolve_global(val) for key, val in func.__globals__.items()}
+
+    g = types.FunctionType(
+        func.__code__,
+        new_globals,
+        name=func.__name__,
+        argdefs=func.__defaults__,
+        closure=new_closure,
+    )
+    g = functools.update_wrapper(g, func)
+    g.__kwdefaults__ = func.__kwdefaults__
+    return g
+
+
+_api_subs = {}
+
+
+def wave_sim(constraints: Optional[list[Constraint]] = None):
+    def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
+        args_handler = _process_func_annotations(f)
+
+        def func_wrapper(*args):
+            global _api_subs
+            subs = copy.copy(_api_subs)
+            if args_handler:
+                args_handler(args, subs)
+
+            new_func = _resolve_symbols(f, subs)
+            return new_func(*args)
+
+        return func_wrapper
+
+    return decorator
+
+
+class _RegisterProxy:
+    def __getitem__(self, indices):
+        shape = indices[:-1]
+        dtype = indices[-1]
+        return _ShapedRegister(shape, dtype)
+
+
+class _ShapedRegister:
+    def __init__(self, shape, dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def __call__(self, init):
+        return torch.full(self.shape, init, dtype=self.dtype)
+
+
+class _TklProxy:
+    f16 = torch.float16
+    f32 = torch.float32
+    Register = _RegisterProxy()
+
+
+def _reduction_proxy(axis, init_args):
+    def decorator(func):
+        return func(*init_args)
+
+    return decorator
+
+
+def _read_proxy(memory, elements_per_thread):
+    return memory.clone()
+
+
+def _write_proxy(src, dst, elements_per_thread):
+    dst[:] = src
+
+
+def _mma_proxy(a, b, acc):
+    return torch.matmul(a, b.T) + acc
+
+
+class _TkwProxy:
+    reduction = _reduction_proxy
+    read = _read_proxy
+    write = _write_proxy
+    mma = _mma_proxy
+
+
+_api_subs[tkl] = _TklProxy
+_api_subs[tkw] = _TkwProxy

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -18,6 +18,24 @@ from .. import lang as tkl
 from .. import wave as tkw
 
 
+def wave_sim(constraints: Optional[list[Constraint]] = None):
+    def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
+        args_handler = _process_func_annotations(f)
+
+        def func_wrapper(*args):
+            global _api_subs
+            subs = copy.copy(_api_subs)
+            if args_handler:
+                args_handler(args, subs)
+
+            new_func = _resolve_symbols(f, subs)
+            return new_func(*args)
+
+        return func_wrapper
+
+    return decorator
+
+
 def _get_shaped_handler(arg_idx, shape, prev_handler):
     def handler(args, subs):
         if prev_handler:
@@ -107,24 +125,6 @@ def _resolve_symbols(func, symbols):
 
 
 _api_subs = {}
-
-
-def wave_sim(constraints: Optional[list[Constraint]] = None):
-    def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
-        args_handler = _process_func_annotations(f)
-
-        def func_wrapper(*args):
-            global _api_subs
-            subs = copy.copy(_api_subs)
-            if args_handler:
-                args_handler(args, subs)
-
-            new_func = _resolve_symbols(f, subs)
-            return new_func(*args)
-
-        return func_wrapper
-
-    return decorator
 
 
 class _RegisterProxy:

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -75,6 +75,11 @@ def _process_func_annotations(func):
 
 
 def _resolve_symbols(func, symbols):
+    """Copy function and update __globals__ and __closure__ vars
+
+    Copy function while updating __globals__ and __closure__ vars according to
+    'symbols' map.
+    """
     old_closure = func.__closure__
     new_closure = None
 
@@ -156,11 +161,11 @@ def _reduction_proxy(axis, init_args):
     return decorator
 
 
-def _read_proxy(memory, elements_per_thread):
+def _read_proxy(memory, elements_per_thread=None):
     return memory.clone()
 
 
-def _write_proxy(src, dst, elements_per_thread):
+def _write_proxy(src, dst, elements_per_thread=None):
     dst[:] = src
 
 

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -60,6 +60,12 @@ def _visit_annotation(ann, arg_idx, prev_handler):
 
 
 def _process_func_annotations(func):
+    """Process symbols in func annotation, so iteration dimensions can be extracted.
+
+    Returns a function which extract shapes from kernel args and generates a
+    substitution map, which can be used to replace symbols inside the kernel
+    with actual values, came from arguments.
+    """
     handler = None
     ann = inspect.get_annotations(func)
     for i, arg in enumerate(inspect.signature(func).parameters):

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -16,6 +16,18 @@ from .. import wave as tkw
 
 
 def wave_sim(constraints: Optional[list[Constraint]] = None):
+    """Kernel simulator decorator.
+
+    This decorator wraps kernel function into simulator harness.
+
+    When kernel is invoked, underlying function is copied and symbolic
+    expressions captured in '__globals__' and '__closure__' are replaced with
+    numerical values, extracted from input tensors shapes.
+
+    Also, all kernel APIs are replaced by 'proxy' API, which just execute ops
+    immediately on host intead of tracing them.
+    """
+
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         args_handler = _process_func_annotations(f)
 

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-import shark_turbine.kernel as tk
 import shark_turbine.kernel.lang as tkl
 import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.wave.wave_sim import wave_sim

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -1,0 +1,79 @@
+import pytest
+import torch
+import shark_turbine.kernel as tk
+import shark_turbine.kernel.lang as tkl
+import shark_turbine.kernel.wave as tkw
+from shark_turbine.kernel.wave.wave_sim import wave_sim
+from numpy.testing import assert_allclose
+
+
+def test_gemm():
+    # Input sizes
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+    ]
+
+    # Wave-level micro-kernel.
+    # Since warps are not directly addressable, there is no
+    # explicit notion of a warp id (like a workgroup or thread id).
+    # This kernel uses the input sizes M, N, K throughout, as the tiling
+    # and data movement strategy is determined during the compilation process.
+    # These can be influenced by introducing constraints.
+    @wave_sim(constraints)
+    def gemm(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            # a_reg: tkw.Register[M, K, tkl.f16]
+            a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # b_reg: tkw.Register[N, K, tkl.f16]
+            b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # acc: tkw.Register[M, N, tkl.f32]
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
+        LOAD_ELEMS_PER_THREAD: 4,
+        STORE_ELEMS_PER_THREAD: 1,
+        BLOCK_M: 32,
+        BLOCK_N: 32,
+        BLOCK_K: 32,
+        M: 64,
+        N: 128,
+        K: 256,
+    }
+
+    a = torch.randn(64, 256, dtype=torch.float16)
+    b = torch.randn(128, 256, dtype=torch.float16)
+    c = torch.zeros(64, 128, dtype=torch.float32)
+    gemm(a, b, c)
+    assert_allclose(c, a @ b.T)

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -60,18 +60,6 @@ def test_gemm():
         # repeat represents the results of the loop
         tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
-    hyperparams = {
-        ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
-        LOAD_ELEMS_PER_THREAD: 4,
-        STORE_ELEMS_PER_THREAD: 1,
-        BLOCK_M: 32,
-        BLOCK_N: 32,
-        BLOCK_K: 32,
-        M: 64,
-        N: 128,
-        K: 256,
-    }
-
     a = torch.randn(64, 256, dtype=torch.float16)
     b = torch.randn(128, 256, dtype=torch.float16)
     c = torch.zeros(64, 128, dtype=torch.float32)


### PR DESCRIPTION
Software simulator for `tk.wave` kernels. It doesn't do any actual compilation or tracing and just executes kernel entirely inside python interpreter, so you can use `print`, python debugger, etc.

No tiling or distribution is done, `tkw.reduction` will always execute a single iteration (as if tile size was bigger than iteration size).

All data (i.e. `Register`) inside kernel is represented using `torch.tensor`.

Currently supported ops:
* `Register`
* `read`
* `write`
* `mma`
* `reduction`