### PR TITLE
Bump version to 2.5.0 and document release process.

### DIFF
--- a/.github/workflows/test_build_release.yml
+++ b/.github/workflows/test_build_release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build Release Wheels
-        run: ./build_tools/build_release.py --core-version 2.3.0
+        run: ./build_tools/build_release.py --package-version 2.5.0.dev
 
       - name: Validate Release Build
         if: ${{ !cancelled() }}

--- a/build_tools/build_release.py
+++ b/build_tools/build_release.py
@@ -34,15 +34,23 @@ IREE_PLATFORM_ARGS = [
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.10"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.11"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.12"],
+    ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.13"],
+    ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.13t"],
     # Linux x86_64
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.9"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.10"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.11"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.12"],
+    ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.13"],
+    ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.13t"],
     # MacOS
     ["--platform", "macosx_13_0_universal2", "--python-version", "3.11"],
+    ["--platform", "macosx_13_0_universal2", "--python-version", "3.12"],
+    ["--platform", "macosx_13_0_universal2", "--python-version", "3.13"],
     # Windows
     ["--platform", "win_amd64", "--python-version", "3.11"],
+    ["--platform", "win_amd64", "--python-version", "3.12"],
+    ["--platform", "win_amd64", "--python-version", "3.13"],
 ]
 
 
@@ -55,13 +63,13 @@ def write_version_info(args):
     with open(VERSION_INFO_FILE, "rt") as f:
         info_dict = json.load(f)
 
-    # Compute core-version.
-    core_version = eval_version(args.core_version)
-    if args.core_pre_version:
-        core_version += eval_version(args.core_pre_version)
-    if args.core_post_version:
-        core_version += f".{eval_version(args.core_post_version)}"
-    info_dict["core-version"] = core_version
+    # Compute package-version.
+    package_version = eval_version(args.package_version)
+    if args.package_pre_version:
+        package_version += eval_version(args.package_pre_version)
+    if args.package_post_version:
+        package_version += f".{eval_version(args.package_post_version)}"
+    info_dict["package-version"] = package_version
 
     with open(VERSION_INFO_FILE, "wt") as f:
         json.dump(info_dict, f)
@@ -112,12 +120,16 @@ def download_iree_binaries():
         ]
         args.extend(platform_args)
         args += [
-            "-f",
-            "https://iree.dev/pip-release-links.html",
+            # Uncomment to allow nightly releases (if not pinned in the file)
+            # "-f",
+            # "https://iree.dev/pip-release-links.html",
             "-f",
             WHEEL_DIR,
+            # Note: could also drop `-ci` here, if coordinating a release
+            # across projects and new stable versions of the IREE packages
+            # haven't yet been pushed.
             "-r",
-            REPO_ROOT / "iree-requirements.txt",
+            REPO_ROOT / "iree-requirements-ci.txt",
         ]
         exec(args)
 
@@ -130,16 +142,14 @@ def build_wheel(path, env=None):
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--package-version", help="Version to use", required=True)
     parser.add_argument(
-        "--core-version", help="Version for the core component", required=True
-    )
-    parser.add_argument(
-        "--core-pre-version",
+        "--package-pre-version",
         help="Pre-release version segment or (YYYYMMDD)",
         default="",
     )
     parser.add_argument(
-        "--core-post-version",
+        "--package-post-version",
         help="Post-release version segment or (YYYYMMDD)",
         default="",
     )

--- a/build_tools/build_release.py
+++ b/build_tools/build_release.py
@@ -35,14 +35,14 @@ IREE_PLATFORM_ARGS = [
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.11"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.12"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.13"],
-    ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.13t"],
+    # ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.13t"],
     # Linux x86_64
     # ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.9"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.10"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.11"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.12"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.13"],
-    ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.13t"],
+    # ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.13t"],
     # MacOS
     ["--platform", "macosx_13_0_universal2", "--python-version", "3.11"],
     ["--platform", "macosx_13_0_universal2", "--python-version", "3.12"],

--- a/build_tools/build_release.py
+++ b/build_tools/build_release.py
@@ -30,14 +30,14 @@ WHEEL_DIR = REPO_ROOT / "wheelhouse"
 # a specific wheel".
 IREE_PLATFORM_ARGS = [
     # Linux aarch64
-    ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.9"],
+    # ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.9"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.10"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.11"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.12"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.13"],
     ["--platform", "manylinux_2_28_aarch64", "--python-version", "3.13t"],
     # Linux x86_64
-    ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.9"],
+    # ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.9"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.10"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.11"],
     ["--platform", "manylinux_2_28_x86_64", "--python-version", "3.12"],

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,76 @@
+
+# Releasing SHARK-Turbine/core
+
+There are multiple release artifacts that are deployed from this project:
+
+* shark-turbine wheel (transitional while switching to iree-turbine)
+* iree-turbine wheel
+* iree-compiler wheels
+* iree-runtime wheels
+
+Typically we deploy IREE compiler and runtime wheels along with a turbine
+release, effectively promoting a nightly.
+
+## Building Artifacts
+
+Build a pre-release:
+
+```
+./build_tools/build_release.py --core-version 2.3.0 --core-pre-version=rcYYYYMMDD
+```
+
+Build an official release:
+
+```
+./build_tools/build_release.py --core-version 2.3.0
+```
+
+This will download all deps, including wheels for all supported platforms and
+Python versions for iree-compiler and iree-runtime. All wheels will be placed
+in the `wheelhouse/` directory.
+
+
+## Testing
+
+TODO: Write a script for this.
+
+```
+python -m venv wheelhouse/test.venv
+source wheelhouse/test.venv/bin/activate
+pip install -f wheelhouse iree-turbine[testing]
+# Temp: tests require torchvision.
+pip install -f wheelhouse torchvision
+pytest core/tests
+```
+
+## Push
+
+From the testing venv, verify that everything is sane:
+
+```
+pip freeze
+```
+
+Push IREE deps (if needed/updated):
+
+```
+twine upload wheelhouse/iree_compiler-* wheelhouse/iree_runtime-*
+```
+
+Push built wheels:
+
+```
+twine upload wheelhouse/iree_turbine-* wheelhouse/shark_turbine-*
+```
+
+## Install from PyPI and Sanity Check
+
+TODO: Script this
+
+From the testing venv:
+
+```
+pip uninstall -y shark-turbine iree-turbine iree-compiler iree-runtime
+pip install iree-turbine
+pytest core/tests
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,66 +1,59 @@
+# Releasing iree-turbine
 
-# Releasing SHARK-Turbine/core
-
-There are multiple release artifacts that are deployed from this project:
-
-* shark-turbine wheel (transitional while switching to iree-turbine)
-* iree-turbine wheel
-* iree-compiler wheels
-* iree-runtime wheels
-
-Typically we deploy IREE compiler and runtime wheels along with a turbine
-release, effectively promoting a nightly.
+This project hosts the https://pypi.org/project/iree-turbine/ package, which
+depends on the https://pypi.org/project/iree-compiler/ and
+https://pypi.org/project/iree-runtime/ packages. Releases can either be
+conducted independently, or they can be coordinated across projects by
+initiating a release here.
 
 ## Building Artifacts
 
 Build a pre-release:
 
-```
-./build_tools/build_release.py --core-version 2.3.0 --core-pre-version=rcYYYYMMDD
+```bash
+./build_tools/build_release.py --package-version 2.5.0 --package-pre-version=rcYYYYMMDD
 ```
 
 Build an official release:
 
-```
-./build_tools/build_release.py --core-version 2.3.0
+```bash
+./build_tools/build_release.py --package-version 2.5.0
 ```
 
 This will download all deps, including wheels for all supported platforms and
 Python versions for iree-compiler and iree-runtime. All wheels will be placed
 in the `wheelhouse/` directory.
 
-
 ## Testing
 
-TODO: Write a script for this.
+```bash
+./build_tools/post_build_release_test.sh
+```
 
-```
-python -m venv wheelhouse/test.venv
-source wheelhouse/test.venv/bin/activate
-pip install -f wheelhouse iree-turbine[testing]
-# Temp: tests require torchvision.
-pip install -f wheelhouse torchvision
-pytest core/tests
-```
+This will
+
+1. Set up a python virtual environment using your default `python` version
+2. Install wheels from the `wheelhouse/` directory
+3. Run `pytest` tests
 
 ## Push
 
 From the testing venv, verify that everything is sane:
 
-```
+```bash
 pip freeze
 ```
 
 Push IREE deps (if needed/updated):
 
-```
+```bash
 twine upload wheelhouse/iree_compiler-* wheelhouse/iree_runtime-*
 ```
 
 Push built wheels:
 
-```
-twine upload wheelhouse/iree_turbine-* wheelhouse/shark_turbine-*
+```bash
+twine upload wheelhouse/iree_turbine-*
 ```
 
 ## Install from PyPI and Sanity Check
@@ -69,8 +62,8 @@ TODO: Script this
 
 From the testing venv:
 
-```
-pip uninstall -y shark-turbine iree-turbine iree-compiler iree-runtime
+```bash
+pip uninstall -y iree-turbine iree-compiler iree-runtime
 pip install iree-turbine
-pytest core/tests
+pytest .
 ```

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def load_version_info():
 
 
 version_info = load_version_info()
-PACKAGE_VERSION = version_info["core-version"]
+PACKAGE_VERSION = version_info["package-version"]
 
 packages = find_namespace_packages(
     include=[

--- a/version_info.json
+++ b/version_info.json
@@ -1,1 +1,3 @@
-{"core-version": "2.3.0rc20240621", "package-version": "0.9.7.dev1"}
+{
+    "package-version": "2.5.0"
+}


### PR DESCRIPTION
The `docs/releasing.md` file was first introduced next to the `build_release.py` script in https://github.com/nod-ai/SHARK-ModelDev/pull/605. I don't see that file in this repository (iree-org/iree-turbine) though, despite https://github.com/nod-ai/SHARK-ModelDev/pull/655 claiming that it had been upstreamed. Since the packages involved have changed over the months (shark-turbine --> iree-turbine naming, see also https://github.com/iree-org/iree-turbine/issues/28), I also updated the document to reflect the current setup.

The `iree-requirements.txt` file was being used to pin versions of the `iree-compiler` and `iree-runtime` that would be released together with this `iree-turbine` package. That was overlooked when https://github.com/iree-org/iree-turbine/pull/115 removed pins from that file. I've reworked the script to reference `iree-requirements-ci.txt` for now, but we can continue to iterate on the cross-project release process going forward (with docs this time).

I've updated the version in code from 2.3.0 to 2.5.0. We can push a release to https://github.com/iree-org/iree-turbine/releases and https://pypi.org/project/iree-turbine/#history using the new version next. Note that 2.3.1, 2.4.0, and 2.4.1 were released to PyPI without updating the code or GitHub releases.