### PR TITLE
WIP Add in-place variant of transfer_to_logical_device

### DIFF
--- a/iree/turbine/support/ir_imports.py
+++ b/iree/turbine/support/ir_imports.py
@@ -10,11 +10,13 @@
 from iree.compiler.ir import (
     AsmState,
     Attribute,
+    ArrayAttr,
     Block,
     BlockArgument,
     Context,
     DenseElementsAttr,
     DenseResourceElementsAttr,
+    DictAttr,
     FlatSymbolRefAttr,
     FloatAttr,
     FunctionType,


### PR DESCRIPTION
The purpose of this is to insert IREE ABI affinity attributes for function arguments.
iree.flow.transfer is not sufficient for cases of in-place updates of function arguments.

An alternative approach is to set the attribute of a Torch FX graph function argument. Then during/after conversion to MLIR to set the corresponding attribute on the MLIR function.