### PR TITLE
Make CI lit verbose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run LIT tests
         if: ${{ !cancelled() }}
         run: |
-          lit lit_tests/
+          lit lit_tests/ -v
 
       - name: MyPy Type Checking
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Pass `-v` option to lit to enable verbose output so we can actually see what failed exactly.