### PR TITLE
[TKW] Add test option to dump generated gemm mlir

### DIFF
--- a/tests/kernel/wave/.gitignore
+++ b/tests/kernel/wave/.gitignore
@@ -1,0 +1,2 @@
+wave_gemm_*.mlir
+

--- a/tests/kernel/wave/.gitignore
+++ b/tests/kernel/wave/.gitignore
@@ -1,2 +1,1 @@
 wave_gemm_*.mlir
-


### PR DESCRIPTION
This is a QOL developer option to easily inspect the generated code. Enabled with `WAVE_DUMP_MLIR=1`, the generated gemms get saved to the test dir.