### PR TITLE
Add automatic promotion and hoisting of placeholders

### DIFF
--- a/shark_turbine/kernel/wave/promotion.py
+++ b/shark_turbine/kernel/wave/promotion.py
@@ -1,4 +1,6 @@
+from .._support.tracing import CapturedTrace
 from ...support.logging import get_logger
+from .._support.indexing import IndexingContext
 from ..ops.wave_ops import *
 from ..lang.global_symbols import *
 
@@ -38,3 +40,15 @@ def promote_node(node: Read | Write, address_space: IndexSymbol):
         )
         allocate_node.add_to_graph(node.graph)
         apply_promotion_pattern(node, allocate_node)
+
+
+def promote_placeholders(graph: CapturedTrace):
+    for node in graph.get_root_graph().nodes:
+        custom = get_custom(node)
+        if isinstance(custom, Read) or isinstance(custom, Write):
+            if not custom.type:
+                continue
+            idxc = IndexingContext.current()
+            address_space = custom.type.address_space.subs(idxc.subs)
+            if address_space == SHARED_ADDRESS_SPACE:
+                promote_node(custom, address_space)

--- a/shark_turbine/kernel/wave/wave.py
+++ b/shark_turbine/kernel/wave/wave.py
@@ -15,6 +15,8 @@ from .constraints import (
 )
 from .codegen import WaveEmitter
 from .expansion import expand_graph
+from .promotion import promote_placeholders
+from .hoisting import hoist_allocs
 from ..lang import Grid, IndexMapping
 from ..lang.global_symbols import *
 from ..ops import wave_ops
@@ -169,6 +171,10 @@ class LaunchableWave(Launchable):
 
         idxc = IndexingContext.current()
         idxc.finalize()
+
+        # Promote the placeholders to the appropriate address space.
+        promote_placeholders(graph)
+        hoist_allocs(graph)
 
         # Expansion
         expand_graph(graph, self.constraints)


### PR DESCRIPTION
This PR adds promotion to shared memory and hoisting of shared memory allocs to wave. If a placeholder is marked with its address space as SHARED_MEMORY, the compiler will introduce the appropriate promotion.