### PR TITLE
Add strided and dynamic offset to memref type

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -95,7 +95,7 @@ def test_read():
         # CHECK: %[[C16_1:.+]] = arith.constant 16 : index
         # CHECK: %[[WG1_OFF:.+]] = arith.muli %[[WG_1]], %[[C16_1]]
         # CHECK: %[[IDX_Y:.+]] = arith.addi %[[WG1_OFF]], %[[T1_OFF]]
-        # CHECK: vector.load %[[DATA]][%[[IDX_X]], %[[IDX_Y]]] : memref<16x16xf16>, vector<16xf16>
+        # CHECK: vector.load %[[DATA]][%[[IDX_X]], %[[IDX_Y]]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xf16>
 
 
 @run

--- a/shark_turbine/kernel/compiler/utils.py
+++ b/shark_turbine/kernel/compiler/utils.py
@@ -1,0 +1,22 @@
+from typing import Optional
+from .._support.indexing import IndexSymbol, IndexingContext
+from math import prod
+
+
+def strides_from_symbolic_shape(
+    indexing_context: IndexingContext,
+    symbolic_shape: Optional[list[IndexSymbol]],
+) -> Optional[list[int]]:
+    """
+    Computes the stride from a given symbolic shape and indexing context,
+    assuming the innermost dimension is contiguous.
+    """
+    if symbolic_shape is None:
+        return None
+    static_shape = [indexing_context.get_static_value(sym) for sym in symbolic_shape]
+    if None in static_shape:
+        return None
+    strides = []
+    for i in range(1, len(static_shape)):
+        strides.append(prod(static_shape[-i:]))
+    return strides[::-1] + [1]

--- a/tests/kernel/compiler/utils_test.py
+++ b/tests/kernel/compiler/utils_test.py
@@ -1,0 +1,47 @@
+import logging
+import pytest
+import unittest
+from shark_turbine.kernel.lang import sym
+from shark_turbine.kernel._support.indexing import IndexSymbol, IndexingContext
+from shark_turbine.kernel.compiler.utils import strides_from_symbolic_shape
+
+
+class UtilsTest(unittest.TestCase):
+    def testStrideComputation(self):
+        symbolic_shape = [sym.M, sym.N, sym.K]
+        idxc = IndexingContext()
+        idxc.bind_constant(sym.M, 64)
+        idxc.bind_constant(sym.N, 128)
+        idxc.bind_constant(sym.K, 256)
+        idxc.finalize()
+        strides = strides_from_symbolic_shape(idxc, symbolic_shape)
+        assert strides == [128 * 256, 256, 1]
+
+    def testSingleStrideComputation(self):
+        symbolic_shape = [sym.M]
+        idxc = IndexingContext()
+        idxc.bind_constant(sym.M, 64)
+        idxc.finalize()
+        strides = strides_from_symbolic_shape(idxc, symbolic_shape)
+        assert strides == [1]
+
+    def testInvalidSymbolicShape(self):
+        symbolic_shape = None
+        idxc = IndexingContext()
+        idxc.finalize()
+        strides = strides_from_symbolic_shape(idxc, symbolic_shape)
+        assert strides is None
+
+    def testDynamicSymbolStrideComputation(self):
+        symbolic_shape = [sym.M, sym.N, sym.K]
+        idxc = IndexingContext()
+        idxc.bind_constant(sym.M, 64)
+        idxc.bind_constant(sym.K, 256)
+        idxc.finalize()
+        strides = strides_from_symbolic_shape(idxc, symbolic_shape)
+        assert strides is None
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
When the static shape information is available,
we use a strided memref type with a dynamic offset for integration with iree.