### PR TITLE
Pin torch version until deprecated functionality is fixed

### DIFF
--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/test/cpu
-torch>=2.3.0, <2.5.0
+torch>=2.3.0, <2.6.0
 torchaudio
 torchvision

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/test/cpu
-torch>=2.3.0, <2.6.0
+torch>=2.3.0, <2.5.0
 torchaudio
 torchvision

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/test/cpu
-torch>=2.3.0
+torch>=2.3.0, <2.5.0
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/nightly/rocm6.0
-torch>=2.3.0
+torch>=2.3.0, <2.5.0
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/nightly/rocm6.0
-torch>=2.3.0, <2.6.0
+torch>=2.3.0, <2.5.0
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/nightly/rocm6.0
-torch>=2.3.0, <2.5.0
+torch>=2.3.0, <2.6.0
 torchaudio
 torchvision


### PR DESCRIPTION
Recent torch 2.5 versions failing with `ImportError: cannot import name 'dynamic_dim' from 'torch.export'`, pin torch version `<2.5.0` for now, until proper fix is ready https://github.com/iree-org/iree-turbine/pull/145