### PR TITLE
Fix computation of iter_args and captured_vars

### DIFF
--- a/shark_turbine/kernel/ops/wave_ops.py
+++ b/shark_turbine/kernel/ops/wave_ops.py
@@ -839,30 +839,23 @@ class Reduction(CustomOp):
         return expand_dims
 
     def iter_args(self, graph: fx.Graph) -> list[fx.Node]:
-        """
-        The first N placeholders in the subgraph are the iter args, where
-        the total number of placeholders in the subgraph is N + M, where M
-        is the number of implicit captures.
-        """
         iter_args = []
         for nested_node in graph.nodes:
             custom = get_custom(nested_node)
-            if isinstance(custom, Placeholder):
+            if isinstance(custom, IterArg):
                 iter_args.append(nested_node)
-        return iter_args[: -len(self.implicit_captures)]
+        return iter_args
 
     def captured_vars(self, graph: fx.Graph) -> list[fx.Node]:
         """
-        The last M placeholders in the subgraph are the captured vars, where
-        the total number of placeholders in the subgraph is N + M, where N
-        is the number of iter args.
+        Nodes that are placeholders and are not iter args are captured vars.
         """
         captured_vars = []
         for nested_node in graph.nodes:
             custom = get_custom(nested_node)
-            if isinstance(custom, Placeholder):
+            if isinstance(custom, Placeholder) and not isinstance(custom, IterArg):
                 captured_vars.append(nested_node)
-        return captured_vars[-len(self.implicit_captures) :]
+        return captured_vars
 
     @property
     def type(self) -> list[Memory | Register]:


### PR DESCRIPTION
Previously, the computation of iter_args and
captured_vars was based on ordering which was brittle. We modify it to use the type information of the nodes.