### PR TITLE
Move index setting outside of expansion

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -500,6 +500,16 @@ class CustomOp(ABC):
 
     @property
     def expanded_dims(self) -> dict[IndexSymbol, int]:
+        """
+        During expansion each node is expanded along its indexing dimensions.
+        The expanded_dims property stores the dimensions along which the node
+        has been expanded as well as the scaling along that dimension.
+
+        For example, a node with indexing dimensions [M, N] with
+        dimensional scaling {M: 2, N: 2}, will be expanded to 4 nodes,
+        with each expanded node mapping to the following expanded_dims
+        {M: 0, N: 0}, {M: 0, N: 1}, {M: 1, N: 0}, {M: 1, N: 1}.
+        """
         if hasattr(self.fx_node, "expanded_dims"):
             return self.fx_node.expanded_dims
         return None

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -498,6 +498,18 @@ class CustomOp(ABC):
             raise ValueError("Scheduling parameters must be a dict")
         self.fx_node.scheduling_parameters = value
 
+    @property
+    def expanded_dims(self) -> dict[IndexSymbol, int]:
+        if hasattr(self.fx_node, "expanded_dims"):
+            return self.fx_node.expanded_dims
+        return None
+
+    @expanded_dims.setter
+    def expanded_dims(self, value: dict[IndexSymbol, int]):
+        if not isinstance(value, dict):
+            raise ValueError("Expanded dims must be a dict")
+        self.fx_node.expanded_dims = value
+
     def post_expansion(self, constraints: list["Constraint"]) -> None:
         """
         Hook for post-expansion operations. This is called after the arguments
@@ -1091,7 +1103,11 @@ class GetResult(CustomOp):
         custom = get_custom(self.value)
         if custom.index is None:
             return None
-        assert isinstance(custom.index, list) and self.res_idx < len(custom.index)
+        if not isinstance(custom, Reduction):
+            return custom.index
+        assert isinstance(custom.index, list) and self.res_idx < len(
+            custom.indexing_dims
+        )
         return custom.index[self.res_idx]
 
     @index.setter

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -37,7 +37,11 @@ from ..lang import Grid, IndexMapping
 from ..lang.global_symbols import *
 from ..ops import wave_ops
 from ..ops.wave_ops import Reduction, CustomOp, get_custom
-from .index_sequence_analysis import partition_strided_operators
+from .index_sequence_analysis import (
+    partition_strided_operators,
+    set_node_indices,
+    set_post_expansion_indices,
+)
 from .shared_memory_indexing import (
     apply_shared_memory_indexing_corrections,
     align_index_sizes,
@@ -224,8 +228,14 @@ class LaunchableWave(Launchable):
         promote_placeholders(graph, self.constraints)
         hoist_allocs(graph)
 
+        # Set indices.
+        set_node_indices(graph, self.constraints)
+
         # Expansion
         expand_graph(graph, self.constraints)
+
+        # Set post expansion indices.
+        set_post_expansion_indices(graph, self.constraints)
 
         # Clean up chains of GetResults
         remove_chained_getresult(graph)

--- a/lit_tests/kernel/wave/barriers.py
+++ b/lit_tests/kernel/wave/barriers.py
@@ -6,6 +6,10 @@ import unittest
 import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.wave.index_sequence_analysis import (
+    set_node_indices,
+    set_post_expansion_indices,
+)
 from iree.turbine.kernel.wave.promotion import promote_node, promote_placeholders
 from iree.turbine.kernel.wave.barriers import add_shared_memory_barriers
 from iree.turbine.kernel.wave.hoisting import hoist_allocs
@@ -83,7 +87,9 @@ def test_read_write_equal_sizes():
         read_node = get_read_nodes(graph)[0]
         IndexingContext.current().finalize()
         promote_node(read_node, SHARED_ADDRESS_SPACE, constraints)
+        set_node_indices(trace, constraints)
         expand_graph(trace, constraints)
+        set_post_expansion_indices(trace, constraints)
         tweak_index(graph)
         add_shared_memory_barriers(trace)
         print_trace(trace, False)
@@ -169,7 +175,9 @@ def test_gemm():
         for read_node in read_nodes:
             promote_node(read_node, SHARED_ADDRESS_SPACE, constraints)
         hoist_allocs(trace)
+        set_node_indices(trace, constraints)
         expand_graph(trace, constraints)
+        set_post_expansion_indices(trace, constraints)
         tweak_index(graph)
         add_shared_memory_barriers(trace)
         print_trace(trace, False)

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -6,6 +6,10 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.wave.expansion import expand_graph
+from iree.turbine.kernel.wave.index_sequence_analysis import (
+    set_node_indices,
+    set_post_expansion_indices,
+)
 from iree.turbine.kernel._support.indexing import IndexingContext
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel.wave.utils import run_test, print_trace
@@ -62,7 +66,9 @@ def test_read_write_equal_sizes():
     ):
         graph = read_write_same_size()
         IndexingContext.current().finalize()
+        set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
         print_trace(graph)
         # CHECK: %a
         # CHECK-NEXT: %c
@@ -141,7 +147,9 @@ def test_read_write():
     ):
         graph = read_write_different_dims()
         IndexingContext.current().finalize()
+        set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
         print_trace(graph)
         # CHECK: %a
         # CHECK-NEXT: %c
@@ -216,7 +224,9 @@ def test_gemm():
     ):
         graph = gemm()
         IndexingContext.current().finalize()
+        set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
         print_trace(graph)
         # Root graph:
         # CHECK: %a
@@ -400,7 +410,9 @@ def test_batched_gemm():
     ):
         graph = batched_gemm()
         IndexingContext.current().finalize()
+        set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
         print_trace(graph)
         # Root graph:
         # CHECK: %a
@@ -559,7 +571,9 @@ def test_gemm_reduction_expansion_only():
     ):
         graph = gemm()
         IndexingContext.current().finalize()
+        set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
         print_trace(graph)
         # Root graph:
         # CHECK: %a
@@ -660,7 +674,9 @@ def py_arithmetic_different_dims():
     ):
         graph = py_arithmetic_different_dims()
         IndexingContext.current().finalize()
+        set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
         print_trace(graph)
         # CHECK: %a
         # CHECK-NEXT: %c

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -19,6 +19,8 @@ from iree.turbine.kernel.wave.shared_memory_indexing import (
 )
 from iree.turbine.kernel.wave.index_sequence_analysis import (
     partition_strided_operators,
+    set_node_indices,
+    set_post_expansion_indices,
 )
 
 
@@ -84,7 +86,9 @@ def test_gemm():
         IndexingContext.current().finalize()
         promote_placeholders(trace, constraints)
         hoist_allocs(trace)
+        set_node_indices(trace, constraints)
         expand_graph(trace, constraints)
+        set_post_expansion_indices(trace, constraints)
         minimize_global_loads(trace, constraints)
         apply_shared_memory_indexing_corrections(trace, constraints)
         partition_strided_operators(trace, constraints)

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -20,6 +20,10 @@ from iree.turbine.kernel.wave.visualization import visualize_graph
 from iree.turbine.kernel.wave.shared_memory_indexing import (
     apply_shared_memory_indexing_corrections,
 )
+from iree.turbine.kernel.wave.index_sequence_analysis import (
+    set_node_indices,
+    set_post_expansion_indices,
+)
 
 
 # Input sizes
@@ -85,7 +89,9 @@ def test_gemm():
         IndexingContext.current().finalize()
         promote_placeholders(trace, constraints)
         hoist_allocs(trace)
+        set_node_indices(trace, constraints)
         expand_graph(trace, constraints)
+        set_post_expansion_indices(trace, constraints)
         if visualize:
             visualize_graph(trace.get_subgraph("region_0"), "before.png")
         minimize_global_loads(trace, constraints)

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -18,6 +18,10 @@ from iree.turbine.kernel.wave.shared_memory_indexing import (
     apply_shared_memory_indexing_corrections,
 )
 from iree.turbine.kernel.wave.scheduling.schedule import schedule_graph
+from iree.turbine.kernel.wave.index_sequence_analysis import (
+    set_node_indices,
+    set_post_expansion_indices,
+)
 
 
 # Input sizes
@@ -90,7 +94,9 @@ def test_gemm_pipelined():
         IndexingContext.current().finalize()
         promote_placeholders(trace, constraints)
         hoist_allocs(trace)
+        set_node_indices(trace, constraints)
         expand_graph(trace, constraints)
+        set_post_expansion_indices(trace, constraints)
         minimize_global_loads(trace, constraints)
         apply_shared_memory_indexing_corrections(trace, constraints)
         schedule_graph(trace, constraints, True)

--- a/tests/kernel/wave/scheduling_test.py
+++ b/tests/kernel/wave/scheduling_test.py
@@ -32,6 +32,10 @@ from iree.turbine.kernel.wave.expansion import expand_graph
 from iree.turbine.kernel.wave.minimize_global_loads import minimize_global_loads
 from iree.turbine.kernel.wave.scheduling.schedule import schedule_graph
 from iree.turbine.kernel.ops.wave_ops import get_custom
+from iree.turbine.kernel.wave.index_sequence_analysis import (
+    set_node_indices,
+    set_post_expansion_indices,
+)
 
 
 class SchedulingTest(unittest.TestCase):
@@ -275,7 +279,9 @@ class SchedulingTest(unittest.TestCase):
             IndexingContext.current().finalize()
             promote_placeholders(trace, constraints)
             hoist_allocs(trace)
+            set_node_indices(trace, constraints)
             expand_graph(trace, constraints)
+            set_post_expansion_indices(trace, constraints)
             minimize_global_loads(trace, constraints)
             schedule_graph(trace, constraints)
             subgraph = trace.get_subgraph("region_0")

--- a/tests/kernel/wave/visualization_test.py
+++ b/tests/kernel/wave/visualization_test.py
@@ -18,6 +18,10 @@ from iree.turbine.kernel._support.indexing import IndexingContext
 from iree.turbine.kernel.ops.wave_ops import get_custom
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel.wave.visualization import visualize_graph
+from iree.turbine.kernel.wave.index_sequence_analysis import (
+    set_node_indices,
+    set_post_expansion_indices,
+)
 
 
 def run(func: Callable[[], None]) -> Callable[[], None]:
@@ -89,7 +93,9 @@ def test_gemm():
     ):
         graph = gemm()
         IndexingContext.current().finalize()
+        set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
         visualize_graph(graph.get_subgraph("region_0"), "gemm.png")
         assert os.path.exists("gemm.png")
 


### PR DESCRIPTION
This PR separates the setting of indices pre-
and post-expansion from expansion itself. This
separation of concerns should make the overall
design more modular.