### PR TITLE
[TK] Some basic APIs for benchmarking

### DIFF
--- a/shark_turbine/kernel/wave/wave.py
+++ b/shark_turbine/kernel/wave/wave.py
@@ -25,7 +25,6 @@ from ..ops.wave_ops import Reduction, CustomOp, get_custom
 from .register_analysis import determine_register_shape
 from .._support.indexing import IndexingContext, IndexExpr
 import shark_turbine.kernel.lang as tkl
-from ...support.logging import get_logger
 from .._support.tracing import (
     CapturedTrace,
     CompiledContext,
@@ -42,9 +41,6 @@ import numpy
 bench.DTYPE_TO_ABI_TYPE[numpy.dtype(numpy.float16)] = "f16"
 
 __all__ = ["wave", "wave_trace_only"]
-
-
-logger = get_logger("turbine.wave")
 
 
 def wave(constraints: Optional[list[Constraint]] = None):
@@ -92,11 +88,11 @@ def _write_file(name, mode, data):
 def _print_bench_result(result, filename):
     import json
 
-    res = str(json.dumps(result, sort_keys=True, indent=4))
+    res = json.dumps(result, sort_keys=True, indent=4)
     if filename is not None:
         _write_file(filename, "w", res)
     else:
-        logger.info(res)
+        print(res)
 
 
 class LaunchableWave(Launchable):

--- a/shark_turbine/kernel/wave/wave.py
+++ b/shark_turbine/kernel/wave/wave.py
@@ -323,10 +323,7 @@ class LaunchableWave(Launchable):
                 if bench_repetitions is not None:
                     benchmark_flags["benchmark_repetitions"] = int(bench_repetitions)
 
-                inputs = [
-                    rt.asdevicearray(device, inp.cpu().contiguous())
-                    for inp in kernel_inputs
-                ]
+                inputs = [inp.numpy() for inp in kernel_inputs]
                 benchmark_results = benchmark_module(
                     mod,
                     entry_function=func_name,

--- a/shark_turbine/kernel/wave/wave.py
+++ b/shark_turbine/kernel/wave/wave.py
@@ -323,11 +323,15 @@ class LaunchableWave(Launchable):
                 if bench_repetitions is not None:
                     benchmark_flags["benchmark_repetitions"] = int(bench_repetitions)
 
+                inputs = [
+                    rt.asdevicearray(device, inp.cpu().contiguous())
+                    for inp in kernel_inputs
+                ]
                 benchmark_results = benchmark_module(
-                    vm_module,
+                    mod,
                     entry_function=func_name,
                     device=device,
-                    inputs=[arg0, arg1],
+                    inputs=inputs,
                     **benchmark_flags,
                 )
                 print(benchmark_results)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -41,14 +41,7 @@ def test_copy():
         res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
         tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
 
-    config = {
-        "backend": "rocm",
-        "device": "hip",
-        "target": "gfx942",
-        "benchmark": True,
-        "benchmark_batch_size": 100,
-        "benchmark_repetitions": 3,
-    }
+    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
 
     shape = (256, 128)
     a = torch.randn(shape, dtype=torch.float16)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -41,7 +41,14 @@ def test_copy():
         res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
         tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
 
-    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
+    config = {
+        "backend": "rocm",
+        "device": "hip",
+        "target": "gfx942",
+        "benchmark": True,
+        "benchmark_batch_size": 100,
+        "benchmark_repetitions": 3,
+    }
 
     shape = (256, 128)
     a = torch.randn(shape, dtype=torch.float16)


### PR DESCRIPTION
Example config
```python
    config = {
        "backend": "rocm",
        "device": "hip",
        "target": "gfx942",
        "benchmark": True,
        "benchmark_batch_size": 100,
        "benchmark_repetitions": 3,
        "benchmark_results_file": "out.json",
    }
```
Example output:
```
[
    [
        "BM_isolated_benchmark/process_time/real_time",
        "0.036 ms",
        "0.080 ms",
        "19313",
        "items_per_second=27.6075k/s"
    ],
    [
        "BM_isolated_benchmark/process_time/real_time",
        "0.036 ms",
        "0.081 ms",
        "19313",
        "items_per_second=27.4817k/s"
    ],
    [
        "BM_isolated_benchmark/process_time/real_time",
        "0.036 ms",
        "0.081 ms",
        "19313",
        "items_per_second=27.5867k/s"
    ],
    [
        "BM_isolated_benchmark/process_time/real_time_mean",
        "0.036 ms",
        "0.081 ms",
        "3",
        "items_per_second=27.5586k/s"
    ],
    [
        "BM_isolated_benchmark/process_time/real_time_median",
        "0.036 ms",
        "0.081 ms",
        "3",
```