### PR TITLE
Make transfer_to_logical_device copy the tensor during eager execution

### DIFF
--- a/iree/turbine/ops/iree.py
+++ b/iree/turbine/ops/iree.py
@@ -89,7 +89,7 @@ class transfer_to_logical_device(CustomOp):
         ksel.return_tensor(ta.t).specialize_dims(*spec)
 
     def eager_execute(self, device_moniker, tensor):
-        return tensor
+        return tensor.clone()
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         moniker = cast(AttrArg, ksel.arg_descs[0]).v

--- a/tests/ops/iree_test.py
+++ b/tests/ops/iree_test.py
@@ -36,7 +36,7 @@ class TransferToLogicalDeviceTest(unittest.TestCase):
     def testEager(self):
         t1 = torch.randn(3, 4)
         t2 = ops.iree.transfer_to_logical_device("1", t1)
-        self.assertIs(t1, t2)
+        assert torch.all(t1 == t2)
 
     def testAOT(self):
         class MyModule(nn.Module):


### PR DESCRIPTION
Currently eager and generate don't have the same semantics. Generate would create a new value while in eager we return the same tensor.
It is desirable to have the same behavior in both paths, this will allow us to catch in-place errors on the torch level and not during IREE execution.
The only downside is that during eager it will be slower. This is far less of headache.