### PR TITLE
Switch to new IREE package names and versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ commits locally, hooks will run. See https://pre-commit.com/
 ### Using a development compiler
 
 If doing native development of the compiler, it can be useful to switch to
-source builds for iree-compiler and iree-runtime.
+source builds for iree-base-compiler and iree-base-runtime.
 
-In order to do this, check out [IREE](https://github.com/openxla/iree) and
+In order to do this, check out [IREE](https://github.com/iree-org/iree) and
 follow the instructions to [build from source](https://iree.dev/building-from-source/getting-started/), making
 sure to specify [additional options for the Python bindings](https://iree.dev/building-from-source/getting-started/#building-with-cmake):
 
@@ -130,11 +130,10 @@ sure to specify [additional options for the Python bindings](https://iree.dev/bu
 
 #### Configuring python
 
-Uninstall existing packages:
+Uninstall existing packages (including any with the old package names):
 
 ```bash
-pip uninstall iree-compiler
-pip uninstall iree-runtime
+pip uninstall iree-compiler iree-base-compiler iree-runtime iree-base-runtime
 ```
 
 Copy the `.env` file from `iree/` to this source directory to get IDE

--- a/build_tools/post_pypi_release_test.sh
+++ b/build_tools/post_pypi_release_test.sh
@@ -13,7 +13,7 @@ WHEELHOUSE_DIR="${REPO_ROOT?}/wheelhouse"
 
 # Use same environment from build_release, but uninstall the local wheels
 source "${WHEELHOUSE_DIR}"/test.venv/bin/activate
-pip uninstall -y shark-turbine iree-turbine iree-compiler iree-runtime
+pip uninstall -y iree-turbine iree-base-compiler iree-base-runtime
 
 # Install from pypi now that latest is released
 pip install iree-turbine

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing iree-turbine
 
 This project hosts the https://pypi.org/project/iree-turbine/ package, which
-depends on the https://pypi.org/project/iree-compiler/ and
-https://pypi.org/project/iree-runtime/ packages. Releases can either be
+depends on the https://pypi.org/project/iree-base-compiler/ and
+https://pypi.org/project/iree-base-runtime/ packages. Releases can either be
 conducted independently, or they can be coordinated across projects by
 initiating a release here.
 
@@ -21,8 +21,8 @@ Build an official release:
 ```
 
 This will download all deps, including wheels for all supported platforms and
-Python versions for iree-compiler and iree-runtime. All wheels will be placed
-in the `wheelhouse/` directory.
+Python versions for iree-base-compiler and iree-base-runtime. All wheels will
+be placed in the `wheelhouse/` directory.
 
 ## Testing
 
@@ -47,7 +47,7 @@ pip freeze
 Push IREE deps (if needed/updated):
 
 ```bash
-twine upload wheelhouse/iree_compiler-* wheelhouse/iree_runtime-*
+twine upload wheelhouse/iree_base_compiler-* wheelhouse/iree_base_runtime-*
 ```
 
 Push built wheels:
@@ -58,12 +58,8 @@ twine upload wheelhouse/iree_turbine-*
 
 ## Install from PyPI and Sanity Check
 
-TODO: Script this
-
 From the testing venv:
 
 ```bash
-pip uninstall -y iree-turbine iree-compiler iree-runtime
-pip install iree-turbine
-pytest .
+./build_tools/post_pypi_release_test.sh
 ```

--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -6,5 +6,8 @@
 # Uncomment to select a nightly version.
 # --find-links https://iree.dev/pip-release-links.html
 
-iree-base-compiler==2.9.0
-iree-base-runtime==2.9.0
+# Uncomment to skip versions from PyPI (so _only_ nightly versions).
+# --no-index
+
+iree-base-compiler~=2.9.0
+iree-base-runtime~=2.9.0

--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -6,5 +6,5 @@
 # Uncomment to select a nightly version.
 # --find-links https://iree.dev/pip-release-links.html
 
-iree-compiler==20241104.1068
-iree_runtime==20241104.1068
+iree-base-compiler==2.9.0
+iree-base-runtime==2.9.0

--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -9,5 +9,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler~=2.9.0
-iree-base-runtime~=2.9.0
+iree-base-compiler<=2.9.0
+iree-base-runtime<=2.9.0

--- a/iree-requirements.txt
+++ b/iree-requirements.txt
@@ -1,2 +1,2 @@
-iree-compiler
-iree-runtime
+iree-base-compiler
+iree-base-runtime

--- a/iree/turbine/aot/builtins/globals.py
+++ b/iree/turbine/aot/builtins/globals.py
@@ -222,7 +222,7 @@ class export_buffers(GlobalsDef, TreeAbstractifiable):
         return self._tree[key]
 
     def __repr__(self):
-        names = [name for name, _ in self._param_list]
+        names = [name for name, _ in self._buffer_list]
         return f"<export_buffers {', '.join(names)}>"
 
 

--- a/iree/turbine/aot/support/procedural/exported_program.py
+++ b/iree/turbine/aot/support/procedural/exported_program.py
@@ -252,8 +252,9 @@ class _Hooks(FxImporterHooks):
             raise ValueError(f"Cannot store value to unmapped global for: {info}")
         logger.debug("Resolved  global for store %r", mapping)
         materialized_global: MaterializedGlobal = mapping.value  # type: ignore
-        assert isinstance(materialized_global.global_op, util_d.GlobalOp)
-        materialized_global.global_op.is_mutable = True
+        materialized_global_op_opview = materialized_global.global_op.opview
+        assert isinstance(materialized_global_op_opview, util_d.GlobalOp)
+        materialized_global_op_opview.is_mutable = True
         converted_value = Operation.create(
             "torch_c.to_builtin_tensor",
             results=[materialized_global.ir_type],

--- a/iree/turbine/dynamo/tensor.py
+++ b/iree/turbine/dynamo/tensor.py
@@ -194,7 +194,7 @@ class Storage:
         device._tx_timepoint += 1
         signal_sem = (device._tx_timeline, device._tx_timepoint)
         hal_device.queue_execute(
-            [cb], wait_semaphores=self.ready_fence, signal_semaphores=[signal_sem]
+            cb, wait_semaphores=self.ready_fence, signal_semaphores=[signal_sem]
         )
         self.ready_fence.insert(*signal_sem)
 

--- a/setup.py
+++ b/setup.py
@@ -104,8 +104,8 @@ setup(
     },
     install_requires=[
         f"numpy{get_version_spec('numpy')}",
-        f"iree-compiler{get_version_spec('iree-compiler')}",
-        f"iree-runtime{get_version_spec('iree-runtime')}",
+        f"iree-base-compiler{get_version_spec('iree-base-compiler')}",
+        f"iree-base-runtime{get_version_spec('iree-base-runtime')}",
         "torch>=2.3.0",
         f"Jinja2{get_version_spec('Jinja2')}",
     ],


### PR DESCRIPTION
IREE is renaming its Python packages from `iree-compiler` and `iree-runtime` to `iree-base-compiler` and `iree-base-runtime`, in order to switch to a new versioning scheme: https://github.com/iree-org/iree/issues/18938. This switches to using the new package names and versions and cleans up some related documentation along the way.

Note: the new packages are not yet built and published, hence this is a draft PR. Once packages are published we can rebase, test this, and then proceed.