### PR TITLE
Add TilingConstraint to represent non-distributed tiled loops

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -40,7 +40,9 @@ def launch(func: Callable[[], None]) -> Callable[[], None]:
 @launch
 def test_read():
     constraints: list[tkw.Constraint] = [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 16, N: 16}
+        )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -59,7 +61,9 @@ def test_read():
 @launch
 def test_add():
     constraints: list[tkw.Constraint] = [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 16, N: 16}
+        )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -79,7 +83,9 @@ def test_add():
 @launch
 def test_neg():
     constraints: list[tkw.Constraint] = [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 16, N: 16}
+        )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -99,7 +105,9 @@ def test_neg():
 @launch
 def test_sub():
     constraints: list[tkw.Constraint] = [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 16, N: 16}
+        )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -119,7 +127,9 @@ def test_sub():
 @launch
 def test_get_item():
     constraints: list[tkw.Constraint] = [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 16, N: 16}
+        ),
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -62,7 +62,7 @@ def test_read_write_equal_sizes():
         tkw.HardwareConstraint(
             threads_per_wave=64,
             waves_per_block=(1, 1, 1),
-            mma_type=tkw.MMAType.F32_16x16x16_F16,
+            vector_shapes={M: 16, N: 16, K: 16},
         )
     ]
 
@@ -111,9 +111,13 @@ def read_write_different_dims(
 def test_read_write():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
     constraints += [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 16, N: 16, K: 16},
+        )
     ]
     with tk.gen.TestLaunchContext(
         {
@@ -166,7 +170,7 @@ def gemm(
 def test_gemm():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
     constraints += [
         tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
@@ -258,7 +262,7 @@ def test_gemm_reduction_expansion_only():
     # gemm kernel to test the expansion of the reduction subgraph.
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
     constraints += [
         tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -363,7 +363,11 @@ def py_arithmetic_different_dims():
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
     constraints += [
-        tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 16, N: 16, K: 16},
+        )
     ]
     with tk.gen.TestLaunchContext(
         {

--- a/shark_turbine/kernel/_support/tracing.py
+++ b/shark_turbine/kernel/_support/tracing.py
@@ -125,6 +125,14 @@ class CapturedTrace:
     def get_root_graph(self) -> fx.Graph:
         return self.get_subgraph(self.root_graph)
 
+    def walk(self, filter: Callable[[fx.Node], bool]) -> list[fx.Node]:
+        nodes: list[fx.Node] = []
+        for region in self.region_graph.subgraphs.values():
+            for node in region.nodes:
+                if filter(node):
+                    nodes.append(node)
+        return nodes
+
 
 ###############################################################################
 # Execution context.

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -500,6 +500,18 @@ class MMA(CustomOp):
         unique_dims = list(dict.fromkeys(combined_dims))
         return unique_dims
 
+    @property
+    def lhs_type(self) -> Memory:
+        return get_custom(self.lhs).type
+
+    @property
+    def rhs_type(self) -> Memory:
+        return get_custom(self.rhs).type
+
+    @property
+    def acc_type(self) -> Memory:
+        return get_custom(self.acc).type
+
 
 @define_op("read")
 @dataclass

--- a/shark_turbine/kernel/wave/constraints.py
+++ b/shark_turbine/kernel/wave/constraints.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Sequence
+from typing import Optional
 import shark_turbine.kernel.lang as tkl
-from sympy import Expr, Symbol
+from sympy import ceiling
 
-from shark_turbine.kernel.ops.wave_ops import MMA
 from .._support.indexing import IndexExpr, IndexSymbol
 
 
@@ -124,7 +123,7 @@ class TilingConstraint(Constraint):
         """
         Returns an expression for the number of iterations in the loop.
         """
-        return self.dim / self.tile_size
+        return ceiling(self.dim / self.tile_size)
 
     def apply(self) -> IndexExpr:
         if self.induction_var is None:

--- a/tests/kernel/wave/constraints_test.py
+++ b/tests/kernel/wave/constraints_test.py
@@ -2,12 +2,17 @@ import logging
 import pytest
 import unittest
 from shark_turbine.kernel.lang import sym
-from shark_turbine.kernel.wave.constraints import WorkgroupConstraint, get_grid_shape
+from shark_turbine.kernel.wave.constraints import (
+    WorkgroupConstraint,
+    get_grid_shape,
+    TilingConstraint,
+)
 
 M = sym.M
 N = sym.N
 BLOCK_N = sym.BLOCK_N
 BLOCK_M = sym.BLOCK_K
+I = sym.I
 
 
 class ConstraintsTest(unittest.TestCase):
@@ -28,9 +33,23 @@ class ConstraintsTest(unittest.TestCase):
         # Checking invalid workgroup dimension
         with pytest.raises(
             ValueError,
-            match="Invalid workgroup dimension. Expected 0 or 1.",
+            match="Invalid workgroup dimension. Expected 0, 1 or 2.",
         ):
-            WorkgroupConstraint(N, BLOCK_N, 2).apply()
+            WorkgroupConstraint(N, BLOCK_N, 3).apply()
+
+    def testTilingConstraint(self):
+        constraints: list[TilingConstraint] = [TilingConstraint(M, BLOCK_M)]
+        constraints.append(TilingConstraint(N, BLOCK_N, I))
+
+        assert constraints[0].iterations() == M / BLOCK_M
+        assert constraints[1].iterations() == N / BLOCK_N
+        assert constraints[1].apply() == I * BLOCK_N
+
+        with pytest.raises(
+            ValueError,
+            match="Index is being computed without setting induction variable",
+        ):
+            constraints[0].apply()
 
 
 if __name__ == "__main__":

--- a/tests/kernel/wave/constraints_test.py
+++ b/tests/kernel/wave/constraints_test.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import unittest
+from sympy import ceiling
 from shark_turbine.kernel.lang import sym
 from shark_turbine.kernel.wave.constraints import (
     WorkgroupConstraint,
@@ -41,8 +42,8 @@ class ConstraintsTest(unittest.TestCase):
         constraints: list[TilingConstraint] = [TilingConstraint(M, BLOCK_M)]
         constraints.append(TilingConstraint(N, BLOCK_N, I))
 
-        assert constraints[0].iterations() == M / BLOCK_M
-        assert constraints[1].iterations() == N / BLOCK_N
+        assert constraints[0].iterations() == ceiling(M / BLOCK_M)
+        assert constraints[1].iterations() == ceiling(N / BLOCK_N)
         assert constraints[1].apply() == I * BLOCK_N
 
         with pytest.raises(


### PR DESCRIPTION
This PR adds a tiling constraint primitive to the language. This is used to represent constraints on how a dimension is to be tiled. In contrast to the workgroup constraints, dimensions with a tiling constraint on them are not distributed and materialized to sequential loops.

This PR also adds support for a third workgroup dimension and deduces the mapping of user dimensions to MMA dimensions based on the operands of the tkw.mma operator.