### PR TITLE
Add `DeviceTensorTrait` to export annotations

### DIFF
--- a/iree/turbine/aot/support/ir_utils.py
+++ b/iree/turbine/aot/support/ir_utils.py
@@ -291,7 +291,7 @@ class ModuleBuilder:
                 ir_attrs["is_mutable"] = UnitAttr.get()
             if device:
                 ir_attrs["iree.abi.affinity"] = Attribute.parse(
-                    f"#hal.device.promise<@{device.device_id}>"
+                    f"#hal.device.promise<@__device_{device.ordinal}>"
                 )
             if external:
                 # Emit named external reference.

--- a/iree/turbine/aot/tensor_traits.py
+++ b/iree/turbine/aot/tensor_traits.py
@@ -12,6 +12,7 @@ import torch
 
 __all__ = [
     "DeviceAffinity",
+    "DeviceTensorTrait",
     "ExternalTensorTrait",
 ]
 
@@ -29,6 +30,26 @@ class DeviceAffinity:
 
     def __repr__(self) -> str:
         return f"DeviceAffinity({self.ordinal})"
+
+
+@dataclass
+class DeviceTensorTrait:
+    """Represents a 'trait' that can be applied to a Tensor to signal that
+    it is to be loaded to a speific device at execution time.
+    """
+
+    device_id: str
+
+    @staticmethod
+    def get(from_tensor: torch.Tensor) -> Optional["DeviceTensorTrait"]:
+        existing = getattr(from_tensor, "_turbine_device_tensor_trait", None)
+        if existing is None:
+            return None
+        assert isinstance(existing, DeviceTensorTrait)
+        return existing
+
+    def set(self, to_tensor: torch.Tensor):
+        to_tensor._turbine_device_tensor_trait = self  # type: ignore
 
 
 @dataclass

--- a/iree/turbine/aot/tensor_traits.py
+++ b/iree/turbine/aot/tensor_traits.py
@@ -38,7 +38,7 @@ class DeviceTensorTrait:
     it is to be loaded to a speific device at execution time.
     """
 
-    device_id: str
+    ordinal: int
 
     @staticmethod
     def get(from_tensor: torch.Tensor) -> Optional["DeviceTensorTrait"]:

--- a/tests/aot/params_test.py
+++ b/tests/aot/params_test.py
@@ -123,7 +123,7 @@ class ExternalTensorTest(unittest.TestCase):
 class DeviceTensorTest(unittest.TestCase):
     def testDeviceTensorTrait(self):
         t = torch.ones([2, 3], dtype=torch.float32)
-        trait = DeviceTensorTrait(device_id="__device_who")
+        trait = DeviceTensorTrait(ordinal=7)
         self.assertIsNone(trait.get(t))
         trait.set(t)
         self.assertIs(DeviceTensorTrait.get(t), trait)

--- a/tests/aot/params_test.py
+++ b/tests/aot/params_test.py
@@ -16,6 +16,7 @@ from iree.turbine.aot import (
     export,
     externalize_module_parameters,
     save_module_parameters,
+    DeviceTensorTrait,
     ExternalTensorTrait,
     ParameterArchive,
     ParameterArchiveBuilder,
@@ -117,6 +118,15 @@ class ExternalTensorTest(unittest.TestCase):
         self.assertIsNone(trait.get(t))
         trait.set(t)
         self.assertIs(ExternalTensorTrait.get(t), trait)
+
+
+class DeviceTensorTest(unittest.TestCase):
+    def testDeviceTensorTrait(self):
+        t = torch.ones([2, 3], dtype=torch.float32)
+        trait = DeviceTensorTrait(device_id="__device_who")
+        self.assertIsNone(trait.get(t))
+        trait.set(t)
+        self.assertIs(DeviceTensorTrait.get(t), trait)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Exported globals can now be parked to belong to a specific device. This works with sharding tooling to ensure globals are not misassigned to the default affinity device