### PR TITLE
Restrict to torch < 2.5.0

### DIFF
--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,5 +1,5 @@
 --pre
 --index-url https://download.pytorch.org/whl/nightly/rocm6.0
-torch>=2.3.0
+torch>=2.3.0, <2.5.0
 torchaudio
 torchvision


### PR DESCRIPTION
The CPU requirements restrict torch to a version < 2.5.0, whereas the ROCm requirements did not so far. The current iree-turbine is incompatible with torch 2.5.0 as `torch.export.dynamic_dim()` was removed with pytorch/pytorch@b454c51.

Closes #227