### PR TITLE
Add support for varying vector shapes

### DIFF
--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -185,19 +185,6 @@ def is_contiguous_dim(
     return is_innermost_dim or all_unit_dims
 
 
-def add_reshape(custom: CustomOp):
-    for arg in custom.node_args.values():
-        if not isinstance(arg, Sequence):
-            arg = [arg]
-        for subarg in arg:
-            # These are ops in the parent graph that have not had their vector shapes set yet.
-            if subarg.vector_shapes is None:
-                continue
-            if subarg.vector_shapes != custom.vector_shapes:
-                with custom.graph.inserting_before(custom.fx_node):
-                    Reshape(subarg, custom.vector_shapes).add_to_graph(custom.graph)
-
-
 def set_vector_shapes(
     constraints: Sequence[Constraint],
     mma_index: dict[MMA, dict[IndexSymbol, int]],

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -261,28 +261,41 @@ def get_mma_dimensional_mapping(
 
     # Determine if any reshapes are required. Reshapes are added for
     # chained matmuls when the vector shapes of the operands in one matmul
-    # differ from those in another matmul.
-    for src in mma_nodes:
-        custom_src = get_custom(src)
-        for dst in mma_nodes:
-            if src == dst:
-                continue
-            custom_dst = get_custom(dst)
-            lhs_slice = capture_backward_slice(custom_dst.lhs)
-            rhs_slice = capture_backward_slice(custom_dst.rhs)
-            if src in lhs_slice or src in rhs_slice:
-                with custom_dst.graph.inserting_before(dst):
-                    for i, arg in custom_dst.node_args.items():
-                        if is_reshape_needed(
-                            arg, custom_dst.vector_shapes, custom_src.vector_shapes
-                        ):
-                            reshape = Reshape(
-                                arg.fx_node, custom_src.vector_shapes
-                            ).add_to_graph(custom.graph)
-                            custom_reshape = get_custom(reshape)
-                            custom_reshape.vector_shapes = custom.vector_shapes
-                            custom_reshape.anchor = custom
-                            custom.update_arg(i, reshape)
+    # differ from those in another matmul. The mma_slices contain all the ops
+    # in the backward slice of the lhs and rhs upto a previous mma (if one exists).
+    # So we check for the previous node of the first operator in the slice to see
+    # if it is an MMA and if so check if a reshape is required.
+    def add_reshape_if_needed(mma: MMA, prev_mma: MMA):
+        with mma.graph.inserting_before(mma.fx_node):
+            for i, arg in mma.node_args.items():
+                if is_reshape_needed(arg, mma.vector_shapes, prev_mma.vector_shapes):
+                    reshape = Reshape(arg.fx_node, prev_mma.vector_shapes).add_to_graph(
+                        custom.graph
+                    )
+                    custom_reshape = get_custom(reshape)
+                    custom_reshape.vector_shapes = custom.vector_shapes
+                    custom_reshape.anchor = custom
+                    custom.update_arg(i, reshape)
+
+    def find_mma_in_slice(node: CustomOp) -> Optional[MMA]:
+        """
+        Find the closest mma by iterating through the backward slice of a node
+        in reverse.
+        """
+        slice = list(capture_backward_slice(node))
+        for arg in reversed(slice):
+            prev_mma = get_custom(arg)
+            if isinstance(prev_mma, MMA):
+                return prev_mma
+        return None
+
+    for mma in mma_nodes:
+        custom_mma = get_custom(mma)
+        prev_mma = find_mma_in_slice(custom_mma.lhs) or find_mma_in_slice(
+            custom_mma.rhs
+        )
+        if prev_mma:
+            add_reshape_if_needed(custom_mma, prev_mma)
 
     return mapping, mma_slices
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -289,11 +289,14 @@ def get_mma_dimensional_mapping(
                 return prev_mma
         return None
 
+    # Look in the backward slices of both the LHS and RHS to find
+    # mmas. If found, add reshapes if necessary.
     for mma in mma_nodes:
         custom_mma = get_custom(mma)
-        prev_mma = find_mma_in_slice(custom_mma.lhs) or find_mma_in_slice(
-            custom_mma.rhs
-        )
+        prev_mma = find_mma_in_slice(custom_mma.lhs)
+        if prev_mma:
+            add_reshape_if_needed(custom_mma, prev_mma)
+        prev_mma = find_mma_in_slice(custom_mma.rhs)
         if prev_mma:
             add_reshape_if_needed(custom_mma, prev_mma)
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -6,7 +6,11 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.utils import run_test
+from iree.turbine.kernel.wave.utils import (
+    run_test,
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+)
 import torch
 
 M = tkl.sym.M
@@ -763,11 +767,12 @@ def test_chained_gemm():
     constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
     constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
 
+    mfma_variant = tkw.MMAType.F32_16x16x16_F16
     constraints += [
         tkw.HardwareConstraint(
             threads_per_wave=64,
             waves_per_block=(2, 2, 1),
-            mma_type=tkw.MMAType.F32_16x16x16_F16,
+            mma_type=mfma_variant,
             vector_shapes={B: 0},
         )
     ]
@@ -808,8 +813,8 @@ def test_chained_gemm():
             BLOCK_N: 64,
             BLOCK_K2: 32,
             BLOCK_B: 1,
-            LOAD_ELEMS_PER_THREAD: 4,
-            STORE_ELEMS_PER_THREAD: 4,
+            LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+            STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
             ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
             ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
         },
@@ -826,6 +831,90 @@ def test_chained_gemm():
         # CHECK-COUNT-8:       {{.*}} = amdgpu.mfma
         # CHECK-COUNT-4:       {{.*}} = arith.truncf
         # CHECK-COUNT-8:       {{.*}} = amdgpu.mfma
+        # CHECK:             scf.yield
+
+
+@run_test
+def test_chained_gemm_32x32x8():
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    mfma_variant = tkw.MMAType.F32_32x32x8_F16
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0},
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def chained_gemm_32x32x8(
+        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
+
+        @tkw.reduction(K2, init_args=[c_reg])
+        def repeat(
+            acc: tkl.Register[B, M, N, tkl.f32]
+        ) -> tkl.Register[B, M, N, tkl.f32]:
+            inner_acc = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            kq_reg = tkw.mma(k_reg, q_reg, inner_acc)
+            qk_reg = tkw.permute(kq_reg, target_shape=[B, M, K2])
+            qk_cast_reg = tkw.cast(qk_reg, tkl.f16)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            acc = tkw.mma(qk_cast_reg, v_reg, acc)
+            return acc
+
+        tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    with tk.gen.TestLaunchContext(
+        {
+            M: 128,
+            N: 128,
+            K1: 32,
+            K2: 256,
+            B: 8,
+            BLOCK_M: 64,
+            BLOCK_N: 64,
+            BLOCK_K2: 32,
+            BLOCK_B: 1,
+            LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+            STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+    ):
+        q = torch.randn(8, 64, 64, dtype=torch.float16)
+        k = torch.randn(8, 256, 64, dtype=torch.float16)
+        v = torch.zeros(8, 128, 256, dtype=torch.float16)
+        output = torch.zeros(8, 64, 128, dtype=torch.float32)
+        print(chained_gemm_32x32x8(q, k, v, output).module_op)
+
+        # CHECK:           func.func @chained_gemm_32x32x8(
+        # CHECK:             {{.*}} = scf.for
+        # CHECK-COUNT-4:       {{.*}} = amdgpu.mfma
+        # CHECK-COUNT-1:       {{.*}} = arith.truncf
+        # CHECK:               {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [0], sizes = [4], strides = [1]}
+        # CHECK:               {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [4], sizes = [4], strides = [1]}
+        # CHECK:               {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [8], sizes = [4], strides = [1]}
+        # CHECK:               {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [12], sizes = [4], strides = [1]}
+        # CHECK-COUNT-4:       {{.*}} = amdgpu.mfma
         # CHECK:             scf.yield
 
 

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -62,6 +62,7 @@ def get_test_shapes(test_name: str) -> list[tuple[int]]:
     "mfma_variant",
     [
         MMAType.F32_16x16x16_F16,
+        MMAType.F32_32x32x8_F16,
     ],
 )
 def testChainedGemm(
@@ -262,6 +263,7 @@ def testAttention(
         c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
         init_sum = tkl.Register[B, M, tkl.f32](0.0)
         init_max = tkl.Register[B, M, tkl.f32](-1e6)
+
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
         @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -198,6 +198,155 @@ def testChainedGemm(
         assert_close(output, iree_ref)
 
 
+# This test requires some more analysis on the index sequences between
+# the two chained GEMMs.
+@require_e2e
+@pytest.mark.xfail
+@pytest.mark.parametrize("shape", get_test_shapes("test_attention"))
+@pytest.mark.parametrize("enable_scheduling", [False])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x32_F8,
+        MMAType.F32_32x32x16_F8,
+    ],
+)
+def testChainedGemm_f8(
+    shape: tuple[int], enable_scheduling: bool, mfma_variant: MMAType, request
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3, inputs={B: i, M: j, N: k}, outputs={B: i, N: k, M: j}
+    )
+
+    @tkw.wave(constraints)
+    def chained_gemm_f8(
+        q: tkl.Memory[B, M, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, N, M, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
+
+        @tkw.reduction(K2, init_args=[c_reg])
+        def repeat(
+            acc: tkl.Register[B, M, N, tkl.f32]
+        ) -> tkl.Register[B, M, N, tkl.f32]:
+            inner_acc = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            q_reg = tkw.cast(q_reg, tkl.f8e4m3fnuz)
+            k_reg = tkw.cast(k_reg, tkl.f8e4m3fnuz)
+            kq_reg = tkw.mma(k_reg, q_reg, inner_acc)
+            qk_reg = tkw.permute(kq_reg, target_shape=[B, M, K2])
+            qk_cast_reg = tkw.cast(qk_reg, tkl.f8e4m3fnuz)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            v_reg = tkw.cast(v_reg, tkl.f8e4m3fnuz)
+            acc = tkw.mma(qk_cast_reg, v_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(
+            repeat, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD
+        )
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        BLOCK_B: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 32,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K1: shape[3],
+        K2: shape[4],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+    }
+    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+    ):
+        q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = torch.randn(shape[0], shape[2], shape[4], dtype=torch.float16)
+        output = torch.zeros(shape[0], shape[2], shape[1], dtype=torch.float32)
+        mb = chained_gemm_f8(q, k, v, output)
+
+        if test_dump_generated_mlir:
+            filename = f"wave_cgemm_{'x'.join(map(str, shape))}.mlir"
+            with open(filename, "w") as f:
+                f.write(mb.module_op.get_asm())
+
+        iree_ref = torch.zeros(shape[0], shape[2], shape[1], dtype=torch.float32)
+        generate_iree_ref(
+            "chain_mmt_f8", [q, k, v], [iree_ref], config, run_bench=run_bench
+        )
+        assert_close(output, iree_ref)
+
+
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_attention"))
 @pytest.mark.parametrize("enable_scheduling", [False])


### PR DESCRIPTION
This PR adds support for expanding operators
with varying vector shapes, specifically for the
MMA case where either the same dimension has different vector shapes in different mmas or if different instructions are being used.

The idea is to insert a reshape operator whenever such a shape mismatch is discovered.  The reshape operator lowers to an extract or concatenate operation, depending on the context.