### PR TITLE
Set `fail-fast: false`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: "Unit Tests and Type Checking"
     strategy:
+      fail-fast: false
       matrix:
         version: [3.11]
         os: [ubuntu-latest, nodai-amdgpu-mi300-x86-64]

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: "Unit Tests and Type Checking"
     strategy:
+      fail-fast: false
       matrix:
         version: [3.11]
         os: [ubuntu-latest, nodai-amdgpu-mi300-x86-64]

--- a/.github/workflows/test_build_release.yml
+++ b/.github/workflows/test_build_release.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: "Test Build Release Process"
     strategy:
+      fail-fast: false
       matrix:
         version: [3.11]
         os: [ubuntu-latest]


### PR DESCRIPTION
Our tests are flaky, `fail-fast: false` won't allow failing builds abort other.