### PR TITLE
[TKW] Make shared mem read/writes using non masked ops

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -494,6 +494,17 @@ class CustomOp(ABC):
         """
         pass
 
+    def align_index(self, constraints: list["Constraint"]) -> None:
+        """
+        Align index to WG/Tile sizes.
+
+        Some ops require their index sizes to be aligned to workgroup/tile sizes.
+        They should do it in this method.
+
+        Default implementation does nothing.
+        """
+        pass
+
 
 @define_py_op(operator.add)
 @define_py_op(operator.sub)
@@ -833,6 +844,12 @@ class MMA(CustomOp):
         custom_str += f"acc={self.acc} (index = {self.acc_index}))"
         return custom_str
 
+    def align_index(self, constraints: list["Constraint"]) -> None:
+        # Local import to break circular dep.
+        from ..wave.utils import align_index_vars
+
+        self.index = align_index_vars(self.index, constraints)
+
 
 @define_op("read")
 @dataclass
@@ -865,6 +882,13 @@ class Read(CustomOp):
     @write_dependency.setter
     def write_dependency(self, value: fx.Node):
         self.update_arg(len(self.fx_node.args) - 1, value)
+
+    def align_index(self, constraints: list["Constraint"]) -> None:
+        # Local import to break circular dep.
+        from ..wave.utils import align_index_vars, is_shared_mem_access
+
+        if is_shared_mem_access(self):
+            self.index = align_index_vars(self.index, constraints)
 
 
 @define_op("reduction")
@@ -1014,6 +1038,13 @@ class Write(CustomOp):
     def register_index(self) -> dict[IndexSymbol, IndexSequence]:
         custom = get_custom(self.register_)
         return custom.index
+
+    def align_index(self, constraints: list["Constraint"]) -> None:
+        # Local import to break circular dep.
+        from ..wave.utils import align_index_vars, is_shared_mem_access
+
+        if is_shared_mem_access(self):
+            self.index = align_index_vars(self.index, constraints)
 
 
 @define_py_op(operator.getitem)

--- a/iree/turbine/kernel/wave/minimize_global_loads.py
+++ b/iree/turbine/kernel/wave/minimize_global_loads.py
@@ -14,7 +14,7 @@ from .._support.tracing import CapturedTrace
 from .._support.indexing import IndexingContext, IndexSequence, IndexSymbol, IndexExpr
 from ..ops.wave_ops import Read, Write, get_custom
 from ..lang.global_symbols import *
-from .utils import delinearize_index, DCE, subs_idxc
+from .utils import delinearize_index, DCE, subs_idxc, ceildiv
 from math import prod
 import torch.fx as fx
 from collections import defaultdict
@@ -97,7 +97,9 @@ def identify_optimizable_loads(
             continue
 
         total_number_of_elements = prod(materialized_shape)
-        expected_number_of_loads = total_number_of_elements // max_elements_per_load
+        expected_number_of_loads = ceildiv(
+            total_number_of_elements, max_elements_per_load
+        )
         actual_number_of_loads = len(
             [x for x in global_read_nodes if get_custom(x).memory == custom.memory]
         )

--- a/iree/turbine/kernel/wave/shared_memory_indexing.py
+++ b/iree/turbine/kernel/wave/shared_memory_indexing.py
@@ -20,13 +20,12 @@ def apply_shared_memory_indexing_corrections(
     Global indexing is an indexing that arises from Workgroup constraints
     and Tiling constraints.
     """
-    tiling_constraints = [c for c in constraints if isinstance(c, TilingConstraint)]
 
     def is_shared_memory_read_or_write(node: fx.Node):
         custom = get_custom(node)
         if isinstance(custom, (Read, Write)):
             if custom.memory_type.address_space == SHARED_ADDRESS_SPACE:
-                custom.index = remove_global_indexing(custom.index, tiling_constraints)
+                custom.index = remove_global_indexing(custom.index, constraints)
         return False
 
     trace.walk(is_shared_memory_read_or_write)

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -271,9 +271,18 @@ def remove_global_indexing(
     """
     tiling_constraints = [c for c in constraints if isinstance(c, TilingConstraint)]
     workgroup_ids = [WORKGROUP_0, WORKGROUP_1, WORKGROUP_2]
-    new_index = {key: index[key].subs({w: 0 for w in workgroup_ids}) for key in index}
+    subs = {w: 0 for w in workgroup_ids}
+
+    key_subs = {
+        c.dim: (c.count * c.tile_size)
+        for c in constraints
+        if isinstance(c, (TilingConstraint, WorkgroupConstraint))
+        and subs_idxc(c.dim) != subs_idxc(c.count * c.tile_size)
+    }
+
+    new_index = {safe_subs(key, key_subs): safe_subs(index[key], subs) for key in index}
     for key in new_index:
-        for constraint in tilingConstraints:
+        for constraint in tiling_constraints:
             new_index[key] = new_index[key].subs({constraint.induction_var: 0})
     return new_index
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -280,6 +280,10 @@ def remove_global_indexing(
     return new_index
 
 
+def is_shared_mem_access(custom: "CustomOp") -> bool:
+    return custom.memory_type.address_space == SHARED_ADDRESS_SPACE
+
+
 def align_index_vars(
     index: dict[IndexSymbol, IndexSequence], constraints: list[Constraint]
 ) -> dict[IndexSymbol, IndexSequence]:

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -262,13 +262,14 @@ def get_hardware_vector_map(constraints: list[Constraint]) -> dict[IndexSymbol, 
 
 
 def remove_global_indexing(
-    index: dict[IndexSymbol, IndexSequence], tilingConstraints: list[TilingConstraint]
+    index: dict[IndexSymbol, IndexSequence], constraints: list[Constraint]
 ) -> dict[IndexSymbol, IndexSequence]:
     """
     This function takes the index sequence for a global read and removes all
     workgroup and induction level indexing. This is necessary for writes to shared memory
     that operate on promoted memory.
     """
+    tiling_constraints = [c for c in constraints if isinstance(c, TilingConstraint)]
     workgroup_ids = [WORKGROUP_0, WORKGROUP_1, WORKGROUP_2]
     new_index = {key: index[key].subs({w: 0 for w in workgroup_ids}) for key in index}
     for key in new_index:

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -682,3 +682,7 @@ def replace_uses_in(users: dict[fx.Node, list[CustomOp]], old: CustomOp, new: fx
         for i, arg in enumerate(user.fx_node.args):
             if arg == old.fx_node:
                 user.update_arg(i, new)
+
+
+def ceildiv(a: int, b: int) -> int:
+    return -(a // -b)

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -244,7 +244,7 @@ class LaunchableWave(Launchable):
 
         # Align sizes to WG/Tile sizes
         # This pass changes indexing keys, which can interfere with other passes,
-        # so it should be called clese to the end of pipeline.
+        # so it should be called close to the end of pipeline.
         align_index_sizes(graph, self.constraints)
 
         # Decompose reduce Ops.

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -38,7 +38,10 @@ from ..lang.global_symbols import *
 from ..ops import wave_ops
 from ..ops.wave_ops import Reduction, CustomOp, get_custom
 from .index_sequence_analysis import partition_strided_operators
-from .shared_memory_indexing import apply_shared_memory_indexing_corrections
+from .shared_memory_indexing import (
+    apply_shared_memory_indexing_corrections,
+    align_index_sizes,
+)
 from .thread_shape_analysis import determine_thread_shapes
 from .scheduling.schedule import schedule_graph
 from .._support.indexing import IndexingContext, IndexExpr
@@ -238,6 +241,9 @@ class LaunchableWave(Launchable):
 
         # Analyze Thread Shapes per Op.
         determine_thread_shapes(graph)
+
+        # Align sizes to WG/Tile sizes
+        align_index_sizes(graph, self.constraints)
 
         # Decompose reduce Ops.
         decompose_reduce_ops(graph, self.constraints, idxc.subs)

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -243,6 +243,8 @@ class LaunchableWave(Launchable):
         determine_thread_shapes(graph)
 
         # Align sizes to WG/Tile sizes
+        # This pass changes indexing keys, which can interfere with other passes,
+        # so it should be called clese to the end of pipeline.
         align_index_sizes(graph, self.constraints)
 
         # Decompose reduce Ops.

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -276,6 +276,48 @@ def test_read_write_masked():
 
 
 @run_test
+def test_read_write_masked_shared():
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 4, N: 4}
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f16],
+    ):
+        res = tkw.read(a, elements_per_thread=4)
+        tkw.write(res, b, elements_per_thread=4)
+
+    with tk.gen.TestLaunchContext(
+        {
+            M: 1,
+            N: 3,
+            BLOCK_M: 4,
+            BLOCK_N: 4,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+    ):
+        a = torch.randn(4, 4, dtype=torch.float16)
+        b = torch.zeros(4, 4, dtype=torch.float16)
+        print(test(a, b).module_op)
+
+        # Check shared mem load stores are non masked
+        # CHECK:            %{{.*}} = vector.maskedload {{.*}} : memref<1x3xf16, strided<[3, 1], offset: ?>>, vector<4xi1>, vector<4xf16> into vector<4xf16>
+        # CHECK:            vector.store {{.*}} : memref<4x8xf16, #gpu.address_space<workgroup>>, vector<4xf16>
+        # CHECK:            %{{.*}} = vector.load {{.*}} : memref<4x8xf16, #gpu.address_space<workgroup>>, vector<4xf16>
+        # CHECK:            vector.maskedstore {{.*}} : memref<1x3xf16, strided<[3, 1], offset: ?>>, vector<4xi1>, vector<4xf16>
+
+
+@run_test
 def test_read_write_mapping():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(


### PR DESCRIPTION
Add a pass which adjusts shared mem reads/writes and MMA indices to never had to partial accesses. This is need to remove masking ops on shared mem.

Also, update `minimize_global_loads.py` to use ceildiv instead if floor div in case of unaligned sizes.