### PR TITLE
Add tensor tracing in eager mode

### DIFF
--- a/iree/turbine/ops/iree.py
+++ b/iree/turbine/ops/iree.py
@@ -6,6 +6,8 @@
 
 """Custom ops for built-in IREE functionality."""
 from typing import cast
+import numpy as np
+import os
 
 from ..support.ir_imports import (
     Attribute,
@@ -23,6 +25,8 @@ from ..runtime.op_reg import (
     AttrArg,
     def_library,
 )
+
+from ..support import debugging
 
 __all__ = [
     "trace",
@@ -45,6 +49,9 @@ class trace_tensor(CustomOp):
     def select(self, ksel: KernelSelection):
         ksel.attr_str(0)
         ksel.arg_tensor(1, inplace_tied=True)
+
+    def eager_execute(self, key, tensor):
+        debugging.trace_tensor_callback(key, tensor)
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         key = cast(AttrArg, ksel.arg_descs[0])

--- a/iree/turbine/support/debugging.py
+++ b/iree/turbine/support/debugging.py
@@ -6,15 +6,21 @@
 
 """Debug flags and settings."""
 
-from typing import Optional
+from typing import Callable, Optional
 from dataclasses import dataclass
 import logging
 import re
 import os
+import torch
+import numpy as np
 
 __all__ = [
+    "default_trace_tensor_callback",
     "flags",
     "NDEBUG",
+    "trace_tensor_callback",
+    "trace_tensor_to_npy",
+    "TraceTensorCallback",
 ]
 
 # We use the native logging vs our .logging setup because our logging depends
@@ -99,3 +105,15 @@ class DebugFlags:
 
 
 flags = DebugFlags.parse_from_env()
+
+TraceKey = str
+TraceTensorCallback = Callable[[TraceKey, torch.Tensor], None]
+
+
+def trace_tensor_to_npy(key: TraceKey, tensor: torch.Tensor):
+    if flags.runtime_trace_dir is not None:
+        np.save(os.path.join(flags.runtime_trace_dir, f"{key}.npy"), tensor)
+
+
+default_trace_tensor_callback = trace_tensor_to_npy
+trace_tensor_callback = default_trace_tensor_callback


### PR DESCRIPTION
We don't trace in eager mode in `ops.iree.trace_tensor`.

This adds the ability to set a tensor trace callback with a default implementation that records the tensor to a npy file.