### PR TITLE
Add ability to dump intermediates

### DIFF
--- a/shark_turbine/kernel/wave/utils.py
+++ b/shark_turbine/kernel/wave/utils.py
@@ -334,6 +334,9 @@ def compile_and_invoke(
     if config.get("print_ir_after_all", False):
         flags.append("--mlir-print-ir-after-all")
 
+    if config.get("dump_intermediates", False):
+        flags.append("--iree-hal-dump-executable-intermediates-to=tmp/intermediates")
+
     if run_bench:
         bench_batch_size = config.get("benchmark_batch_size", None)
         bench_repetitions = config.get("benchmark_repetitions", None)

--- a/shark_turbine/kernel/wave/utils.py
+++ b/shark_turbine/kernel/wave/utils.py
@@ -334,8 +334,11 @@ def compile_and_invoke(
     if config.get("print_ir_after_all", False):
         flags.append("--mlir-print-ir-after-all")
 
-    if config.get("dump_intermediates", False):
-        flags.append("--iree-hal-dump-executable-intermediates-to=tmp/intermediates")
+    if "dump_intermediates" in config:
+        intermediates_path = config.get("dump_intermediates")
+        flags.append(
+            f"--iree-hal-dump-executable-intermediates-to={intermediates_path}"
+        )
 
     if run_bench:
         bench_batch_size = config.get("benchmark_batch_size", None)


### PR DESCRIPTION
This PR adds a flag to dump intermediates which include .ll and .s files to see what instructions were
generated.