### PR TITLE
Add support for chained matmuls

### DIFF
--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -66,6 +66,7 @@ from ..ops.wave_ops import (
     scheduling_barrier,
     scheduling_group_barrier,
     cast,
+    permute,
 )
 from ..lang.wave_types import IndexMapping, IndexSymbol
 from ..compiler.base import CodegenError, ValidationError, NDEBUG
@@ -1299,3 +1300,13 @@ def handle_cast(emitter: WaveEmitter, node: fx.Node):
         )
 
     emitter.bind_node_proxy(node, IRProxyValue(casted_vector))
+
+
+@handle_op(permute)
+def handle_permute(emitter: WaveEmitter, node: fx.Node):
+    try:
+        register, _ = node.args
+    except ValueError as e:
+        raise ValidationError("Malformed arguments") from e
+    vector_src = cast_py_value(emitter, register)
+    emitter.bind_node_proxy(node, vector_src)

--- a/iree/turbine/kernel/wave/expansion.py
+++ b/iree/turbine/kernel/wave/expansion.py
@@ -117,10 +117,7 @@ def expand_graph(
     Create a graph that represents the expanded version of the wave function.
     The expansion is done in the dimensions specified by the constraints.
     """
-    if isinstance(constraints_or_scaling, dict):
-        dim_scaling = constraints_or_scaling
-    else:
-        dim_scaling = get_dim_scaling(constraints_or_scaling)
+    get_node_dim_scaling = partial(get_dim_scaling, constraints_or_scaling)
 
     # Start from the back and expand in the corresponding indexing dimensions of a node
     # Then proceed to the operands
@@ -146,6 +143,7 @@ def expand_graph(
         if node.__class__ not in leaf_nodes:
             continue
 
+        dim_scaling = get_node_dim_scaling(node)
         for dim_combination in get_dim_combinations(dim_scaling, node.indexing_dims):
             expand_dims = {
                 dim: val for dim, val in zip(dim_scaling.keys(), dim_combination)
@@ -157,6 +155,7 @@ def expand_graph(
                 expand_dims,
                 dim_scaling,
                 expansion_context,
+                get_node_dim_scaling,
             )
 
 
@@ -166,6 +165,7 @@ def _expand_node(
     dim_query: dict[IndexSymbol, int],
     dim_scaling: dict[IndexSymbol, int],
     context: ExpandedNodeMap,
+    get_node_dim_scaling: Callable[[fx.Node], dict[IndexSymbol, int]],
     res_idx: int = 0,
 ) -> CustomOp:
     """Expand a single node or list of nodes in specific dimensions and recursively proceed to its inputs."""
@@ -177,8 +177,9 @@ def _expand_node(
                     elem,
                     trace,
                     dim_query,
-                    dim_scaling,
+                    get_node_dim_scaling(elem),
                     context,
+                    get_node_dim_scaling,
                     res_idx,
                 ).fx_node
             )
@@ -187,8 +188,25 @@ def _expand_node(
     if (node, get_indexed_dims(dim_query, node), res_idx) in context:
         logger.debug(f"Already expanded node: {node} in {dim_query}")
         return context[(node, get_indexed_dims(dim_query, node), res_idx)]
+    elif isinstance(node, MMA):
+        # Handle expansion of MMA nodes whose reduction dim is not the same as the reduction
+        # dim of the parent reduction op.
+        if hasattr(node.graph, "parent_op") and node.reduction_dim not in dim_query:
+            reduction: Reduction = get_custom(node.graph.parent_op)
+            if reduction.axis != node.reduction_dim:
+                return _expand_mma_reduction(
+                    node,
+                    trace,
+                    dim_query,
+                    get_node_dim_scaling(node),
+                    context,
+                    get_node_dim_scaling,
+                    res_idx,
+                )
     elif isinstance(node, Reduction):
-        return _expand_reduction(node, trace, dim_query, dim_scaling, context, res_idx)
+        return _expand_reduction(
+            node, trace, dim_query, dim_scaling, context, get_node_dim_scaling, res_idx
+        )
     elif isinstance(node, Getitem):
         res_idx = node.res_idx
     elif isinstance(node, GetResult) and not isinstance(node, Getitem):
@@ -230,15 +248,34 @@ def _expand_node(
 
     # Proceed with expansion of the arguments
     for i, arg in node.node_args.items():
-        if is_expandable(arg):
-            new_arg = _expand_node(
-                arg,
-                trace,
-                restricted_dims,
-                dim_scaling,
-                context,
-                res_idx,
-            )
+        new_arg = None
+        if not isinstance(arg, Sequence):
+            if is_expandable(arg):
+                new_arg = _expand_node(
+                    arg,
+                    trace,
+                    restricted_dims,
+                    get_node_dim_scaling(arg),
+                    context,
+                    get_node_dim_scaling,
+                    res_idx,
+                )
+                new_node.update_arg(i, new_arg)
+        else:
+            new_arg = []
+            for subarg in arg:
+                if is_expandable(subarg):
+                    new_subarg = _expand_node(
+                        subarg,
+                        trace,
+                        restricted_dims,
+                        get_node_dim_scaling(subarg),
+                        context,
+                        get_node_dim_scaling,
+                        res_idx,
+                    )
+                    new_arg.append(new_subarg.fx_node)
+            assert len(new_arg) == len(arg), "All subargs must be expanded"
             new_node.update_arg(i, new_arg)
 
     context[(node, get_indexed_dims(restricted_dims, node), res_idx)] = new_node
@@ -251,6 +288,7 @@ def _expand_reduction(
     dim_query: dict[IndexSymbol, int],
     dim_scaling: dict[IndexSymbol, int],
     context: ExpandedNodeMap,
+    get_node_dim_scaling: Callable[[fx.Node], dict[IndexSymbol, int]],
     res_idx: int = 0,
 ) -> CustomOp:
     """Expand a reduction in a specific dimension and recursively proceed to its inputs."""
@@ -258,6 +296,7 @@ def _expand_reduction(
     users = reduction.users
     expand_dims: list[IndexSymbol] = []
     for user in users:
+        dim_scaling.update(get_node_dim_scaling(user))
         for indexing_dim in user.indexing_dims:
             if indexing_dim not in expand_dims:
                 expand_dims.append(indexing_dim)
@@ -295,21 +334,24 @@ def _expand_reduction(
                     arg,
                     trace,
                     dims,
-                    dim_scaling,
+                    get_node_dim_scaling(arg),
                     context,
+                    get_node_dim_scaling,
                     res_idx,
                 )
             )
 
         # Proceed with expansion outside the reduction
         for init_arg in reduction.init_args:
+            custom_init_arg = get_custom(init_arg)
             new_init_args.append(
                 _expand_node(
-                    get_custom(init_arg),
+                    custom_init_arg,
                     trace,
                     dims,
-                    dim_scaling,
+                    get_node_dim_scaling(custom_init_arg),
                     context,
+                    get_node_dim_scaling,
                     res_idx,
                 )
             )
@@ -325,11 +367,105 @@ def _expand_reduction(
         trace,
         dim_scaling,
         context,
+        get_node_dim_scaling,
         res_idx,
     )
     # Even though we expanded the reduction in multiple dimensions, we only return
     # the node corresponding to the original query
     return context[(reduction, get_indexed_dims(dim_query, expand_dims), res_idx)]
+
+
+def _expand_mma_reduction(
+    mma: MMA,
+    trace: CapturedTrace,
+    dim_query: dict[IndexSymbol, int],
+    dim_scaling: dict[IndexSymbol, int],
+    context: ExpandedNodeMap,
+    get_node_dim_scaling: Callable[[fx.Node], dict[IndexSymbol, int]],
+    res_idx: int,
+) -> CustomOp:
+    """
+    This function expands an MMA node along its reduction dimension. It is called
+    P times where P is the product of all of its parallel dimensions. For each
+    invocation, we expand the reduction dimension.
+
+    We first compute the dim scaling along the reduction dimension and then append
+    it to the dim query so that the expanded node and its arguments can use the
+    expanded dim query with the appropriate value of the reduction dimension.
+
+    Unlike the reduction expansion, where we can do a separate expansion for each iter_arg,
+    here we only have a single MMA node to start with. So we keep track of it and re-use
+    it for all the expansions. We also keep track of the accumulator value to be used as
+    the accumulator for the first expansion along the reduction dimension.
+    """
+
+    logger.debug(f"Expanding MMA reduction: {mma} in dims: {dim_query}")
+    idxc = IndexingContext.current()
+    for dim in mma.indexing_dims:
+        if dim not in dim_scaling and mma.vector_shapes[dim] > 0:
+            tile_size = idxc.get_static_value(dim)
+            dim_scaling[dim] = tile_size // mma.vector_shapes[dim]
+
+    expand_dims = set(mma.indexing_dims) - set([mma.reduction_dim])
+
+    # Store the original mma node and accumulator value for expansion.
+    dim_query_dims = tuple(dim_query.keys())
+    if not hasattr(_expand_mma_reduction, "acc"):
+        _expand_mma_reduction.acc = {}
+    if not hasattr(_expand_mma_reduction, "mma"):
+        _expand_mma_reduction.mma = {}
+    if dim_query_dims not in _expand_mma_reduction.mma:
+        _expand_mma_reduction.mma[dim_query_dims] = mma
+        _expand_mma_reduction.acc[dim_query_dims] = mma.acc
+
+    context_key = (
+        _expand_mma_reduction.mma[dim_query_dims],
+        get_indexed_dims(dim_query, expand_dims),
+        res_idx,
+    )
+
+    user = _expand_mma_reduction.mma[dim_query_dims]
+    for scale_idx in range(dim_scaling[mma.reduction_dim]):
+        if isinstance(user, Output):
+            continue
+
+        dims = dim_query
+        dims[mma.reduction_dim] = scale_idx
+        # Temporarily replace the loop carried arg here to avoid
+        # duplicated expansion. Otherwise we have the following situation:
+        # Suppose we have:
+        #   mma_0_0_0(..., acc_0_0_0)
+        #   mma_0_0_1(..., mma_0_0_0)
+        # Expanding mma_0_0_1 to mma_0_0_2 will trigger expansion of its arg
+        # mma_0_0_0 in dims 0_0_2 as well, effectively duplicating the new node.
+        # To avoid this we temporarily replace the use of it with a dummy
+        # placeholder which will not trigger further expansion.
+        index = user.get_node_arg_index(get_custom(user.acc))
+        dummy = Placeholder("dummy").add_to_graph(user.graph)
+        dummy.type = None
+
+        saved_arg = user.node_args[index]
+        user.update_arg(index, dummy)
+        new_node = _expand_node(
+            user,
+            trace,
+            dims,
+            get_node_dim_scaling(user),
+            context,
+            get_node_dim_scaling,
+        )
+
+        # Update the new node accumulator with the user, except the first one.
+        if scale_idx > 0:
+            new_node.update_arg(index, user)
+        else:
+            new_node.update_arg(index, _expand_mma_reduction.acc[dim_query_dims])
+        user.update_arg(index, saved_arg)
+        user.graph.erase_node(dummy)
+        user = new_node
+
+    context[context_key] = new_node
+    return new_node
 
 
 def get_expanded_name(node: CustomOp, dims: dict[IndexSymbol, int]) -> str:
@@ -355,9 +491,14 @@ def _contains(elem, container):
     return elem in container
 
 
-def get_dim_scaling(constraints: Sequence[Constraint]) -> dict[IndexSymbol, int]:
-    """Get the number of expansions for the dimensions based on the constraints."""
+def get_dim_scaling(
+    constraints: Sequence[Constraint], node: fx.Node
+) -> dict[IndexSymbol, int]:
+    """Get the number of expansions for the dimensions based on the constraints for a specific node."""
     dim_scaling: dict[IndexSymbol, int] = {}
+    if node.vector_shapes is None:
+        return dim_scaling
+
     hardware_constraints: list[HardwareConstraint] = [
         constraint
         for constraint in constraints
@@ -373,12 +514,9 @@ def get_dim_scaling(constraints: Sequence[Constraint]) -> dict[IndexSymbol, int]
         ):
             hw_cons = hardware_constraints[0]
             tile_size = idxc.get_static_value(constraint.tile_size)
-            if not _contains(constraint.dim, hw_cons.vector_shapes):
-                raise ValueError(
-                    f"Attempting to determine vector shape for unmapped dimension {constraint.dim}"
-                )
-
-            vector_size = hw_cons.vector_shapes[constraint.dim]
+            if constraint.dim not in node.vector_shapes:
+                continue
+            vector_size = node.vector_shapes[constraint.dim]
 
             # No dim scaling for dims with 0 vector size.
             if vector_size == 0:
@@ -399,6 +537,7 @@ def get_dim_scaling(constraints: Sequence[Constraint]) -> dict[IndexSymbol, int]
                     "Tile size must be divisible by wave count and vector size"
                 )
             dim_scaling[constraint.dim] = tile_size // wave_count // vector_size
+
     return dim_scaling
 
 
@@ -408,6 +547,7 @@ def _handle_reduction_dim(
     trace: CapturedTrace,
     dim_scaling: dict[IndexSymbol, int],
     context: ExpandedNodeMap,
+    get_node_dim_scaling: Callable[[fx.Node], dict[IndexSymbol, int]],
     res_idx: int,
 ):
     # Rediscover iter args
@@ -422,6 +562,7 @@ def _handle_reduction_dim(
     # Users of the loop carried nodes will be duplicated
     for idx, carried_node in enumerate(iter_args):
         # The initial nodes are expanded in the first dimension, so we start from 1
+        dim_scaling = get_node_dim_scaling(carried_node)
         for scale_idx in range(1, dim_scaling[reduction.axis]):
             for user in carried_node.users:
                 if isinstance(user, Output):
@@ -450,6 +591,7 @@ def _handle_reduction_dim(
                     dims,
                     dim_scaling,
                     context,
+                    get_node_dim_scaling,
                     res_idx,
                 )
 

--- a/lit_tests/kernel/wave/barriers.py
+++ b/lit_tests/kernel/wave/barriers.py
@@ -115,13 +115,13 @@ def test_read_write_equal_sizes():
         # CHECK-SAME: (%read_0_1, %allocate, 4, None)
         # CHECK-NEXT: %shared_memory_barrier
         # CHECK-NEXT: %read_shared_0_0
-        # CHECK-SAME: (%allocate, 4, None, [%write_shared_0_0])
+        # CHECK-SAME: (%allocate, 4, None, [%write_shared_0_0]
         # CHECK-NEXT: %read_shared_1_1
-        # CHECK-SAME: (%allocate, 4, None, [%write_shared_1_1])
+        # CHECK-SAME: (%allocate, 4, None, [%write_shared_1_1]
         # CHECK-NEXT: %read_shared_1_0
-        # CHECK-SAME: (%allocate, 4, None, [%write_shared_1_0])
+        # CHECK-SAME: (%allocate, 4, None, [%write_shared_1_0]
         # CHECK-NEXT: %read_shared_0_1
-        # CHECK-SAME: (%allocate, 4, None, [%write_shared_0_1])
+        # CHECK-SAME: (%allocate, 4, None, [%write_shared_0_1]
         # CHECK-NEXT: %write_0_0
         # CHECK-SAME: (%read_shared_0_0, %c, 4, None)
         # CHECK-NEXT: %write_1_1

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -256,10 +256,10 @@ def test_gemm():
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
-        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16), N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
-        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
-        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
-        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16), N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
+        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
+        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
+        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
+        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
         # CHECK-NEXT: reduction(axis=K, init_args=[register_0_0_0, register_0_1_0, register_1_0_0, register_1_1_0], subgraph_name=region_0, implicit_captures=[a, b])
         # CHECK-NEXT: get_result(value=reduction, res_idx=3)
         # CHECK-NEXT: get_result(value=reduction, res_idx=2)
@@ -442,10 +442,10 @@ def test_batched_gemm():
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
-        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16), N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
-        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
-        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
-        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16), N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
+        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
+        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
+        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
+        # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16})
         # CHECK-NEXT: reduction(axis=K, init_args=[register_0_0_0, register_0_1_0, register_1_0_0, register_1_1_0], subgraph_name=region_0, implicit_captures=[a, b])
         # CHECK-NEXT: get_result(value=reduction, res_idx=3)
         # CHECK-NEXT: get_result(value=reduction, res_idx=2)
@@ -590,7 +590,7 @@ def test_gemm_reduction_expansion_only():
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
-        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16), N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
+        # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16)})
         # CHECK-NEXT: reduction(axis=K, init_args=[register_0_0_0]
         # CHECK-NEXT: get_result(value=reduction, res_idx=0)
         # CHECK-NEXT: write(register_=getresult_0_0_0

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -186,13 +186,13 @@ def test_gemm():
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
         # CHECK-NEXT: register
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16), N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
         # CHECK-NEXT: register(
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
         # CHECK-NEXT: register(
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
         # CHECK-NEXT: register(
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16), N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: reduction(

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -137,13 +137,13 @@ def test_gemm():
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
         # CHECK-NEXT: register
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16), N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
         # CHECK-NEXT: register(
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
         # CHECK-NEXT: register(
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16) + 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16)})
         # CHECK-NEXT: register(
-        # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod($T0, 16), N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
+        # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16})
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: reduction(

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -1,0 +1,187 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import pytest
+import torch
+import unittest
+import iree.turbine.kernel as tk
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
+from iree.turbine.kernel.wave.utils import (
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+)
+from iree.turbine.kernel.wave.constraints import MMAType
+import os
+import json
+from torch.testing import assert_close
+
+_run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
+require_e2e = pytest.mark.skipif(not _run_e2e, reason="e2e tests are disabled")
+# Whether to dump the generated MLIR module.
+test_dump_generated_mlir = int(os.environ.get("WAVE_DUMP_MLIR", 0))
+# Whether to use scheduling group barriers (needs LLVM fix).
+enable_scheduling_barriers = int(os.environ.get("WAVE_USE_SCHED_BARRIERS", 0))
+
+# Add test shapes for validation and performance testing.
+perf_test = lambda *a: pytest.param(*a, marks=pytest.mark.perf_only)
+default_test_shapes = {}
+# Order of shapes: (B, M, N, K1, K2)
+default_test_shapes["test_attention"] = [
+    (8, 128, 128, 64, 256),
+]
+default_test_shapes["test_attention"] += [perf_test(x) for x in default_test_shapes]
+
+
+user_specified_test_shapes = ""
+
+test_params_path = os.environ.get("TEST_PARAMS_PATH", None)
+
+if test_params_path:
+    with open(test_params_path, "r") as file:
+        user_specified_test_shapes = json.load(file)
+
+
+def get_test_shapes(test_name: str) -> list[tuple[int]]:
+    if test_name in user_specified_test_shapes:
+        return user_specified_test_shapes[test_name]
+    return default_test_shapes[test_name]
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_attention"))
+@pytest.mark.parametrize("enable_scheduling", [False])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x16_F16,
+    ],
+)
+def testChainedGemm(
+    shape: tuple[int], enable_scheduling: bool, mfma_variant: MMAType, request
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0},
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def chained_gemm(
+        q: tkl.Memory[B, M, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
+
+        @tkw.reduction(K2, init_args=[c_reg])
+        def repeat(
+            acc: tkl.Register[B, M, N, tkl.f32]
+        ) -> tkl.Register[B, M, N, tkl.f32]:
+            inner_acc = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            kq_reg = tkw.mma(k_reg, q_reg, inner_acc)
+            qk_reg = tkw.permute(kq_reg, target_shape=[B, M, K2])
+            qk_cast_reg = tkw.cast(qk_reg, tkl.f16)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            acc = tkw.mma(qk_cast_reg, v_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        BLOCK_B: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 32,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K1: shape[3],
+        K2: shape[4],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+    }
+    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+    ):
+        q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = torch.randn(shape[0], shape[2], shape[4], dtype=torch.float16)
+        output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        mb = chained_gemm(q, k, v, output)
+
+        if test_dump_generated_mlir:
+            filename = f"wave_cgemm_{'x'.join(map(str, shape))}.mlir"
+            with open(filename, "w") as f:
+                f.write(mb.module_op.get_asm())
+
+        iree_ref = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        generate_iree_ref(
+            "chain_mmt", [q, k, v], [iree_ref], config, run_bench=run_bench
+        )
+        assert_close(output, iree_ref)


### PR DESCRIPTION
This PR adds support for chained matmuls. In
order to do this, we implement the following
- Support for op-specific vector_shapes
- Support for op-specific dim expansions (reduction
  dims of mmas will now always have chained expansions,
  even if they are not the induction variable of
  reduction ops)
- Adds a permute operator
- Adds anchor and vector_shapes to each op
- Adds reduction_dim to MMA ops