### PR TITLE
Increment package version to 3.0.0

### DIFF
--- a/version_info.json
+++ b/version_info.json
@@ -1,3 +1,3 @@
 {
-    "package-version": "2.9.1"
+    "package-version": "3.0.0"
 }


### PR DESCRIPTION
This increments the package version to 3.0.0 which is the version number for the next stable release. In contrast to the iree-base-* packages, no `.dev` suffix is added as the `version_info.json` file is included as is in the python package (see `MANIFEST.in`).