### PR TITLE
Add indexing to nodes

### DIFF
--- a/shark_turbine/kernel/wave/distribution_symbols.py
+++ b/shark_turbine/kernel/wave/distribution_symbols.py
@@ -1,0 +1,9 @@
+import shark_turbine.kernel.lang as tkl
+
+WORKGROUP_0 = tkl.sym.WG0
+WORKGROUP_1 = tkl.sym.WG1
+WORKGROUP_2 = tkl.sym.WG2
+
+THREAD_0 = tkl.sym.T0
+THREAD_1 = tkl.sym.T1
+THREAD_2 = tkl.sym.T2

--- a/shark_turbine/kernel/wave/expansion.py
+++ b/shark_turbine/kernel/wave/expansion.py
@@ -12,6 +12,7 @@ from ..ops.wave_ops import *
 from .._support.indexing import IndexingContext
 from ...support.logging import get_logger
 from .._support.tracing import CapturedTrace
+from .indexing import IndexSequence
 
 logger = get_logger("turbine.wave.expansion")
 # This represents a mapping of a node + indexing into the dimensions to the
@@ -87,7 +88,7 @@ def is_expandable(arg: Any) -> bool:
     return isinstance(arg, CustomOp)
 
 
-def get_mma_dimensional_mapping(trace: CapturedTrace) -> dict[fx.Node, int]:
+def get_mma_dimensional_mapping(trace: CapturedTrace) -> dict[IndexSymbol, int]:
     """
     Given a trace, determine the MMA dimensional mapping for all the
     MMA operations in the graph. For example, if we have
@@ -103,7 +104,7 @@ def get_mma_dimensional_mapping(trace: CapturedTrace) -> dict[fx.Node, int]:
             return True
 
     mma_nodes = trace.walk(is_mma)
-    mapping: dict[fx.Node, int] = {}
+    mapping: dict[IndexSymbol, int] = {}
     for node in mma_nodes:
         custom: MMA = get_custom(node)
         m, n = custom.acc_type.symbolic_shape[-2:]
@@ -120,6 +121,50 @@ def get_mma_dimensional_mapping(trace: CapturedTrace) -> dict[fx.Node, int]:
     return mapping
 
 
+def set_node_indices(
+    trace: CapturedTrace,
+    constraints: Sequence[Constraint],
+    mma_index: dict[IndexSymbol, int],
+):
+    """
+    Set the indices of the nodes based on the user constraints. In certain
+    operators (like read, write), there is only a single index associated
+    with the node (the index to read from, the index to write to). But for
+    other operators like mma, each operand reads from a different index.
+
+    Rather than maintain operand specific indices for operators, we maintain
+    dimension specific indices for each operator. So for an mma operator that
+    has a signature of (MxK, NxK) -> MxN, we maintain only 3 mappings for
+    dimensions M, N and K, but allow each mapping to be piecewise conditioned
+    on the operand.
+    """
+
+    def compute_index(node: fx.Node) -> bool:
+        custom = get_custom(node)
+        custom.index = {}
+        for dim in custom.indexing_dims:
+            for constraint in constraints:
+                if (
+                    not isinstance(constraint, HardwareConstraint)
+                    and dim != constraint.dim
+                ):
+                    continue
+                if not custom.index:
+                    custom.index = {
+                        dim: IndexSequence(0, 1) for dim in custom.indexing_dims
+                    }
+                if isinstance(constraint, HardwareConstraint):
+                    if dim in mma_index and isinstance(custom, MMA):
+                        custom.index[dim] += constraint.apply(mma_index[dim])
+                elif dim == constraint.dim:
+                    custom.index[dim] += constraint.apply()
+        if custom.index:
+            setattr(custom.fx_node, "index", custom.index)
+        return False
+
+    trace.walk(compute_index)
+
+
 def expand_graph(
     trace: CapturedTrace,
     constraints_or_scaling: Sequence[Constraint] | dict[IndexSymbol, int],
@@ -132,6 +177,7 @@ def expand_graph(
         dim_scaling = constraints_or_scaling
     else:
         mma_index = get_mma_dimensional_mapping(trace)
+        set_node_indices(trace, constraints_or_scaling, mma_index)
         dim_scaling = get_dim_scaling(constraints_or_scaling, mma_index)
 
     # Start from the back and expand in the corresponding indexing dimensions of a node
@@ -142,6 +188,7 @@ def expand_graph(
     for node in (
         get_custom(fx_node) for fx_node in reversed(list(trace.get_root_graph().nodes))
     ):
+
         # Expansion begins at the leaf nodes
         if node.__class__ not in leaf_nodes:
             continue
@@ -276,7 +323,7 @@ def get_expanded_name(node: CustomOp, dims: dict[IndexSymbol, int]) -> str:
 
 
 def get_dim_scaling(
-    constraints: Sequence[Constraint], mma_indices: dict[IndexExpr, int]
+    constraints: Sequence[Constraint], mma_indices: dict[IndexSymbol, int]
 ) -> dict[IndexSymbol, int]:
     """Get the number of expansions for the dimensions based on the constraints."""
     dim_scaling: dict[IndexSymbol, int] = {}

--- a/shark_turbine/kernel/wave/indexing.py
+++ b/shark_turbine/kernel/wave/indexing.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import Optional, Any
+from ...support.logging import get_logger
+from .._support.indexing import IndexExpr, IndexSymbol
+import sympy
+
+logger = get_logger("turbine.wave.indexing")
+
+
+@dataclass
+class IndexSequence:
+    start: IndexExpr | int
+    size: IndexExpr | int
+    stride: Optional[IndexExpr | int] = 1
+
+    def __add__(self, other: Any) -> Any:
+        if isinstance(other, IndexSequence):
+            return IndexSequence(
+                self.start + other.start,
+                self.size * other.size,
+                self.stride * other.stride,
+            )
+        else:
+            raise NotImplementedError("IndexSequence addition not implemented!")
+
+    def subs(self, map: dict[IndexSymbol, int]):
+        start = self.start
+        if isinstance(self.start, IndexExpr):
+            start = self.start.subs(map)
+        size = self.size
+        if isinstance(self.size, IndexExpr):
+            size = self.size.subs(map)
+        stride = self.stride
+        if isinstance(self.stride, IndexExpr):
+            stride = self.stride.subs(map)
+        return IndexSequence(start, size, stride)
+
+    def __repr__(self):
+        if isinstance(self.size, sympy.Integer):
+            self.size = int(self.size)
+        if isinstance(self.size, int) and self.size <= 1:
+            return f"{self.start}"
+        return f"{self.start} : {self.size} : {self.stride}"

--- a/shark_turbine/kernel/wave/indexing.py
+++ b/shark_turbine/kernel/wave/indexing.py
@@ -13,26 +13,18 @@ class IndexSequence:
     size: IndexExpr | int
     stride: Optional[IndexExpr | int] = 1
 
-    def __add__(self, other: Any) -> Any:
-        if isinstance(other, IndexSequence):
-            return IndexSequence(
-                self.start + other.start,
-                self.size * other.size,
-                self.stride * other.stride,
-            )
-        else:
-            raise NotImplementedError("IndexSequence addition not implemented!")
+    def _subs(
+        self, value: int | IndexExpr, map: dict[IndexSymbol, int]
+    ) -> int | IndexExpr:
+        new_value = value
+        if isinstance(value, IndexExpr):
+            new_value = value.subs(map)
+        return new_value
 
     def subs(self, map: dict[IndexSymbol, int]):
-        start = self.start
-        if isinstance(self.start, IndexExpr):
-            start = self.start.subs(map)
-        size = self.size
-        if isinstance(self.size, IndexExpr):
-            size = self.size.subs(map)
-        stride = self.stride
-        if isinstance(self.stride, IndexExpr):
-            stride = self.stride.subs(map)
+        start = self._subs(self.start, map)
+        size = self._subs(self.size, map)
+        stride = self._subs(self.stride, map)
         return IndexSequence(start, size, stride)
 
     def __repr__(self):

--- a/tests/kernel/wave/constraints_test.py
+++ b/tests/kernel/wave/constraints_test.py
@@ -44,7 +44,7 @@ class ConstraintsTest(unittest.TestCase):
 
         assert constraints[0].iterations() == ceiling(M / BLOCK_M)
         assert constraints[1].iterations() == ceiling(N / BLOCK_N)
-        assert constraints[1].apply() == I * BLOCK_N
+        assert constraints[1].apply().start == I * BLOCK_N
 
         with pytest.raises(
             ValueError,

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
         # Expose user-constraints
         constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
         constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-        constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 2)]
+        constraints += [tkw.TilingConstraint(K, BLOCK_K)]
 
         constraints += [
             tkw.HardwareConstraint(threads_per_wave=64, waves_per_block=(1, 1, 1))


### PR DESCRIPTION
This primary purpose of this PR is to annotate nodes with their access patterns based on the workgroup, tiling and MMA constraints. This is accomplished prior to expansion and propagates through expansion to the expanded nodes.