### PR TITLE
Use `assert_allclose` in gemm test

### DIFF
--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -8,6 +8,7 @@ import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.lang.global_symbols import *
 from shark_turbine.kernel.wave.iree_utils import generate_iree_ref
 import os
+from numpy.testing import assert_allclose
 
 _run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
 
@@ -93,7 +94,7 @@ class Test(unittest.TestCase):
             gemm(a, b, c)
             iree_ref = torch.zeros(2048, 10240, dtype=torch.float32)
             generate_iree_ref("mmt", [a, b], [iree_ref], config)
-            assert torch.equal(c, iree_ref)
+            assert_allclose(c.numpy(), iree_ref.numpy())
 
 
 if __name__ == "__main__":

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -8,7 +8,7 @@ import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.lang.global_symbols import *
 from shark_turbine.kernel.wave.iree_utils import generate_iree_ref
 import os
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 
 _run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
 
@@ -94,7 +94,7 @@ class Test(unittest.TestCase):
             gemm(a, b, c)
             iree_ref = torch.zeros(2048, 10240, dtype=torch.float32)
             generate_iree_ref("mmt", [a, b], [iree_ref], config)
-            assert_allclose(c, iree_ref)
+            assert_close(c, iree_ref)
 
 
 if __name__ == "__main__":

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -8,7 +8,7 @@ import shark_turbine.kernel.wave as tkw
 from shark_turbine.kernel.lang.global_symbols import *
 from shark_turbine.kernel.wave.iree_utils import generate_iree_ref
 import os
-from numpy.testing import assert_allclose
+from torch.testing import assert_allclose
 
 _run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
 
@@ -94,7 +94,7 @@ class Test(unittest.TestCase):
             gemm(a, b, c)
             iree_ref = torch.zeros(2048, 10240, dtype=torch.float32)
             generate_iree_ref("mmt", [a, b], [iree_ref], config)
-            assert_allclose(c.numpy(), iree_ref.numpy())
+            assert_allclose(c, iree_ref)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`assert_allclose` will actually show you how many elements mismatched and the relative/absolute difference.