### PR TITLE
[TKW] Implement various ops required for FA

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -476,8 +476,7 @@ def test_add_integer():
         # CHECK: arith.addi %[[SLICE]], %[[SLICE]] : vector<16xi32>
 
 
-@launch
-@pytest.mark.skip(reason="neg: Currently only stub implementation")
+@run_test
 def test_neg():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -491,13 +490,12 @@ def test_neg():
 
     @tkw.wave(constraints)
     def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
-        res = -a
+        a_reg = tkw.read(a, elements_per_thread=4)
+        res = -a_reg
         tkw.write(res, a, elements_per_thread=4)
 
     a = torch.randn(16, 16, dtype=torch.float16)
-    with pytest.raises(
-        NotImplementedError, match="neg: Currently only stub implementation"
-    ):
+    with codegen_test_context():
         test(a)
 
 
@@ -516,13 +514,12 @@ def test_sub():
 
     @tkw.wave(constraints)
     def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
-        res = a - a
+        a_reg = tkw.read(a, elements_per_thread=4)
+        res = a_reg - a_reg
         tkw.write(res, a, elements_per_thread=4)
 
     a = torch.randn(16, 16, dtype=torch.float16)
-    with pytest.raises(
-        NotImplementedError, match="sub: Currently only stub implementation"
-    ):
+    with codegen_test_context():
         test(a)
 
 

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -173,7 +173,7 @@ def get_custom(node: fx.Node) -> "CustomOp":
     return Unknown.from_fx_node(node)
 
 
-def has_same_custom_type(lhs_type: Memory, rhs_type: Memory):
+def has_same_custom_type(lhs_type: Memory, rhs_type: Memory) -> bool:
     same_shape = lhs_type.symbolic_shape == rhs_type.symbolic_shape
     same_dtype = lhs_type.dtype == rhs_type.dtype
     return same_shape and same_dtype

--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -363,6 +363,8 @@ class CustomOp(ABC):
 @define_py_op(operator.getitem)
 @define_py_op(operator.add)
 @define_py_op(operator.sub)
+@define_py_op(operator.mul)
+@define_py_op(operator.truediv)
 @dataclass
 class BinaryPyOp(CustomOp, ABC):
     """

--- a/shark_turbine/kernel/wave/codegen.py
+++ b/shark_turbine/kernel/wave/codegen.py
@@ -628,7 +628,7 @@ def handle_div(lhs: Value, rhs: Value) -> OpResult:
 def handle_unary_op(op):
     def decorator(unary_fn: Callable[[Value, Value], OpResult]):
         @handle_op(op)
-        def handle_generic_binary(emitter: WaveEmitter, node: fx.Node):
+        def handle_generic_unary(emitter: WaveEmitter, node: fx.Node):
             try:
                 (src,) = node.args
             except ValueError as e:


### PR DESCRIPTION
This PR introduces ops required to implement Flash Attention

1. Create new template to make adding unary/binary ops easier
2. Add symbolic type propagation for BinaryPyOp and UnaryPyOp (to work with mapping codegen)
3. Implemented elementwise ops needed for FA2. 