### PR TITLE
Add device affinities for arguments in AOT

### DIFF
--- a/iree/turbine/aot/tensor_traits.py
+++ b/iree/turbine/aot/tensor_traits.py
@@ -11,8 +11,24 @@ import torch
 
 
 __all__ = [
+    "DeviceAffinity",
     "ExternalTensorTrait",
 ]
+
+
+class DeviceAffinity:
+    """This is used to provide device affinities to exported function arguments."""
+
+    def __init__(self, ordinal: int):
+        self.ordinal = ordinal
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, DeviceAffinity):
+            return False
+        return self.ordinal == other.ordinal
+
+    def __repr__(self) -> str:
+        return f"DeviceAffinity({self.ordinal})"
 
 
 @dataclass

--- a/iree/turbine/support/ir_imports.py
+++ b/iree/turbine/support/ir_imports.py
@@ -8,6 +8,7 @@
 """Unifies all imports of iree.compiler.ir into one place."""
 
 from iree.compiler.ir import (
+    ArrayAttr,
     AsmState,
     Attribute,
     Block,
@@ -15,6 +16,7 @@ from iree.compiler.ir import (
     Context,
     DenseElementsAttr,
     DenseResourceElementsAttr,
+    DictAttr,
     FlatSymbolRefAttr,
     FloatAttr,
     FunctionType,

--- a/tests/aot/fx_programs_test.py
+++ b/tests/aot/fx_programs_test.py
@@ -61,10 +61,10 @@ def test_save_load_dynamic_shapes():
     prog_0 = new_programs.programs["dynamic_batch"]
     prog_1 = new_programs.programs["bs32"]
 
-    for key, value_0 in prog_0.state_dict.items():
-        value_1 = prog_1.state_dict[key]
+    for key, value_0 in prog_0.target.state_dict.items():
+        value_1 = prog_1.target.state_dict[key]
         assert value_0 is value_1, f"State dict item {key} was not aliased on load"
 
-    for key, value_0 in prog_0.constants.items():
-        value_1 = prog_1.constants[key]
+    for key, value_0 in prog_0.target.constants.items():
+        value_1 = prog_1.target.constants[key]
         assert value_0 is value_1, f"Constant item {key} was not aliased on load"

--- a/tests/aot/fx_programs_test_device.py
+++ b/tests/aot/fx_programs_test_device.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+import unittest
+
+import torch
+
+from iree.turbine.aot import (
+    DeviceAffinity,
+    export,
+    FxProgramsBuilder,
+)
+
+
+class FxProgramsTestDevice(unittest.TestCase):
+    def test_argument_device_affinities(self):
+        class Module(torch.nn.Module):
+            def main(self, x1, x2):
+                return x1, x2
+
+        args = (
+            torch.empty(2, 3, dtype=torch.int8),
+            torch.empty(4, 5, dtype=torch.int8),
+        )
+        fxb = FxProgramsBuilder(Module())
+
+        @fxb.export_program(
+            args=args,
+            arg_device={0: DeviceAffinity(0), 1: DeviceAffinity(1)},
+        )
+        def main(module: Module, x1, x2):
+            return module.main(x1, x2)
+
+        output = export(fxb)
+        asm = str(output.mlir_module)
+        self.assertRegex(
+            asm,
+            (
+                "func.func @main\("
+                "%.+: !torch.vtensor<\[2,3\],si8> {iree.abi.affinity = #hal.device.promise<@__device_0>}, "
+                "%.+: !torch.vtensor<\[4,5\],si8> {iree.abi.affinity = #hal.device.promise<@__device_1>}\)"
+            ),
+        )


### PR DESCRIPTION
We don't have support for providing device affinities for function arguments, which need to end up as MLIR function argument attributes.

This change adds a class DeviceAffinity and provides the ability to supply affinities when exporting Torch functions/modules or when tracing in IREE-Trubine itself.