### PR TITLE
Refactor run and print_trace methods

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -6,6 +6,7 @@ import shark_turbine.kernel as tk
 import shark_turbine.kernel.lang as tkl
 import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.lang.global_symbols import *
+from shark_turbine.kernel.wave.utils import run_test
 import torch
 
 M = tkl.sym.M
@@ -41,15 +42,6 @@ def launch(func: Callable[[], None]) -> Callable[[], None]:
     return func
 
 
-def run(func: Callable[[], None]) -> Callable[[], None]:
-    """Run a function as part of the test suite."""
-    if __name__ == "__main__":
-        func()
-        # Print a separator between tests
-        print("-----")
-    return func
-
-
 def codegen_test_context():
     return tk.gen.TestLaunchContext(
         {
@@ -64,7 +56,7 @@ def codegen_test_context():
     )
 
 
-@run
+@run_test
 def test_read():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -102,7 +94,7 @@ def test_read():
         # CHECK: vector.load %[[DATA]][%[[IDX_X]], %[[IDX_Y]]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xf16>
 
 
-@run
+@run_test
 def test_read_mapped():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -149,7 +141,7 @@ def test_read_mapped():
         # CHECK: %[[RES:.+]] = vector.gather %[[DATA]][%[[IDX_X]], %[[IDX_Y]]] [%[[OFF]]], %[[MASK]], %[[PASSTHRU]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xindex>, vector<16xi1>, vector<16xf16> into vector<16xf16>
 
 
-@run
+@run_test
 def test_read_write():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -196,7 +188,7 @@ def test_read_write():
         # CHECK: vector.store %[[RES]], %[[OUT]][%[[IDX_X]], %[[IDX_Y]]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xf16>
 
 
-@run
+@run_test
 def test_read_write_mapping():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -251,7 +243,7 @@ def test_read_write_mapping():
         # CHECK: vector.scatter %[[OUT]][%[[IDX_Y]], %[[IDX_X]]] [%[[OFF]]], %[[MASK]], %[[RES]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xindex>, vector<16xi1>, vector<16xf16>
 
 
-@run
+@run_test
 def test_mma():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -346,7 +338,7 @@ def test_mma():
         # CHECK: vector.store %[[R24]], %[[R25]][%[[R28]], %[[R31]]] : memref<64x128xf32, strided<[128, 1], offset: ?>>, vector<4xf32>
 
 
-@run
+@run_test
 def test_gemm():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -471,7 +463,7 @@ def test_gemm():
         # CHECK-SAME:      vector<4xf32>
 
 
-@run
+@run_test
 def test_add_float():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -495,7 +487,7 @@ def test_add_float():
         # CHECK: arith.addf %[[SLICE]], %[[SLICE]] : vector<16xf16>
 
 
-@run
+@run_test
 def test_add_integer():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -1,39 +1,14 @@
 # RUN: python %s | FileCheck %s
 
 import logging
-from typing import Callable
 import unittest
 import shark_turbine.kernel as tk
 import shark_turbine.kernel.lang as tkl
 import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.wave.expansion import expand_graph
-from shark_turbine.kernel._support.tracing import CapturedTrace
 from shark_turbine.kernel._support.indexing import IndexingContext
-from shark_turbine.kernel.ops.wave_ops import get_custom
 from shark_turbine.kernel.lang.global_symbols import *
-
-
-def run(func: Callable[[], None]) -> Callable[[], None]:
-    """Run a function as part of the test suite."""
-    if __name__ == "__main__":
-        func()
-        # Print a separator between tests
-        print("-----")
-    return func
-
-
-def print_trace(trace: CapturedTrace):
-    """
-    Prints all subgraphs of a trace starting with the root graph.
-    The graphs are printed first in the torch printing format and
-    then using our custom node format.
-    """
-    # The root graph is at the back so we print the subgraphs in reverse order
-    for subgraph in reversed(list(trace.region_graph.subgraphs.values())):
-        print(subgraph)
-        for node in subgraph.nodes:
-            print(get_custom(node))
-
+from shark_turbine.kernel.wave.utils import run_test, print_trace
 
 # Input sizes
 M = tkl.sym.M
@@ -61,7 +36,7 @@ def read_write_same_size(
     tkw.write(a_reg, c, elements_per_thread=4)
 
 
-@run
+@run_test
 def test_read_write_equal_sizes():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -138,7 +113,7 @@ def read_write_different_dims(
     tkw.write(a_reg, c, elements_per_thread=4)
 
 
-@run
+@run_test
 def test_read_write():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -217,7 +192,7 @@ def gemm(
     tkw.write(repeat, c, elements_per_thread=4)
 
 
-@run
+@run_test
 def test_gemm():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
@@ -374,7 +349,7 @@ def test_gemm():
         # CHECK-NEXT: -----
 
 
-@run
+@run_test
 def test_gemm_reduction_expansion_only():
     # Note: This does not implement an actual gemm computation but reuses the
     # gemm kernel to test the expansion of the reduction subgraph.
@@ -537,7 +512,7 @@ def py_arithmetic_different_dims(
     tkw.write(a_reg, c, elements_per_thread=4)
 
 
-@run
+@run_test
 def py_arithmetic_different_dims():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]

--- a/lit_tests/kernel/wave/tracing.py
+++ b/lit_tests/kernel/wave/tracing.py
@@ -5,6 +5,7 @@ from shark_turbine.kernel._support.tracing import CapturedTrace
 import shark_turbine.kernel.lang as tkl
 import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.ops.wave_ops import get_custom, Read, Write
+from shark_turbine.kernel.wave.utils import run_test, print_trace
 
 M = tkl.sym.M
 N = tkl.sym.N
@@ -12,28 +13,7 @@ K = tkl.sym.K
 ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
 
 
-def run(func: Callable[[], None]) -> Callable[[], None]:
-    """Run a function as part of the test suite."""
-    if __name__ == "__main__":
-        func()
-
-    return func
-
-
-def print_trace(trace: CapturedTrace):
-    """
-    Prints all subgraphs of a trace starting with the root graph.
-    The graphs are printed first in the torch printing format and then using
-    our custom node format.
-    """
-    # The root graph is at the back so we print the subgraphs in reverse order
-    for subgraph in reversed(list(trace.region_graph.subgraphs.values())):
-        print(subgraph)
-        for node in subgraph.nodes:
-            print(get_custom(node))
-
-
-@run
+@run_test
 def test_trace_empty():
     @tkw.wave_trace_only()
     def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
@@ -50,7 +30,7 @@ def test_trace_empty():
     # CHECK-NEXT: output
 
 
-@run
+@run_test
 def test_trace_empty_then_add_nodes():
     """
     This tests the modification of a graph after the trace has been created.
@@ -83,7 +63,7 @@ def test_trace_empty_then_add_nodes():
     # CHECK-NEXT: output
 
 
-@run
+@run_test
 def test_trace_py_arithmetic():
     @tkw.wave_trace_only()
     def test(A: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
@@ -117,7 +97,7 @@ def test_trace_py_arithmetic():
     # CHECK-NEXT: output
 
 
-@run
+@run_test
 def test_trace_read():
     @tkw.wave_trace_only()
     def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
@@ -135,7 +115,7 @@ def test_trace_read():
     # CHECK-NEXT: output
 
 
-@run
+@run_test
 def test_trace_register():
     @tkw.wave_trace_only()
     def test(
@@ -156,7 +136,7 @@ def test_trace_register():
     # CHECK-NEXT: output
 
 
-@run
+@run_test
 def test_trace_write():
     @tkw.wave_trace_only()
     def test(
@@ -179,7 +159,7 @@ def test_trace_write():
     # CHECK-NEXT: output
 
 
-@run
+@run_test
 def test_trace_mma():
     @tkw.wave_trace_only()
     def test(
@@ -208,7 +188,7 @@ def test_trace_mma():
     # CHECK-NEXT: output
 
 
-@run
+@run_test
 def test_trace_gemm():
     @tkw.wave_trace_only()
     def gemm(


### PR DESCRIPTION
This PR moves the common run and print_trace
utilities to the utils file so they do not
need to duplicated in every test.