### PR TITLE
[TKW] Implement define interface op and tk.max

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -620,7 +620,7 @@ def test_unary_lowerings():
 
 
 @run_test
-def test_reduce():
+def test_reduce_sum():
     M = tkl.sym.M
     N = tkl.sym.N
     BLOCK_M = tkl.sym.BLOCK_M
@@ -693,6 +693,82 @@ def test_reduce():
         # CHECK: arith.addf {{.*}} : vector<1xf16>
         # CHECK: gpu.shuffle  xor %{{.+}}, %[[C32]], %{{.+}} : f32
         # CHECK: arith.addf {{.*}} : vector<1xf16>
+
+
+@run_test
+def test_reduce_max():
+    M = tkl.sym.M
+    N = tkl.sym.N
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    ELEMS_PER_THREAD = tkl.sym.ELEMS_PER_THREAD
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 1, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, ADDRESS_SPACE, tkl.f16],
+    ):
+        lhs = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+        rhs = tkw.read(b, elements_per_thread=ELEMS_PER_THREAD)
+        res = lhs * rhs
+        res = tkw.max(res, dim=N)
+        tkw.write(res, c, elements_per_thread=1)
+
+    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
+
+    shape = (256, 128)
+    a = torch.randn(shape, dtype=torch.float16)
+    b = torch.randn(shape, dtype=torch.float16)
+    c = torch.zeros((shape[0],), dtype=torch.float16)
+    with tk.gen.TestLaunchContext(
+        {
+            M: shape[0],
+            N: shape[1],
+            BLOCK_M: 1,
+            BLOCK_N: 128,
+            ELEMS_PER_THREAD: 2,
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+    ):
+        print(test(a, b, c).module_op)
+        # CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i32
+        # CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i32
+        # CHECK-DAG: %[[C4:.+]] = arith.constant 4 : i32
+        # CHECK-DAG: %[[C8:.+]] = arith.constant 8 : i32
+        # CHECK-DAG: %[[C16:.+]] = arith.constant 16 : i32
+        # CHECK-DAG: %[[C32:.+]] = arith.constant 32 : i32
+        # Elementwise
+        # CHECK: arith.mulf {{.*}} : vector<2xf16>
+        # Local Reduction
+        # CHECK: arith.maximumf {{.*}} : vector<1xf16>
+        # Global Reduction
+        # CHECK: gpu.shuffle  xor %{{.+}}, %[[C1]], %{{.+}} : f32
+        # CHECK: arith.maximumf {{.*}} : vector<1xf16>
+        # CHECK: gpu.shuffle  xor %{{.+}}, %[[C2]], %{{.+}} : f32
+        # CHECK: arith.maximumf {{.*}} : vector<1xf16>
+        # CHECK: gpu.shuffle  xor %{{.+}}, %[[C4]], %{{.+}} : f32
+        # CHECK: arith.maximumf {{.*}} : vector<1xf16>
+        # CHECK: gpu.shuffle  xor %{{.+}}, %[[C8]], %{{.+}} : f32
+        # CHECK: arith.maximumf {{.*}} : vector<1xf16>
+        # CHECK: gpu.shuffle  xor %{{.+}}, %[[C16]], %{{.+}} : f32
+        # CHECK: arith.maximumf {{.*}} : vector<1xf16>
+        # CHECK: gpu.shuffle  xor %{{.+}}, %[[C32]], %{{.+}} : f32
+        # CHECK: arith.maximumf {{.*}} : vector<1xf16>
 
 
 @run_test

--- a/shark_turbine/kernel/wave/codegen.py
+++ b/shark_turbine/kernel/wave/codegen.py
@@ -44,6 +44,7 @@ from ..ops.wave_ops import (
     read,
     reduction,
     exp2,
+    maximum,
     get_custom,
     get_result,
     allocate,
@@ -681,6 +682,24 @@ def handle_div(lhs: Value, rhs: Value) -> OpResult:
         result = arith_d.divui(lhs, rhs)
     else:
         raise ValidationError(f"Found unhandled operand type for div: {element_type}")
+    return result
+
+
+@handle_binary_op(maximum)
+def handle_maximum(lhs: Value, rhs: Value) -> OpResult:
+    element_type = get_type_or_element_type(lhs.type)
+    if _is_float_type(element_type):
+        result = arith_d.maximumf(lhs, rhs)
+    elif _is_integer_like_type(element_type) and (
+        element_type.is_signed() or element_type.is_signless()
+    ):
+        result = arith_d.maxsi(lhs, rhs)
+    elif _is_integer_like_type(element_type) and element_type.is_unsigned():
+        result = arith_d.maxui(lhs, rhs)
+    else:
+        raise ValidationError(
+            f"Found unhanlded operand type for maximum: {element_type}"
+        )
     return result
 
 

--- a/shark_turbine/kernel/wave/codegen.py
+++ b/shark_turbine/kernel/wave/codegen.py
@@ -698,7 +698,7 @@ def handle_maximum(lhs: Value, rhs: Value) -> OpResult:
         result = arith_d.maxui(lhs, rhs)
     else:
         raise ValidationError(
-            f"Found unhanlded operand type for maximum: {element_type}"
+            f"Found unhandled operand type for maximum: {element_type}"
         )
     return result
 

--- a/shark_turbine/kernel/wave/decompose_reduce_ops.py
+++ b/shark_turbine/kernel/wave/decompose_reduce_ops.py
@@ -6,14 +6,22 @@ from ..wave.constraints import (
 )
 from .._support.tracing import CapturedTrace
 from .._support.indexing import IndexingContext, IndexSequence, IndexSymbol, IndexExpr
-from ..ops.wave_ops import get_custom, Add, ReduceOp, ShuffleOp, CustomOp, ExtractSlice
+from ..ops.wave_ops import (
+    get_custom,
+    Add,
+    Maximum,
+    ReduceOp,
+    ShuffleOp,
+    CustomOp,
+    ExtractSlice,
+)
 
 from .utils import DCE
 import torch.fx as fx
 import math
 from typing import Callable
 
-TKW_COMBINER = {"sum": Add}
+TKW_COMBINER = {"sum": Add, "max": Maximum}
 
 
 def get_graph_node(custom: CustomOp, graph: fx.Graph):

--- a/shark_turbine/kernel/wave/register_analysis.py
+++ b/shark_turbine/kernel/wave/register_analysis.py
@@ -1,6 +1,7 @@
 from .._support.tracing import CapturedTrace
 from ...support.logging import get_logger
-from ..ops.wave_ops import *
+from ..ops.wave_ops import get_custom, NewRegister, CustomOp, MMA, Reduction
+import torch.fx as fx
 
 logger = get_logger("turbine.wave.register_analysis")
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -184,7 +184,7 @@ def test_transpose_write(shape):
 
 @require_e2e
 @pytest.mark.parametrize("shape", _test_shapes)
-def test_reduce(shape):
+def test_reduce_sum(shape):
     M = tkl.sym.M
     N = tkl.sym.N
     wave_size = 64
@@ -235,3 +235,58 @@ def test_reduce(shape):
     ):
         test(a, b, c)
         assert_allclose(ref, c, atol=0.1)
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", _test_shapes)
+def test_reduce_max(shape):
+    M = tkl.sym.M
+    N = tkl.sym.N
+    wave_size = 64
+    BLOCK_M = 1
+    BLOCK_N = N
+    ELEMS_PER_THREAD = BLOCK_N / wave_size
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 1, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, ADDRESS_SPACE, tkl.f16],
+    ):
+        lhs = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+        rhs = tkw.read(b, elements_per_thread=ELEMS_PER_THREAD)
+        res = lhs * rhs
+        res = tkw.max(res, dim=N)
+        tkw.write(res, c, elements_per_thread=1)
+
+    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
+
+    a = torch.randn(shape, dtype=torch.float16)
+    b = torch.randn(shape, dtype=torch.float16)
+    c = torch.zeros((shape[0],), dtype=torch.float16)
+    ref = torch.max((a * b), dim=-1)
+    with tk.gen.TestLaunchContext(
+        {
+            M: shape[0],
+            N: shape[1],
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+        run=True,
+        run_config=config,
+    ):
+        test(a, b, c)
+        assert_allclose(ref.values, c)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -234,4 +234,4 @@ def test_reduce(shape):
         run_config=config,
     ):
         test(a, b, c)
-        assert_allclose(ref, c, atol=0.15)
+        assert_allclose(ref, c, atol=0.1)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -234,4 +234,4 @@ def test_reduce(shape):
         run_config=config,
     ):
         test(a, b, c)
-        assert_allclose(ref, c, atol=0.1)
+        assert_allclose(ref, c, atol=0.15)


### PR DESCRIPTION
In this PR, we add 3 things:

    1. Define Interface Op
    2. Reduction max op
    3. elementwise maximum op

Define interface op is created to generate new subclass op that can
derive from base interface class. this is useful for custom TK ops that
has very similar properties such as "sum" and "max" S.T we can reuse
code as much as possible.