### PR TITLE
Switch code of conduct from OpenXLA to LF Projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,4 +17,4 @@ To get started with contributing, please take a look at the
 ## Community guidelines
 
 This project follows the
-[OpenXLA Code of Conduct](https://github.com/openxla/community/blob/main/CODE-OF-CONDUCT.md).
+[LF Projects code of conduct](https://lfprojects.org/policies/code-of-conduct/).


### PR DESCRIPTION
IREE was moved out of OpenXLA into the Linux Foundation (LF AI & Data): https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/ Therefore, switching the code of conduct to
https://lfprojects.org/policies/code-of-conduct/.