### PR TITLE
Bump iree-requirements-ci incrementally to 20241106.1070.

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -61,7 +61,7 @@ jobs:
       if: "contains(matrix.os, 'mi300') && !cancelled()"
       run: |
         export WAVE_RUN_E2E_TESTS=1
-        pytest -n 4 --capture=tee-sys -vv ./tests/kernel/wave/
+        pytest -n 4 --timeout=60 --capture=tee-sys -vv ./tests/kernel/wave/
 
     - name: Run LIT tests
       if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Run unit tests
       if: ${{ !cancelled() }}
       run: |
-        pytest -n 4 --capture=tee-sys -vv .
+        pytest -n 4 --capture=tee-sys -vv --ignore=tests/kernel/wave/ .
 
     - name: Run LIT tests
       if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Run unit tests
       if: ${{ !cancelled() }}
       run: |
-        pytest -n 4 --capture=tee-sys -vv --ignore=tests/kernel/wave/ .
+        pytest -n 4 --timeout=60 --capture=tee-sys -vv --ignore=tests/kernel/wave/ .
 
     - name: Run LIT tests
       if: ${{ !cancelled() }}

--- a/build_tools/post_build_release_test.sh
+++ b/build_tools/post_build_release_test.sh
@@ -22,4 +22,4 @@ pip install --no-index -f "${WHEELHOUSE_DIR}" torchvision
 pip freeze
 
 # Run tests
-pytest -n 4 --ignore=tests/kernel/wave/ "${REPO_ROOT}"
+pytest -n 4 --timeout=60 --ignore=tests/kernel/wave/ "${REPO_ROOT}"

--- a/build_tools/post_build_release_test.sh
+++ b/build_tools/post_build_release_test.sh
@@ -22,4 +22,4 @@ pip install --no-index -f "${WHEELHOUSE_DIR}" torchvision
 pip freeze
 
 # Run tests
-pytest -n 4 "${REPO_ROOT}"
+pytest -n 4 --ignore=tests/kernel/wave/ "${REPO_ROOT}"

--- a/build_tools/post_pypi_release_test.sh
+++ b/build_tools/post_pypi_release_test.sh
@@ -19,4 +19,4 @@ pip uninstall -y shark-turbine iree-turbine iree-compiler iree-runtime
 pip install iree-turbine
 
 # Run tests
-pytest -n 4 --ignore=tests/kernel/wave/ "${REPO_ROOT}"
+pytest -n 4 --timeout=60 --ignore=tests/kernel/wave/ "${REPO_ROOT}"

--- a/build_tools/post_pypi_release_test.sh
+++ b/build_tools/post_pypi_release_test.sh
@@ -19,4 +19,4 @@ pip uninstall -y shark-turbine iree-turbine iree-compiler iree-runtime
 pip install iree-turbine
 
 # Run tests
-pytest -n 4 "${REPO_ROOT}"
+pytest -n 4 --ignore=tests/kernel/wave/ "${REPO_ROOT}"

--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -4,7 +4,7 @@
 # forgiving on the exact version.
 
 # Uncomment to select a nightly version.
-# --find-links https://iree.dev/pip-release-links.html
+--find-links https://iree.dev/pip-release-links.html
 
-iree-compiler==20241104.1068
-iree_runtime==20241104.1068
+iree-compiler==20241106.1070
+iree_runtime==20241106.1070

--- a/iree/turbine/dynamo/tensor.py
+++ b/iree/turbine/dynamo/tensor.py
@@ -194,7 +194,7 @@ class Storage:
         device._tx_timepoint += 1
         signal_sem = (device._tx_timeline, device._tx_timepoint)
         hal_device.queue_execute(
-            [cb], wait_semaphores=self.ready_fence, signal_semaphores=[signal_sem]
+            cb, wait_semaphores=self.ready_fence, signal_semaphores=[signal_sem]
         )
         self.ready_fence.insert(*signal_sem)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 # Build/test requirements.
+# TODO: move these to requirements-dev.txt
 Jinja2==3.1.3
 filecheck==1.0.0
 numpy==1.26.3
 parameterized==0.9.0
 pytest==8.0.0
+pytest-timeout==2.3.1
 pytest-xdist==3.5.0
 lit==18.1.7
 mypy==1.8.0

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
         "testing": [
             f"pytest{get_version_spec('pytest')}",
             f"pytest-xdist{get_version_spec('pytest-xdist')}",
+            f"pytest-timeout{get_version_spec('pytest-timeout')}",
             f"parameterized{get_version_spec('parameterized')}",
         ],
     },


### PR DESCRIPTION
I'm seeing all sorts of test failures on https://github.com/iree-org/iree-turbine/pull/258 when I try to roll up to the latest stable release with new package names and versions (`iree-base-compiler<=2.9.0`). Trying an incremental update while debugging that.