### PR TITLE
Wave sim mapping support and igemm kernel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,6 @@ jobs:
       - name: Run LIT tests
         if: ${{ !cancelled() }}
         run: |
-          lit --version
           lit lit_tests/ -v
 
       - name: MyPy Type Checking

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: Run LIT tests
         if: ${{ !cancelled() }}
         run: |
+          lit --version
           lit lit_tests/ -v
 
       - name: MyPy Type Checking

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -88,13 +88,13 @@ def test_read_write_equal_sizes():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_1_1
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_1_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_0_1
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %write_0_0
         # CHECK-SAME: (%read_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_1
@@ -166,9 +166,9 @@ def test_read_write():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_1_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %write_0_0_0
         # CHECK-SAME: (%read_0_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_0_1
@@ -295,23 +295,23 @@ def test_gemm():
 
         # CHECK-NEXT: %a
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_1_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_1_0_1
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
 
         # CHECK-NEXT: %b
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_1_0
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_1_1
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
 
         # CHECK-NEXT: %mma_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
@@ -436,31 +436,31 @@ def test_gemm_reduction_expansion_only():
 
         # CHECK-NEXT: %a
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_0_0_2
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_0_0_3
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
 
         # CHECK-NEXT: %b
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_0_2
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_0_3
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_1_0
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_1_1
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_1_2
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
         # CHECK-NEXT: %read_0_1_3
-        # CHECK-SAME: (%b, 4, None, None)
+        # CHECK-SAME: (%b, 4, None)
 
         # CHECK-NEXT: %mma_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
@@ -567,9 +567,9 @@ def py_arithmetic_different_dims():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %read_1_0_0
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %add_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0)
         # CHECK-NEXT: %add_1_0_0

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -88,21 +88,21 @@ def test_read_write_equal_sizes():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_1_1
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_1_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_0_1
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %write_0_0
-        # CHECK-SAME: (%read_0_0, %c, 4)
+        # CHECK-SAME: (%read_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_1
-        # CHECK-SAME: (%read_1_1, %c, 4)
+        # CHECK-SAME: (%read_1_1, %c, 4, None)
         # CHECK-NEXT: %write_1_0
-        # CHECK-SAME: (%read_1_0, %c, 4)
+        # CHECK-SAME: (%read_1_0, %c, 4, None)
         # CHECK-NEXT: %write_0_1
-        # CHECK-SAME: (%read_0_1, %c, 4)
+        # CHECK-SAME: (%read_0_1, %c, 4, None)
         # CHECK-NEXT: return
 
         # Custom format:
@@ -166,17 +166,17 @@ def test_read_write():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_1_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %write_0_0_0
-        # CHECK-SAME: (%read_0_0_0, %c, 4)
+        # CHECK-SAME: (%read_0_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_0_1
-        # CHECK-SAME: (%read_1_0_0, %c, 4)
+        # CHECK-SAME: (%read_1_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_0_0
-        # CHECK-SAME: (%read_1_0_0, %c, 4)
+        # CHECK-SAME: (%read_1_0_0, %c, 4, None)
         # CHECK-NEXT: %write_0_0_1
-        # CHECK-SAME: (%read_0_0_0, %c, 4)
+        # CHECK-SAME: (%read_0_0_0, %c, 4, None)
         # CHECK-NEXT: return None
 
         # Custom format:
@@ -253,13 +253,13 @@ def test_gemm():
         # CHECK-NEXT: %getresult_0_1_0
         # CHECK-NEXT: %getresult_0_0_0
         # CHECK-NEXT: %write_0_0_0
-        # CHECK-SAME: (%getresult_0_0_0, %c, 4)
+        # CHECK-SAME: (%getresult_0_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_1_0
-        # CHECK-SAME: (%getresult_1_1_0, %c, 4)
+        # CHECK-SAME: (%getresult_1_1_0, %c, 4, None)
         # CHECK-NEXT: %write_1_0_0
-        # CHECK-SAME: (%getresult_1_0_0, %c, 4)
+        # CHECK-SAME: (%getresult_1_0_0, %c, 4, None)
         # CHECK-NEXT: %write_0_1_0
-        # CHECK-SAME: (%getresult_0_1_0, %c, 4)
+        # CHECK-SAME: (%getresult_0_1_0, %c, 4, None)
         # CHECK-NEXT: return None
 
         # Custom format:
@@ -295,23 +295,23 @@ def test_gemm():
 
         # CHECK-NEXT: %a
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_1_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_1_0_1
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
 
         # CHECK-NEXT: %b
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_1_0
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_1_1
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
 
         # CHECK-NEXT: %mma_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
@@ -408,9 +408,9 @@ def test_gemm_reduction_expansion_only():
         # CHECK-NEXT: %getresult_0_1_0
         # CHECK-NEXT: %getresult_0_0_0
         # CHECK-NEXT: %write_0_0_0
-        # CHECK-SAME: (%getresult_0_0_0, %c, 4)
+        # CHECK-SAME: (%getresult_0_0_0, %c, 4, None)
         # CHECK-NEXT: %write_0_1_0
-        # CHECK-SAME: (%getresult_0_1_0, %c, 4)
+        # CHECK-SAME: (%getresult_0_1_0, %c, 4, None)
         # CHECK-NEXT: return None
 
         # Custom format:
@@ -436,31 +436,31 @@ def test_gemm_reduction_expansion_only():
 
         # CHECK-NEXT: %a
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_0_0_2
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_0_0_3
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
 
         # CHECK-NEXT: %b
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_0_1
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_0_2
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_0_3
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_1_0
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_1_1
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_1_2
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
         # CHECK-NEXT: %read_0_1_3
-        # CHECK-SAME: (%b, 4)
+        # CHECK-SAME: (%b, 4, None, None)
 
         # CHECK-NEXT: %mma_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
@@ -567,9 +567,9 @@ def py_arithmetic_different_dims():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read_0_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %read_1_0_0
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %add_0_0_0
         # CHECK-SAME: (%read_0_0_0, %read_0_0_0)
         # CHECK-NEXT: %add_1_0_0
@@ -583,13 +583,13 @@ def py_arithmetic_different_dims():
         # CHECK-NEXT: %neg_1_0_0
         # CHECK-SAME: (%sub_1_0_0,)
         # CHECK-NEXT: %write_0_0_0
-        # CHECK-SAME: (%neg_0_0_0, %c, 4)
+        # CHECK-SAME: (%neg_0_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_0_1
-        # CHECK-SAME: (%neg_1_0_0, %c, 4)
+        # CHECK-SAME: (%neg_1_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_0_0
-        # CHECK-SAME: (%neg_1_0_0, %c, 4)
+        # CHECK-SAME: (%neg_1_0_0, %c, 4, None)
         # CHECK-NEXT: %write_0_0_1
-        # CHECK-SAME: (%neg_0_0_0, %c, 4)
+        # CHECK-SAME: (%neg_0_0_0, %c, 4, None)
         # CHECK-NEXT: return None
 
         # Custom format:

--- a/lit_tests/kernel/wave/promotion.py
+++ b/lit_tests/kernel/wave/promotion.py
@@ -90,15 +90,15 @@ def test_read_write_equal_sizes():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read
-        # CHECK-SAME: (%a, 4)
+        # CHECK-SAME: (%a, 4, None, None)
         # CHECK-NEXT: %allocate
         # CHECK-SAME: ((M, N), f16, $SHARED_ADDRESS_SPACE)
         # CHECK-NEXT: %write_1
-        # CHECK-SAME: (%read, %allocate, 4)
+        # CHECK-SAME: (%read, %allocate, 4, None)
         # CHECK-NEXT: %read_1
-        # CHECK-SAME: (%allocate, 4)
+        # CHECK-SAME: (%allocate, 4, None, None)
         # CHECK-NEXT: %write
-        # CHECK-SAME: (%read_1, %c, 4)
+        # CHECK-SAME: (%read_1, %c, 4, None)
 
         # CHECK: -----
 
@@ -155,22 +155,22 @@ def test_gemm():
         # CHECK-SAME: ((N, K), f16, $SHARED_ADDRESS_SPACE)
         # CHECK-NEXT: reduction
         # CHECK-NEXT: %write
-        # CHECK-SAME: (%reduction, %c, 4)
+        # CHECK-SAME: (%reduction, %c, 4, None)
 
         # Reduction subgraph:
         # CHECK: %acc
         # CHECK-NEXT: %a
         # CHECK-NEXT: %read
         # CHECK-NEXT: %write
-        # CHECK-SAME: (%read, %allocate, 4)
+        # CHECK-SAME: (%read, %allocate, 4, None)
         # CHECK-NEXT: %read_2
-        # CHECK-SAME: (%allocate, 4)
+        # CHECK-SAME: (%allocate, 4, None, None)
         # CHECK-NEXT: %b
         # CHECK-NEXT: %read_1
         # CHECK-NEXT: %write_1
-        # CHECK-SAME: (%read_1, %allocate_1, 4)
+        # CHECK-SAME: (%read_1, %allocate_1, 4, None)
         # CHECK-NEXT: %read_3
-        # CHECK-SAME: (%allocate_1, 4)
+        # CHECK-SAME: (%allocate_1, 4, None, None)
         # CHECK-NEXT: %mma
         # CHECK-SAME: (%read_2, %read_3, %acc)
 

--- a/lit_tests/kernel/wave/promotion.py
+++ b/lit_tests/kernel/wave/promotion.py
@@ -90,13 +90,13 @@ def test_read_write_equal_sizes():
         # CHECK: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read
-        # CHECK-SAME: (%a, 4, None, None)
+        # CHECK-SAME: (%a, 4, None)
         # CHECK-NEXT: %allocate
         # CHECK-SAME: ((M, N), f16, $SHARED_ADDRESS_SPACE)
         # CHECK-NEXT: %write_1
         # CHECK-SAME: (%read, %allocate, 4, None)
         # CHECK-NEXT: %read_1
-        # CHECK-SAME: (%allocate, 4, None, None)
+        # CHECK-SAME: (%allocate, 4, None)
         # CHECK-NEXT: %write
         # CHECK-SAME: (%read_1, %c, 4, None)
 
@@ -164,13 +164,13 @@ def test_gemm():
         # CHECK-NEXT: %write
         # CHECK-SAME: (%read, %allocate, 4, None)
         # CHECK-NEXT: %read_2
-        # CHECK-SAME: (%allocate, 4, None, None)
+        # CHECK-SAME: (%allocate, 4, None)
         # CHECK-NEXT: %b
         # CHECK-NEXT: %read_1
         # CHECK-NEXT: %write_1
         # CHECK-SAME: (%read_1, %allocate_1, 4, None)
         # CHECK-NEXT: %read_3
-        # CHECK-SAME: (%allocate_1, 4, None, None)
+        # CHECK-SAME: (%allocate_1, 4, None)
         # CHECK-NEXT: %mma
         # CHECK-SAME: (%read_2, %read_3, %acc)
 

--- a/lit_tests/kernel/wave/tracing.py
+++ b/lit_tests/kernel/wave/tracing.py
@@ -96,7 +96,7 @@ def test_trace_py_arithmetic():
     print_trace(trace)
     # CHECK: %a
     # CHECK-NEXT: %read
-    # CHECK-SAME: (%a, None, None, None)
+    # CHECK-SAME: (%a, None, None)
     # CHECK-NEXT: %add
     # CHECK-SAME: (%read, %read)
     # CHECK-NEXT: %sub

--- a/lit_tests/kernel/wave/tracing.py
+++ b/lit_tests/kernel/wave/tracing.py
@@ -96,7 +96,7 @@ def test_trace_py_arithmetic():
     print_trace(trace)
     # CHECK: %a
     # CHECK-NEXT: %read
-    # CHECK-SAME: (%a, None)
+    # CHECK-SAME: (%a, None, None, None)
     # CHECK-NEXT: %add
     # CHECK-SAME: (%read, %read)
     # CHECK-NEXT: %sub
@@ -104,7 +104,7 @@ def test_trace_py_arithmetic():
     # CHECK-NEXT: %neg
     # CHECK-SAME: (%sub,)
     # CHECK-NEXT: %write
-    # CHECK-SAME: (%neg, %a, 4)
+    # CHECK-SAME: (%neg, %a, 4, None)
     # CHECK-NEXT: return None
 
     # Custom format:

--- a/shark_turbine/kernel/lang/__init__.py
+++ b/shark_turbine/kernel/lang/__init__.py
@@ -2,7 +2,7 @@ from .prims import *
 from .types import *
 from .kernel_buffer import *
 from .wave_types import *
-from .wave_types import Memory, Register
+from .wave_types import Memory, Register, IndexMapping
 from .grid import *
 
 # Include publics from the _support library.

--- a/shark_turbine/kernel/lang/wave_types.py
+++ b/shark_turbine/kernel/lang/wave_types.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, TypeVar, ClassVar
+from typing import Optional, Type, TypeVar, ClassVar, Callable, Any
 
 from .kernel_buffer import AddressSpace, KernelBufferMeta, KernelBufferUsage
 from ..ops.wave_ops import register
@@ -6,6 +6,7 @@ from .._support.dtype import DataType
 from .._support.indexing import IndexExpr
 
 __all__ = [
+    "IndexMapping",
     "Memory",
     "Register",
 ]
@@ -109,3 +110,11 @@ class Register(metaclass=KernelBufferMeta):
             symbolic_shape=shape,
             dtype=dtype,
         )
+
+
+class IndexMapping:
+
+    mapping_func: ClassVar[Callable[..., Any]]
+
+    def __init__(self, func: Callable[..., Any]) -> None:
+        self.mapping_func = func

--- a/shark_turbine/kernel/lang/wave_types.py
+++ b/shark_turbine/kernel/lang/wave_types.py
@@ -114,7 +114,7 @@ class Register(metaclass=KernelBufferMeta):
 
 class IndexMapping:
     """
-    Represents am mapping between 2 sets of indices.
+    Represents a mapping between 2 sets of indices.
     """
 
     mapping_func: ClassVar[Callable[tuple[IndexExpr, ...], tuple[IndexExpr, ...]]]

--- a/shark_turbine/kernel/lang/wave_types.py
+++ b/shark_turbine/kernel/lang/wave_types.py
@@ -147,9 +147,11 @@ class IndexMapping:
     output_mapping: SymbolsMap
     iteration_shape: tuple[IndexExpr, ...]
 
-    def __init__(self, num_dims: int, inputs: SymbolsMap, outputs: SymbolsMap) -> None:
-        iters = {self.iterator(i): i for i in range(num_dims)}
-        iter_shape = [None] * num_dims
+    def __init__(
+        self, num_iterators: int, inputs: SymbolsMap, outputs: SymbolsMap
+    ) -> None:
+        iters = {self.iterator(i): i for i in range(num_iterators)}
+        iter_shape = [None] * num_iterators
         for sym, expr in chain(inputs.items(), outputs.items()):
             i = iters.get(expr, None)
             if i is None:
@@ -170,7 +172,7 @@ class IndexMapping:
         self.output_mapping = outputs
 
     @property
-    def num_dims(self) -> int:
+    def num_iterators(self) -> int:
         return len(self.iters)
 
     def substitute(self, subs: Iterable[tuple[IndexExpr, IndexExpr]]) -> Self:
@@ -180,7 +182,7 @@ class IndexMapping:
         new_outputs = {
             key: _subs_expr(val, subs) for key, val in self.output_mapping.items()
         }
-        return IndexMapping(self.num_dims, new_inputs, new_outputs)
+        return IndexMapping(self.num_iterators, new_inputs, new_outputs)
 
     @property
     def output_shape(self) -> tuple[IndexExpr]:

--- a/shark_turbine/kernel/lang/wave_types.py
+++ b/shark_turbine/kernel/lang/wave_types.py
@@ -184,7 +184,7 @@ class IndexMapping:
 
     @property
     def output_shape(self) -> tuple[IndexExpr]:
-        return self.output_mapping.keys()
+        return tuple(self.output_mapping.keys())
 
     @staticmethod
     def iterator(index: int) -> IndexSymbol:

--- a/shark_turbine/kernel/lang/wave_types.py
+++ b/shark_turbine/kernel/lang/wave_types.py
@@ -113,8 +113,13 @@ class Register(metaclass=KernelBufferMeta):
 
 
 class IndexMapping:
+    """
+    Represents am mapping between 2 sets of indices.
+    """
 
-    mapping_func: ClassVar[Callable[..., Any]]
+    mapping_func: ClassVar[Callable[tuple[IndexExpr, ...], tuple[IndexExpr, ...]]]
 
-    def __init__(self, func: Callable[..., Any]) -> None:
+    def __init__(
+        self, func: Callable[tuple[IndexExpr, ...], tuple[IndexExpr, ...]]
+    ) -> None:
         self.mapping_func = func

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -206,6 +206,7 @@ class CustomOp(ABC):
     def custom_string(self, value_map: dict[str, str]) -> str:
         # print all variables of the node apart from graph and fx_node
         ignore_list = ["fx_node", "graph"]
+
         if self.index is None:
             ignore_list += ["index"]
         vars_list = [

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -42,9 +42,9 @@ def allocate(
 
 def read(
     memory: "Memory",
-    elements_per_thread: Optional[IndexExpr] = None,
+    elements_per_thread: Optional[IndexExpr | int] = None,
     mapping: Optional[IndexMapping] = None,
-    shape: Optional[tuple[IndexExpr, ...]] = None,
+    shape: Optional[tuple[IndexExpr]] = None,
 ) -> "Register":
     ...
 
@@ -568,6 +568,8 @@ class MMA(CustomOp):
 class Read(CustomOp):
     memory: fx.Proxy
     elements_per_thread: Optional[Any] = None
+    mapping: Optional[IndexMapping] = None
+    shape: Optional[tuple(IndexExpr)] = None
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:
@@ -630,6 +632,7 @@ class Write(CustomOp):
     register_: fx.Proxy
     memory: fx.Proxy
     elements_per_thread: Optional[Any]
+    mapping: Optional[IndexMapping] = None
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -41,7 +41,10 @@ def allocate(
 
 
 def read(
-    memory: "Memory", elements_per_thread: Optional[IndexExpr] = None
+    memory: "Memory",
+    elements_per_thread: Optional[IndexExpr] = None,
+    mapping: Optional[IndexMapping] = None,
+    shape: Optional[tuple[IndexExpr, ...]] = None,
 ) -> "Register":
     ...
 
@@ -64,6 +67,7 @@ def write(
     register_: "Register",
     memory: "Memory",
     elements_per_thread: Optional[IndexExpr | int] = None,
+    mapping: Optional[IndexMapping] = None,
 ):
     ...
 

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -17,7 +17,7 @@ from typing import (
 import torch.fx as fx
 
 if TYPE_CHECKING:
-    from ..lang.wave_types import Memory, Register
+    from ..lang.wave_types import Memory, Register, IndexMapping
 from .._support.indexing import IndexExpr, IndexSymbol
 from .._support.dtype import DataType
 from .._support.regions import RegionGraph

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -44,7 +44,6 @@ def read(
     memory: "Memory",
     elements_per_thread: Optional[IndexExpr | int] = None,
     mapping: Optional[IndexMapping] = None,
-    shape: Optional[tuple[IndexExpr]] = None,
 ) -> "Register":
     ...
 
@@ -570,7 +569,6 @@ class Read(CustomOp):
     memory: fx.Proxy
     elements_per_thread: Optional[Any] = None
     mapping: Optional[IndexMapping] = None
-    shape: Optional[tuple(IndexExpr)] = None
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:

--- a/shark_turbine/kernel/wave/__init__.py
+++ b/shark_turbine/kernel/wave/__init__.py
@@ -1,3 +1,4 @@
 from ..ops.wave_ops import *
 from .constraints import *
 from .wave import *
+from .wave import IndexMapping

--- a/shark_turbine/kernel/wave/codegen.py
+++ b/shark_turbine/kernel/wave/codegen.py
@@ -223,9 +223,11 @@ def handle_register(emitter: WaveEmitter, node: fx.Node):
 def handle_read(emitter: WaveEmitter, node: fx.Node):
     # This is similar to tkl.store with fixed start indices for now.
     try:
-        memory, elements_per_thread = node.args
+        memory, elements_per_thread, mapping = node.args
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
+
+    assert mapping is None, "mapping is not supported yet"
 
     vector_shape = cast_py_literal(emitter, (elements_per_thread,))
     # memory has no IR node yet.

--- a/shark_turbine/kernel/wave/wave.py
+++ b/shark_turbine/kernel/wave/wave.py
@@ -15,7 +15,7 @@ from .constraints import (
 )
 from .codegen import WaveEmitter
 from .expansion import expand_graph
-from ..lang import Grid
+from ..lang import Grid, IndexMapping
 from ..lang.global_symbols import *
 from ..ops import wave_ops
 from ..ops.wave_ops import Reduction, CustomOp, get_custom

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -7,6 +7,7 @@ import torch
 from typing import Any, Callable, Optional, TypeAlias
 from .constraints import Constraint
 
+import numpy as np
 from sympy import Symbol
 from sympy.core.expr import Expr
 from .._support.shaped_type import ShapedType

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -192,8 +192,8 @@ def _reduction_proxy(axis: int, init_args: list[Any]):
 def _read_proxy(
     memory: "Memory",
     elements_per_thread: Optional[IndexExpr] = None,
-    mapping: IndexMapping = None,
-    shape: tuple[IndexExpr, ...] = None,
+    mapping: Optional[IndexMapping] = None,
+    shape: Optional[tuple[IndexExpr, ...]] = None,
 ) -> "Register":
     if mapping:
         assert shape
@@ -212,7 +212,7 @@ def _write_proxy(
     src: "Register",
     dst: "Memory",
     elements_per_thread: Optional[IndexExpr] = None,
-    mapping: IndexMapping = None,
+    mapping: Optional[IndexMapping] = None,
 ):
     if mapping:
         mapping_func = mapping.mapping_func

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -14,6 +14,7 @@ from .._support.shaped_type import ShapedType
 
 from .. import lang as tkl
 from .. import wave as tkw
+from ..wave import IndexMapping
 
 
 def wave_sim(constraints: Optional[list[Constraint]] = None):
@@ -191,7 +192,7 @@ def _reduction_proxy(axis: int, init_args: list[Any]):
 def _read_proxy(
     memory: "Memory",
     elements_per_thread: Optional[IndexExpr] = None,
-    mapping: Callable[..., Any] = None,
+    mapping: IndexMapping = None,
     shape: tuple[IndexExpr, ...] = None,
 ) -> "Register":
     if mapping:
@@ -211,7 +212,7 @@ def _write_proxy(
     src: "Register",
     dst: "Memory",
     elements_per_thread: Optional[IndexExpr] = None,
-    mapping: Callable[..., Any] = None,
+    mapping: IndexMapping = None,
 ):
     if mapping:
         mapping_func = mapping.mapping_func

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -186,6 +186,7 @@ def _reduction_proxy(axis: int, init_args: list[Any]):
 
     return decorator
 
+
 def _read_proxy(
     memory: "Memory",
     elements_per_thread: Optional[IndexExpr] = None,
@@ -209,7 +210,7 @@ def _write_proxy(
     src: "Register",
     dst: "Memory",
     elements_per_thread: Optional[IndexExpr] = None,
-    mapping: Callable[..., Any] = None
+    mapping: Callable[..., Any] = None,
 ):
     if mapping:
         mapping_func = mapping.mapping_func

--- a/shark_turbine/kernel/wave/wave_sim.py
+++ b/shark_turbine/kernel/wave/wave_sim.py
@@ -198,9 +198,7 @@ def _read_proxy(
         res = torch.zeros(shape)
         for index in np.ndindex(*shape):
             mapped = mapping_func(*index)
-            # print(index, mapped)
-            if all(i >= 0 and i < b for i, b in zip(mapped, memory.shape)):
-                res[index] = memory[mapped]
+            res[index] = memory[mapped]
 
         return res
 

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -245,16 +245,6 @@ def test_transpose_1():
         )
         tkw.write(a_reg, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
-    hyperparams = {
-        ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
-        LOAD_ELEMS_PER_THREAD: 4,
-        STORE_ELEMS_PER_THREAD: 1,
-        BLOCK_M: 32,
-        BLOCK_N: 32,
-        M: 64,
-        N: 128,
-    }
-
     a = torch.randn(128, 256, dtype=torch.float32)
     c = torch.zeros(256, 128, dtype=torch.float32)
     transpose(a, c)
@@ -298,17 +288,93 @@ def test_transpose_2():
             elements_per_thread=STORE_ELEMS_PER_THREAD,
         )
 
-    hyperparams = {
-        ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
-        LOAD_ELEMS_PER_THREAD: 4,
-        STORE_ELEMS_PER_THREAD: 1,
-        BLOCK_M: 32,
-        BLOCK_N: 32,
-        M: 64,
-        N: 128,
-    }
-
     a = torch.randn(128, 256, dtype=torch.float32)
     c = torch.zeros(256, 128, dtype=torch.float32)
     transpose(a, c)
     assert_allclose(c, a.T)
+
+
+def test_igemm_conv():
+    n, c, h, w = 2, 3, 4, 4 # Image.
+    nf, cf, hf, wf = 2, c, 2, 2 # Filters.
+    x = torch.randn(n, c, h, w, dtype=torch.float32)
+    we = torch.randn(nf, cf, hf, wf, dtype=torch.float32)
+
+    stride = 1
+    padding = 0 # TODO: only pad=0 is supported for now
+    convRef = torch.nn.Conv2d(c, nf, hf, stride=stride, padding=padding, bias=False)
+    convRef.weight = torch.nn.Parameter(we)
+    out_ref = convRef(x).detach()
+    print("src")
+    print(x)
+    print("weight")
+    print(we)
+    print("res")
+    print(out_ref)
+
+    sym = tkl.sym
+    N, C, H, W = sym.N, sym.C, sym.H, sym.W
+    NF, HF, WF = sym.NF, sym.HF, sym.WF
+    KB = sym.KB
+    H_OUT = (H + 2 * padding - HF) / stride + 1
+    W_OUT = (W + 2 * padding - WF) / stride + 1
+    SZ_OUT = H_OUT * W_OUT
+    # SZ_OUT_N = SZ_OUT *
+
+    x_mapping = tkw.IndexMapping(lambda i, j: (i // SZ_OUT, j // (HF * WF), (i % SZ_OUT) % W_OUT + (j % (HF * WF)) % WF, (i % SZ_OUT) // W_OUT + (j % (HF * WF)) // WF))
+    w_mapping = tkw.IndexMapping(lambda i, j: (i % NF, j // (HF * WF), j % WF, (j % (HF * WF)) // WF))
+    out_mapping = tkw.IndexMapping(lambda i, j: (i // SZ_OUT,j, (i % SZ_OUT) % W_OUT, (i % SZ_OUT) // W_OUT))
+
+    constraints = []
+
+    # # Input sizes
+    # M = tkl.sym.M
+    # N = tkl.sym.N
+    # K = tkl.sym.K
+    # # Workgroup tile sizes
+    # BLOCK_M = tkl.sym.BLOCK_M
+    # BLOCK_N = tkl.sym.BLOCK_N
+    # BLOCK_K = tkl.sym.BLOCK_K
+    # # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # # Expose user-constraints
+    # constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    # constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    # constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+
+    # constraints += [
+    #     tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
+    # ]
+
+
+    @wave_sim(constraints)
+    def conv(
+        x: tkl.Memory[N, C, H, W, ADDRESS_SPACE, tkl.f16],
+        we: tkl.Memory[NF, C, HF, WF, ADDRESS_SPACE, tkl.f16],
+        out: tkl.Memory[N, NF, H_OUT, W_OUT, ADDRESS_SPACE, tkl.f32],
+    ):
+        print('-=-=-=-=-=-=-')
+        K = HF * WF * C
+        M = SZ_OUT * N
+        c_reg = tkl.Register[M, NF, tkl.f32](0.0)
+        @tkw.reduction(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, NF, tkl.f32]) -> tkl.Register[M, NF, tkl.f32]:
+            a_reg = tkw.read(x, mapping=x_mapping, shape=(M, K), elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            print(a_reg)
+            b_reg = tkw.read(we, mapping=w_mapping, shape=(NF, K), elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            print(b_reg)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            print(acc)
+            return acc
+
+        print(repeat.shape)
+        tkw.write(repeat, out, mapping=out_mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    out = torch.zeros_like(out_ref)
+    conv(x, we, out)
+    print(out)
+    assert_allclose(out, out_ref, rtol=1e-05)

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -284,7 +284,6 @@ def test_transpose_2():
             a_reg,
             c,
             mapping=mapping,
-            shape=(N, M),
             elements_per_thread=STORE_ELEMS_PER_THREAD,
         )
 

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -170,7 +170,7 @@ def test_gemm():
     # Expose user-constraints
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
 
     constraints += [
         tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
@@ -347,7 +347,7 @@ def test_igemm_conv(n, c, nf, stride):
     # Expose user-constraints
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(NF, BLOCK_N, 1)]
-    constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
 
     constraints += [
         tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -307,21 +307,14 @@ def test_igemm_conv(n, c, nf, stride):
     convRef = torch.nn.Conv2d(c, nf, hf, stride=stride, padding=padding, bias=False)
     convRef.weight = torch.nn.Parameter(we)
     out_ref = convRef(x).detach()
-    print("src")
-    print(x)
-    print("weight")
-    print(we)
-    print("res")
-    print(out_ref)
 
     sym = tkl.sym
     N, C, H, W = sym.N, sym.C, sym.H, sym.W
     NF, HF, WF = sym.NF, sym.HF, sym.WF
-    KB = sym.KB
+
     H_OUT = (H + 2 * padding - HF) // stride + 1
     W_OUT = (W + 2 * padding - WF) // stride + 1
     SZ_OUT = H_OUT * W_OUT
-    # SZ_OUT_N = SZ_OUT *
 
     x_mapping = tkw.IndexMapping(
         lambda i, j: (
@@ -366,7 +359,6 @@ def test_igemm_conv(n, c, nf, stride):
         we: tkl.Memory[NF, C, HF, WF, ADDRESS_SPACE, tkl.f16],
         out: tkl.Memory[N, NF, H_OUT, W_OUT, ADDRESS_SPACE, tkl.f32],
     ):
-        print("-=-=-=-=-=-=-")
         c_reg = tkl.Register[M, NF, tkl.f32](0.0)
 
         @tkw.reduction(K, init_args=[c_reg])
@@ -377,16 +369,13 @@ def test_igemm_conv(n, c, nf, stride):
                 shape=(M, K),
                 elements_per_thread=LOAD_ELEMS_PER_THREAD,
             )
-            print(a_reg)
             b_reg = tkw.read(
                 we,
                 mapping=w_mapping,
                 shape=(NF, K),
                 elements_per_thread=LOAD_ELEMS_PER_THREAD,
             )
-            print(b_reg)
             acc = tkw.mma(a_reg, b_reg, acc)
-            print(acc)
             return acc
 
         tkw.write(
@@ -395,5 +384,4 @@ def test_igemm_conv(n, c, nf, stride):
 
     out = torch.zeros_like(out_ref)
     conv(x, we, out)
-    print(out)
     assert_allclose(out, out_ref, rtol=1e-05, atol=1e-05)

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -152,6 +152,8 @@ def test_broadcast_3():
     assert_allclose(c, b[0] + torch.zeros(128, 256, dtype=torch.float32))
 
 
+=======
+>>>>>>> b7ec3c9 (eltwise test)
 def test_gemm():
     # Input sizes
     M = tkl.sym.M

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -233,16 +233,16 @@ def test_transpose_1():
         tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
 
-    mapping = tkw.IndexMapping(lambda i, j: (j, i))
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    mapping = tkw.IndexMapping(num_dims=2, inputs={N: i, M: j}, outputs={N: i, M: j})
 
     @wave_sim(constraints)
     def transpose(
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f32],
         c: tkl.Memory[N, M, ADDRESS_SPACE, tkl.f32],
     ):
-        a_reg = tkw.read(
-            a, mapping=mapping, shape=(N, M), elements_per_thread=LOAD_ELEMS_PER_THREAD
-        )
+        a_reg = tkw.read(a, mapping=mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD)
         tkw.write(a_reg, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     a = torch.randn(128, 256, dtype=torch.float32)
@@ -272,7 +272,9 @@ def test_transpose_2():
         tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))
     ]
 
-    mapping = tkw.IndexMapping(lambda i, j: (j, i))
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    mapping = tkw.IndexMapping(num_dims=2, inputs={N: i, M: j}, outputs={N: i, M: j})
 
     @wave_sim(constraints)
     def transpose(

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -235,7 +235,9 @@ def test_transpose_1():
 
     i = tkw.IndexMapping.iterator(0)
     j = tkw.IndexMapping.iterator(1)
-    mapping = tkw.IndexMapping(num_dims=2, inputs={N: i, M: j}, outputs={N: i, M: j})
+    mapping = tkw.IndexMapping(
+        num_iterators=2, inputs={N: i, M: j}, outputs={N: i, M: j}
+    )
 
     @wave_sim(constraints)
     def transpose(
@@ -274,7 +276,9 @@ def test_transpose_2():
 
     i = tkw.IndexMapping.iterator(0)
     j = tkw.IndexMapping.iterator(1)
-    mapping = tkw.IndexMapping(num_dims=2, inputs={N: i, M: j}, outputs={N: i, M: j})
+    mapping = tkw.IndexMapping(
+        num_iterators=2, inputs={N: i, M: j}, outputs={N: i, M: j}
+    )
 
     @wave_sim(constraints)
     def transpose(
@@ -325,7 +329,7 @@ def test_igemm_conv(n, c, nf, stride):
     j = tkw.IndexMapping.iterator(1)
 
     x_mapping = tkw.IndexMapping(
-        num_dims=2,
+        num_iterators=2,
         inputs={
             N: i // SZ_OUT,
             C: j // (HF * WF),
@@ -335,12 +339,12 @@ def test_igemm_conv(n, c, nf, stride):
         outputs={M: i, K: j},
     )
     w_mapping = tkw.IndexMapping(
-        num_dims=2,
+        num_iterators=2,
         inputs={NF: i % NF, C: j // (HF * WF), HF: j % WF, WF: (j % (HF * WF)) // WF},
         outputs={NF: i, K: j},
     )
     out_mapping = tkw.IndexMapping(
-        num_dims=2,
+        num_iterators=2,
         inputs={M: i, NF: j},
         outputs={
             N: i // SZ_OUT,

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -293,12 +293,12 @@ def test_transpose_2():
     assert_allclose(c, a.T)
 
 
-@pytest.mark.parametrize("n", [1, 2, 4])
-@pytest.mark.parametrize("c", [1, 3])
+@pytest.mark.parametrize("n", [1, 2, 4, 20])
+@pytest.mark.parametrize("c", [1, 3, 10])
 @pytest.mark.parametrize("nf", [1, 2, 8])
 @pytest.mark.parametrize("stride", [1, 2, 3])
 def test_igemm_conv(n, c, nf, stride):
-    h, w = 4, 4  # Image.
+    h, w = 5, 5  # Image.
     cf, hf, wf = c, 2, 2  # Filters.
     x = torch.randn(n, c, h, w, dtype=torch.float32)
     we = torch.randn(nf, cf, hf, wf, dtype=torch.float32)

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -300,7 +300,7 @@ def test_igemm_conv():
     x = torch.randn(n, c, h, w, dtype=torch.float32)
     we = torch.randn(nf, cf, hf, wf, dtype=torch.float32)
 
-    stride = 1
+    stride = 2
     padding = 0 # TODO: only pad=0 is supported for now
     convRef = torch.nn.Conv2d(c, nf, hf, stride=stride, padding=padding, bias=False)
     convRef.weight = torch.nn.Parameter(we)
@@ -321,7 +321,7 @@ def test_igemm_conv():
     SZ_OUT = H_OUT * W_OUT
     # SZ_OUT_N = SZ_OUT *
 
-    x_mapping = tkw.IndexMapping(lambda i, j: (i // SZ_OUT, j // (HF * WF), (i % SZ_OUT) % W_OUT + (j % (HF * WF)) % WF, (i % SZ_OUT) // W_OUT + (j % (HF * WF)) // WF))
+    x_mapping = tkw.IndexMapping(lambda i, j: (i // SZ_OUT, j // (HF * WF), (i % SZ_OUT) % W_OUT * stride + (j % (HF * WF)) % WF, (i % SZ_OUT) // W_OUT * stride + (j % (HF * WF)) // WF))
     w_mapping = tkw.IndexMapping(lambda i, j: (i % NF, j // (HF * WF), j % WF, (j % (HF * WF)) // WF))
     out_mapping = tkw.IndexMapping(lambda i, j: (i // SZ_OUT,j, (i % SZ_OUT) % W_OUT, (i % SZ_OUT) // W_OUT))
 


### PR DESCRIPTION
Add `mapping` argument to `read` and `write` ops and add support to the simulator.

* Add `IndexMapping` class which describes how to map between 2 sets of indices. Mapping consists of set of iterators and input/output dicts, which describe, how to map symbolic dimension to the specific iterator. Mapping is similar to `linalg.generic` index maps, where it's iterators corresponds to linalg `parallel` iterator. The difference is that we are binding iterator to dimensions symbols instead of dim index. E.g. if we have mapping like this:
```
    i = tkw.IndexMapping.iterator(0)
    j = tkw.IndexMapping.iterator(1)
    mapping = tkw.IndexMapping(
        num_iterators=2, inputs={N: i, M: j}, outputs={N: i, M: j}
    )
```
If the input array has shape `[N, M]`, we will copy a contiguous slice, but for the input shape `[M, N]` we will transpose input data.
If operation doesn't have output symbols by itself (i.e. `read`) the output will have same shape as `outputs` keys (e.g. `[N,M]` for prev example).
* Add simulator tests (simple transposes and implicit gemm conv example)
