### PR TITLE
Adapt to API break where resolve_literal takes an InputInfo arg.

### DIFF
--- a/shark_turbine/aot/builtins/jittable.py
+++ b/shark_turbine/aot/builtins/jittable.py
@@ -26,6 +26,7 @@ from iree.compiler.extras.fx_importer import (
     GraphNodeImporter,
     FxImporter,
     FxImporterHooks,
+    InputInfo,
 )
 
 from ...support.ir_imports import (
@@ -77,7 +78,9 @@ class _Hooks(FxImporterHooks):
         # symbols we have done this to here.
         self.cloned_global_symbols: set[str] = set()
 
-    def resolve_literal(self, gni: GraphNodeImporter, literal: Any) -> Optional[Value]:
+    def resolve_literal(
+        self, gni: GraphNodeImporter, literal: Any, info: Optional[InputInfo] = None
+    ) -> Optional[Value]:
         module_builder = self.module_builder
         cloned_global_symbols = self.cloned_global_symbols
 

--- a/shark_turbine/aot/support/procedural/exported_program.py
+++ b/shark_turbine/aot/support/procedural/exported_program.py
@@ -241,7 +241,9 @@ class _Hooks(FxImporterHooks):
         ).result
         util_d.GlobalStoreOp(converted_value, materialized_global.symbol_name)
 
-    def resolve_literal(self, gni: GraphNodeImporter, literal: Any) -> Optional[Value]:
+    def resolve_literal(
+        self, gni: GraphNodeImporter, literal: Any, info: Optional[InputInfo] = None
+    ) -> Optional[Value]:
         # We support resolution of tracked reference types. Currently this
         # only includes Tensors. All others we let the importer do what it
         # is going to do.


### PR DESCRIPTION
In the upstream FxImporter, an `info` arg was added to resolve_literal. Adding it to the hooks here (without use) so that iree-turbine is forward/backward compatible with respect to this change.

See https://github.com/llvm/torch-mlir/pull/3688