### PR TITLE
Bump iree-requirements-ci.txt to the latest stable release.

### DIFF
--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -1,7 +1,10 @@
-# Meant for CI jobs. We want to pin to a specific nightly version.
-# A normal user is supposed to install from iree-requirements.txt where we are
-# more forgiving on the exact version.
+# Requirements for CI jobs.
+#
+# Developer may want to install from iree-requirements.txt where we are more
+# forgiving on the exact version.
 
---find-links https://iree.dev/pip-release-links.html
-iree-compiler==20240918.1020
-iree_runtime==20240918.1020
+# Uncomment to select a nightly version.
+# --find-links https://iree.dev/pip-release-links.html
+
+iree-compiler==20241104.1068
+iree_runtime==20241104.1068

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -1139,7 +1139,7 @@ def handle_scheduling_group_barrier(emitter: WaveEmitter, node: fx.Node):
         mask = arith_d.constant(IntegerType.get_signless(32), mask)
         counts = arith_d.constant(IntegerType.get_signless(32), counts)
         llvm_d.call_intrinsic(
-            None, "llvm.amdgcn.sched.group.barrier", [mask, counts, sync_id]
+            None, "llvm.amdgcn.sched.group.barrier", [mask, counts, sync_id], [], []
         )
 
 


### PR DESCRIPTION
This release was just promoted to stable: https://github.com/iree-org/iree/releases/tag/candidate-20241104.1068. As we align the versions across projects (https://github.com/iree-org/iree/issues/18938), we should aim to use stable versions or at least test nightly versions with care.