### PR TITLE
[TKW] Teach expansion to handle non direct acc and ReduceOp on reduction dim.

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -615,7 +615,7 @@ class BinaryPyOp(CustomOp, ABC):
             raise ValueError(
                 "BinaryPyOp requires lhs and rhs shape to be at least broadcastable."
             )
-        broadcasted_type = lhs_type if lhs_dim_set > rhs_dim_set else rhstype
+        broadcasted_type = lhs_type if lhs_dim_set > rhs_dim_set else rhs_type
         return broadcasted_type
 
 

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -409,11 +409,15 @@ class CustomOp(ABC):
             new_node.reduction_dim = self.fx_node.reduction_dim
         return get_custom(new_node)
 
-    def replace_all_uses_with(self, new_node: CustomOp | fx.Node):
+    def replace_all_uses_with(
+        self,
+        new_node: CustomOp | fx.Node,
+        filter_fn: Callable[[fx.node], bool] = lambda x: True,
+    ):
         """Replace all uses of the current node with the new node."""
         if isinstance(new_node, CustomOp):
             new_node = new_node.fx_node
-        self.fx_node.replace_all_uses_with(new_node)
+        self.fx_node.replace_all_uses_with(new_node, filter_fn)
 
     def erase(self):
         """Erase the current node from the graph where it exists."""
@@ -1321,6 +1325,10 @@ class ReduceOp(CustomOp, ABC):
             return len(self.dim)
         else:
             return 1
+
+    @property
+    def reduction_dim(self) -> IndexSymbol:
+        return self.dim
 
 
 # TODO: Add support for more shuffle types.

--- a/iree/turbine/kernel/wave/expansion.py
+++ b/iree/turbine/kernel/wave/expansion.py
@@ -365,6 +365,8 @@ def _expand_reduction(
                 get_node_dim_scaling,
                 res_idx,
             )
+            # TODO: Handle expansion of induction variables with "non-complete" dims
+            #       by checking on the indexing_dims on each induction variable.
             if expanded_init_arg in new_init_args:
                 continue
             new_init_args.append(expanded_init_arg)

--- a/iree/turbine/kernel/wave/expansion.py
+++ b/iree/turbine/kernel/wave/expansion.py
@@ -565,6 +565,7 @@ def _expand_mma_tiled_reduction(
     res_idx: int,
 ) -> CustomOp:
     latest_reduced_op = mma
+    # The initial nodes are expanded in the first dimension, so we start from 1
     for scale_idx in range(1, dim_scaling[mma.reduction_dim]):
         dim_query[mma.reduction_dim] = scale_idx
         # Temporarily replace the loop carried arg here to avoid
@@ -638,7 +639,6 @@ def _handle_reduction_dim(
     new_outputs = list(reduction.outputs(trace.get_subgraph(reduction.subgraph_name)))
     # Users of the loop carried nodes will be duplicated
     for root_op in reduction_root_ops:
-        # The initial nodes are expanded in the first dimension, so we start from 1
         dim_scaling = get_node_dim_scaling(root_op)
         dims = dict(root_op.fx_node.expanded_dims)
         latest_reduced_op = root_op
@@ -657,6 +657,7 @@ def _handle_reduction_dim(
             )
         elif isinstance(root_op, ReduceOp):
             original_src = latest_reduced_op.arg
+            # The initial nodes are expanded in the first dimension, so we start from 1
             for scale_idx in range(1, dim_scaling[reduction.axis]):
                 dims[root_op.reduction_dim] = scale_idx
                 current_src = latest_reduced_op.arg


### PR DESCRIPTION
In flash attention, we need to enable non direct acc matmul, and also expansion of reduceOp in reduction dimension. The former is needed in FA since we are applying some scaling to the acc of second MMA before feeding it in. The second case is required in FA because ReduceOp/MaxOp is in the backward slice of second MMA's LHS, which would require it to be expanded in K2/reduction dim as well. 