### PR TITLE
Add iree_ref for gemm functionality test

### DIFF
--- a/shark_turbine/kernel/wave/iree_utils.py
+++ b/shark_turbine/kernel/wave/iree_utils.py
@@ -1,0 +1,54 @@
+import torch
+from .utils import compile_and_invoke
+
+
+def get_mmt_asm(lhs_type: str, rhs_type: str, acc_type: str) -> str:
+    acc_dtype = acc_type.split("x")[-1]
+    matmul_function = (
+        f"func.func @mmt(%lhs: tensor<{lhs_type}>, %rhs: tensor<{rhs_type}>) -> tensor<{acc_type}> {{\n"
+        f"  %c0 = arith.constant 0.0 : {acc_dtype}\n"
+        f"  %init = tensor.empty() : tensor<{acc_type}>\n"
+        f"  %inital_result = linalg.fill ins(%c0 : {acc_dtype}) outs(%init : tensor<{acc_type}>) -> tensor<{acc_type}>\n"
+        f"  %result = linalg.matmul_transpose_b ins(%lhs, %rhs: tensor<{lhs_type}>, tensor<{rhs_type}>)\n"
+        f"             outs(%inital_result: tensor<{acc_type}>) -> tensor<{acc_type}>\n"
+        f"  return %result : tensor<{acc_type}>\n"
+        f"}}\n"
+    )
+    return matmul_function
+
+
+def dtype_str(dtype: torch.dtype) -> str:
+    if dtype == torch.float32:
+        return "f32"
+    elif dtype == torch.float16:
+        return "f16"
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+def get_type_str(shape: tuple[int], dtype: torch.dtype) -> str:
+    return "x".join([str(x) for x in shape] + [dtype_str(dtype)])
+
+
+def generate_iree_ref(
+    kernel_type: str,
+    kernel_inputs: list[torch.Tensor],
+    kernel_outputs: list[torch.Tensor],
+    config: dict[str, str],
+):
+    """
+    Generate a reference output for the given kernel type and arguments.
+    """
+
+    asm = None
+    if kernel_type == "mmt":
+        lhs_type = get_type_str(kernel_inputs[0].shape, kernel_inputs[0].dtype)
+        rhs_type = get_type_str(kernel_inputs[1].shape, kernel_inputs[1].dtype)
+        acc_type = get_type_str(kernel_outputs[0].shape, kernel_outputs[0].dtype)
+        asm = get_mmt_asm(lhs_type, rhs_type, acc_type)
+    else:
+        raise ValueError(f"Unknown kernel type: {kernel_type}")
+
+    compile_and_invoke(
+        asm, kernel_type, config, kernel_inputs, kernel_outputs, True, False
+    )

--- a/shark_turbine/kernel/wave/iree_utils.py
+++ b/shark_turbine/kernel/wave/iree_utils.py
@@ -1,29 +1,27 @@
 import torch
 from .utils import compile_and_invoke
+from ...support.conversions import TORCH_DTYPE_TO_MLIR_TYPE_ASM
 
 
 def get_mmt_asm(lhs_type: str, rhs_type: str, acc_type: str) -> str:
     acc_dtype = acc_type.split("x")[-1]
-    matmul_function = (
-        f"func.func @mmt(%lhs: tensor<{lhs_type}>, %rhs: tensor<{rhs_type}>) -> tensor<{acc_type}> {{\n"
-        f"  %c0 = arith.constant 0.0 : {acc_dtype}\n"
-        f"  %init = tensor.empty() : tensor<{acc_type}>\n"
-        f"  %inital_result = linalg.fill ins(%c0 : {acc_dtype}) outs(%init : tensor<{acc_type}>) -> tensor<{acc_type}>\n"
-        f"  %result = linalg.matmul_transpose_b ins(%lhs, %rhs: tensor<{lhs_type}>, tensor<{rhs_type}>)\n"
-        f"             outs(%inital_result: tensor<{acc_type}>) -> tensor<{acc_type}>\n"
-        f"  return %result : tensor<{acc_type}>\n"
-        f"}}\n"
-    )
+    matmul_function = f"""
+    func.func @mmt(%lhs: tensor<{lhs_type}>, %rhs: tensor<{rhs_type}>) -> tensor<{acc_type}> {{\n
+      %c0 = arith.constant 0.0 : {acc_dtype}\n
+      %init = tensor.empty() : tensor<{acc_type}>\n
+      %inital_result = linalg.fill ins(%c0 : {acc_dtype}) outs(%init : tensor<{acc_type}>) -> tensor<{acc_type}>\n
+      %result = linalg.matmul_transpose_b ins(%lhs, %rhs: tensor<{lhs_type}>, tensor<{rhs_type}>)\n
+                 outs(%inital_result: tensor<{acc_type}>) -> tensor<{acc_type}>\n
+      return %result : tensor<{acc_type}>\n
+    }}\n"""
     return matmul_function
 
 
 def dtype_str(dtype: torch.dtype) -> str:
-    if dtype == torch.float32:
-        return "f32"
-    elif dtype == torch.float16:
-        return "f16"
-    else:
+    dtype_str = TORCH_DTYPE_TO_MLIR_TYPE_ASM.get(dtype, None)
+    if dtype_str is None:
         raise ValueError(f"Unsupported dtype: {dtype}")
+    return dtype_str
 
 
 def get_type_str(shape: tuple[int], dtype: torch.dtype) -> str:

--- a/shark_turbine/kernel/wave/iree_utils.py
+++ b/shark_turbine/kernel/wave/iree_utils.py
@@ -6,14 +6,14 @@ from ...support.conversions import TORCH_DTYPE_TO_MLIR_TYPE_ASM
 def get_mmt_asm(lhs_type: str, rhs_type: str, acc_type: str) -> str:
     acc_dtype = acc_type.split("x")[-1]
     matmul_function = f"""
-    func.func @mmt(%lhs: tensor<{lhs_type}>, %rhs: tensor<{rhs_type}>) -> tensor<{acc_type}> {{\n
-      %c0 = arith.constant 0.0 : {acc_dtype}\n
-      %init = tensor.empty() : tensor<{acc_type}>\n
-      %inital_result = linalg.fill ins(%c0 : {acc_dtype}) outs(%init : tensor<{acc_type}>) -> tensor<{acc_type}>\n
-      %result = linalg.matmul_transpose_b ins(%lhs, %rhs: tensor<{lhs_type}>, tensor<{rhs_type}>)\n
-                 outs(%inital_result: tensor<{acc_type}>) -> tensor<{acc_type}>\n
-      return %result : tensor<{acc_type}>\n
-    }}\n"""
+    func.func @mmt(%lhs: tensor<{lhs_type}>, %rhs: tensor<{rhs_type}>) -> tensor<{acc_type}> {{
+      %c0 = arith.constant 0.0 : {acc_dtype}
+      %init = tensor.empty() : tensor<{acc_type}>
+      %inital_result = linalg.fill ins(%c0 : {acc_dtype}) outs(%init : tensor<{acc_type}>) -> tensor<{acc_type}>
+      %result = linalg.matmul_transpose_b ins(%lhs, %rhs: tensor<{lhs_type}>, tensor<{rhs_type}>)
+                 outs(%inital_result: tensor<{acc_type}>) -> tensor<{acc_type}>
+      return %result : tensor<{acc_type}>
+    }}"""
     return matmul_function
 
 

--- a/shark_turbine/kernel/wave/wave.py
+++ b/shark_turbine/kernel/wave/wave.py
@@ -17,7 +17,7 @@ from .codegen import WaveEmitter
 from .expansion import expand_graph
 from .promotion import promote_placeholders
 from .hoisting import hoist_allocs
-from .utils import canonicalize_module
+from .utils import canonicalize_module, compile_and_invoke
 from .minimize_global_loads import minimize_global_loads
 from .decompose_reduce_ops import decompose_reduce_ops
 from .barriers import add_shared_memory_barriers
@@ -35,16 +35,8 @@ from .._support.tracing import (
     KernelRegionGraph,
     Launchable,
 )
-from iree.compiler import compile_str
-import iree.runtime as rt
-import iree.runtime.benchmark as bench
 
 import sympy
-
-# TODO: Monkey-patching f16 support, need to fix in iree.
-import numpy
-
-bench.DTYPE_TO_ABI_TYPE[numpy.dtype(numpy.float16)] = "f16"
 
 __all__ = ["wave", "wave_trace_only"]
 
@@ -62,43 +54,6 @@ def wave_trace_only(constraints: Optional[list[Constraint]] = None):
         return wave._trace  # type: ignore
 
     return decorator
-
-
-def _invoke(vm_context, device, entry_function, inputs, outputs):
-    arg_list = rt.VmVariantList(len(inputs))
-    ret_list = rt.VmVariantList(len(outputs))
-
-    for input in inputs:
-        input_cpu = input.cpu().contiguous()
-        device_array = rt.asdevicearray(device, input_cpu)
-        arg_list.push_ref(device_array._buffer_view)
-
-    vm_context.invoke(entry_function, arg_list, ret_list)
-
-    for i, ret in enumerate(outputs):
-        device_buffer_view = rt.HalBufferView.__iree_vm_cast__(ret_list.get_as_ref(i))
-        device_array = rt.DeviceArray(device, device_buffer_view)
-
-        # TODO: Make to_host accept out array/buffer, so we can avoid extra data copy.
-        host_array = device_array.to_host()
-
-        # Convert to torch tensor without actually importing torch.
-        ret[:] = type(ret)(host_array)
-
-
-def _write_file(name, mode, data):
-    with open(name, mode) as file:
-        file.write(data)
-
-
-def _print_bench_result(result, filename):
-    import json
-
-    res = json.dumps(result, sort_keys=True, indent=4)
-    if filename is not None:
-        _write_file(filename, "w", res)
-    else:
-        print(res)
 
 
 class LaunchableWave(Launchable):
@@ -315,79 +270,19 @@ class LaunchableWave(Launchable):
                 if usage == kernel_codegen.KernelBufferUsage.OUTPUT:
                     kernel_outputs.append(arg)
 
-            # TODO: Have some default config.
             config = kwargs.get("run_config", None)
             if not config:
                 raise ValueError("no config provided")
 
-            backend = config["backend"]
-            device = config["device"]
-            flags = [
-                f"--iree-hal-target-backends={backend}",
-                "--iree-vm-bytecode-module-strip-source-map=true",
-                "--iree-opt-strip-assertions=true",
-                "--iree-vm-target-truncate-unsupported-floats",
-            ]
-
-            # TODO: More targets/backends support.
-            if backend == "rocm":
-                target = config["target"]
-                flags.append(f"--iree-rocm-target-chip={target}")
-
-            if config.get("print_ir_after_all", False):
-                flags.append("--mlir-print-ir-after-all")
-
-            if run_bench:
-                bench_batch_size = config.get("benchmark_batch_size", None)
-                bench_repetitions = config.get("benchmark_repetitions", None)
-                bench_file = config.get("benchmark_results_file", None)
-
-                benchmark_flags = {}
-
-                if bench_batch_size is not None:
-                    flags.append(
-                        f"--iree-hal-benchmark-dispatch-repeat-count={bench_batch_size}"
-                    )
-                    benchmark_flags["batch_size"] = int(bench_batch_size)
-
-                if bench_repetitions is not None:
-                    benchmark_flags["benchmark_repetitions"] = int(bench_repetitions)
-
-            res = compile_str(asm, target_backends=[backend], extra_args=flags)
-
-            dump_vmfb_file = config.get("dump_vmfb_file", None)
-            if dump_vmfb_file is not None:
-                _write_file(dump_vmfb_file, "wb", res)
-
-            rt_config = rt.Config(device)
-            device = rt_config.device
-            vm_instance = rt_config.vm_instance
-            mod = rt.VmModule.copy_buffer(vm_instance, res)
-
-            vm_modules = [
-                mod,
-                rt.create_hal_module(vm_instance, device),
-            ]
-            ctx = rt.SystemContext(
-                vm_modules=vm_modules,
-                config=rt_config,
+            compile_and_invoke(
+                asm,
+                "isolated_benchmark",
+                config,
+                kernel_inputs,
+                kernel_outputs,
+                run,
+                run_bench,
             )
-
-            func_name = "isolated_benchmark"
-            if run:
-                func = mod.lookup_function(func_name)
-                _invoke(ctx.vm_context, device, func, kernel_inputs, kernel_outputs)
-
-            if run_bench:
-                inputs = [inp.numpy() for inp in kernel_inputs]
-                benchmark_results = bench.benchmark_module(
-                    mod,
-                    entry_function=func_name,
-                    device=device,
-                    inputs=inputs,
-                    **benchmark_flags,
-                )
-                _print_bench_result(benchmark_results, bench_file)
 
         return mb
 

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -6,6 +6,7 @@ import shark_turbine.kernel as tk
 import shark_turbine.kernel.lang as tkl
 import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.lang.global_symbols import *
+from shark_turbine.kernel.wave.iree_utils import generate_iree_ref
 import os
 
 _run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
@@ -90,8 +91,9 @@ class Test(unittest.TestCase):
             b = torch.randn(10240, 1280, dtype=torch.float16)
             c = torch.zeros(2048, 10240, dtype=torch.float32)
             gemm(a, b, c)
-            d = torch.matmul(a, b.T).float()
-            torch.testing.assert_close(c, d, rtol=0.1, atol=0.1)
+            iree_ref = torch.zeros(2048, 10240, dtype=torch.float32)
+            generate_iree_ref("mmt", [a, b], [iree_ref], config)
+            assert torch.equal(c, iree_ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds utils to generate an iree reference
mmt kernel that can be compiled and run to
obtain a golden output for comparison. Compared
to the torch output, the advantage of this output
is that it can be matched exactly and makes for
an easier comparison target.