### PR TITLE
Revert rocm-requirements.txt

### DIFF
--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/nightly/rocm6.0
-torch>=2.3.0, <2.5.0
+torch>=2.3.0
 torchaudio
 torchvision


### PR DESCRIPTION
Revert `pytorch-rocm-requirements.txt` as they doesn't provide 2.4 version.

Version which works for me locally is `2.5.0.dev20240802+rocm6.0`.