### PR TITLE
[TKW] Implement MFMA F8 intrinsic/layout with interleaved reads based on VGPR

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1255,6 +1255,16 @@ class ExtractSlice(CustomOp):
     def type(self) -> "Register":
         return get_custom(self.register_).type
 
+    @property
+    def rank(self) -> int:
+        offset_rank = len(self.offset)
+        size_rank = len(self.size)
+        stride_rank = len(self.stride)
+        assert (
+            offset_rank == size_rank == stride_rank
+        ), "Expected offset, size, and stride to have same rank."
+        return size_rank
+
 
 @define_op("broadcast")
 @dataclass

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -1393,7 +1393,6 @@ def handle_reshape(emitter: WaveEmitter, node: fx.Node):
         raise ValidationError("Malformed arguments") from e
     custom = get_custom(node)
     innermost_dim = custom.type.symbolic_shape[-1]
-    offset = custom.expanded_dims[innermost_dim]
 
     # Determine whether to extract or combine.
     if len(args) > 1:
@@ -1421,6 +1420,7 @@ def handle_reshape(emitter: WaveEmitter, node: fx.Node):
     # actual offset, we need to multiply by the size. The size is obtained by
     # computing the number of partitions using the source and target vector shapes
     # and dividing the incoming vector shape by the number of partitions.
+    offset = custom.expanded_dims[innermost_dim]
     num_partitions = (
         target_vector_shapes[innermost_dim] // custom.vector_shapes[innermost_dim]
     )

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -1392,7 +1392,6 @@ def handle_reshape(emitter: WaveEmitter, node: fx.Node):
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
     custom = get_custom(node)
-    innermost_dim = custom.type.symbolic_shape[-1]
 
     # Determine whether to extract or combine.
     if len(args) > 1:
@@ -1420,6 +1419,7 @@ def handle_reshape(emitter: WaveEmitter, node: fx.Node):
     # actual offset, we need to multiply by the size. The size is obtained by
     # computing the number of partitions using the source and target vector shapes
     # and dividing the incoming vector shape by the number of partitions.
+    innermost_dim = custom.type.symbolic_shape[-1]
     offset = custom.expanded_dims[innermost_dim]
     num_partitions = (
         target_vector_shapes[innermost_dim] // custom.vector_shapes[innermost_dim]

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -230,7 +230,7 @@ class HardwareConstraint(Constraint):
                     1,  # N
                     1,  # K
                 ]
-            case MMAType.F32_16x16x32_F8 | MMAType.I32_16x16x32_I8:
+            case MMAType.F32_16x16x32_F8 | MMAType.F32_16x16x32_K4_F8 | MMAType.I32_16x16x32_I8:
                 offset = [
                     Piecewise(
                         (lane % 16, ~MMA_ACC), (4 * floor(lane / 16), MMA_ACC)
@@ -248,7 +248,7 @@ class HardwareConstraint(Constraint):
                     1,  # N
                     1,  # K
                 ]
-            case MMAType.F32_32x32x16_F8 | MMAType.I32_32x32x16_I8:
+            case MMAType.F32_32x32x16_F8 | MMAType.F32_32x32x16_K4_F8 | MMAType.I32_32x32x16_I8:
                 offset = [
                     Piecewise(
                         (lane % 32, ~MMA_ACC),
@@ -272,52 +272,22 @@ class HardwareConstraint(Constraint):
                     1,  # N
                     1,  # K
                 ]
-            case MMAType.F32_16x16x32_K4_F8:
-                offset = [
-                    Piecewise(
-                        (lane % 16, ~MMA_ACC), (4 * floor(lane / 16), MMA_ACC)
-                    ),  # M
-                    lane % 16,  # N
-                    (16 * floor(GPR_NUM / 4))
-                    + 4 * floor(lane / 16)
-                    + (GPR_NUM % 4),  # K
-                ]
-                size = [
-                    Piecewise((1, ~MMA_ACC), (4, MMA_ACC)),  # M
-                    1,  # N
-                    8,  # K
-                ]
-                stride = [
-                    Piecewise((1, ~MMA_ACC), (16, MMA_ACC)),  # M
-                    1,  # N
-                    16,  # K
-                ]
-            case MMAType.F32_32x32x16_K4_F8:
-                offset = [
-                    Piecewise(
-                        (lane % 32, ~MMA_ACC),
-                        (
-                            (8 * floor(GPR_NUM / 4) % 32)
-                            + 4 * floor(lane / 32)
-                            + (GPR_NUM % 4),
-                            MMA_ACC,
-                        ),
-                    ),  # M
-                    lane % 32,  # N
-                    (8 * floor(GPR_NUM / 4))
-                    + 4 * floor(lane / 32)
-                    + (GPR_NUM % 4),  # K
-                ]
-                size = [
-                    Piecewise((1, ~MMA_ACC), (16, MMA_ACC)),  # M
-                    1,  # N
-                    8,  # K
-                ]
-                stride = [
-                    Piecewise((1, ~MMA_ACC), (32, MMA_ACC)),  # M
-                    1,  # N
-                    1,  # K
-                ]
+                if self.mma_type == MMAType.F32_32x32x16_K4_F8:
+                    offset = [
+                        Piecewise(
+                            (lane % 32, ~MMA_ACC),
+                            (
+                                (8 * floor(GPR_NUM / 4) % 32)
+                                + 4 * floor(lane / 32)
+                                + (GPR_NUM % 4),
+                                MMA_ACC,
+                            ),
+                        ),  # M
+                        lane % 32,  # N
+                        (8 * floor(GPR_NUM / 4))
+                        + 4 * floor(lane / 32)
+                        + (GPR_NUM % 4),  # K
+                    ]
             case _:
                 raise ValueError("Unsupported MMA type")
         assert isinstance(

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -248,6 +248,16 @@ class HardwareConstraint(Constraint):
                     1,  # N
                     1,  # K
                 ]
+                if self.mma_type == MMAType.F32_16x16x32_K4_F8:
+                    offset = [
+                        Piecewise(
+                            (lane % 16, ~MMA_ACC), (4 * floor(lane / 16), MMA_ACC)
+                        ),  # M
+                        lane % 16,  # N
+                        (16 * floor(GPR_NUM / 4))
+                        + 4 * floor(lane / 16)
+                        + (GPR_NUM % 4),  # K
+                    ]
             case MMAType.F32_32x32x16_F8 | MMAType.F32_32x32x16_K4_F8 | MMAType.I32_32x32x16_I8:
                 offset = [
                     Piecewise(

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -278,9 +278,9 @@ class HardwareConstraint(Constraint):
                         (lane % 16, ~MMA_ACC), (4 * floor(lane / 16), MMA_ACC)
                     ),  # M
                     lane % 16,  # N
-                    (
-                        (16 * floor(GPR_NUM / 4)) + 4 * floor(lane / 16) + (GPR_NUM % 4)
-                    ),  # K
+                    (16 * floor(GPR_NUM / 4))
+                    + 4 * floor(lane / 16)
+                    + (GPR_NUM % 4),  # K
                 ]
                 size = [
                     Piecewise((1, ~MMA_ACC), (4, MMA_ACC)),  # M

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -65,9 +65,13 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
         """
         custom = get_custom(node)
         if isinstance(custom, Write):
-            strides = [simplify_index(custom.index[dim]).stride for dim in custom.index]
+            strides = [
+                simplify_index(custom.register_index[dim]).stride
+                for dim in custom.register_index
+            ]
             elements_per_thread = [
-                simplify_index(custom.index[dim]).size for dim in custom.index
+                simplify_index(custom.register_index[dim]).size
+                for dim in custom.register_index
             ]
             strides = [x for x, y in zip(strides, elements_per_thread) if y > 1]
             num_strided_accesses = sum(1 for stride in strides if stride > 1)
@@ -83,7 +87,7 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
     for operator in strided_operators:
         custom = get_custom(operator)
         simplified_index = {
-            dim: simplify_index(custom.index.get(dim, custom.index[dim]))
+            dim: simplify_index(custom.register_index.get(dim, custom.index[dim]))
             for dim in custom.index
         }
 
@@ -212,6 +216,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                     extract = ExtractSlice(
                         custom.register_, [cur_gpr_start_id], [gpr_size], [1]
                     ).add_to_graph(custom.graph)
+                    extract.index = updated_index_with_gpr_offset
                     new_node = Write(
                         extract,
                         custom.memory,

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -178,7 +178,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                 next_gpr_offset = gpr_offset_expr.subs({GPR_NUM: i + 1})
                 cur_gpr_offset = gpr_offset_expr.subs({GPR_NUM: i})
                 gpr_offset_step = next_gpr_offset - cur_gpr_offset
-                if not isinstance(gpr_offset_step, sympy.Integer):
+                if not gpr_offset_step.is_number:
                     raise NotImplementedError(
                         "Only constant integer GPR offset steps supported."
                     )
@@ -189,9 +189,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                 if gpr_offset_step > 1 or i == elements_per_thread - 1:
                     # Get VGPR number of elements.
                     gpr_size = (cur_gpr_offset - gpr_cur_base_offset) + 1
-                    assert isinstance(
-                        gpr_size, sympy.Integer
-                    ), "Expected gpr_size to be int."
+                    assert gpr_size.is_number, "Expected gpr_size to be int."
                     gpr_size = int(gpr_size)
 
                     # Get updated index with VGPR offset.

--- a/iree/turbine/kernel/wave/minimize_global_loads.py
+++ b/iree/turbine/kernel/wave/minimize_global_loads.py
@@ -50,12 +50,13 @@ def construct_min_global_access_pattern(
     It takes a 1-D global offset and delinearizes it to a multi-dimensional offset
     and updates the access pattern accordingly.
     """
-    thread_ids = [THREAD_0, THREAD_1, THREAD_2]
+    thread_ids = [THREAD_0, THREAD_1, THREAD_2, GPR_NUM]
     new_index = {key: index[key].subs({t: 0 for t in thread_ids}) for key in index}
     nd_index = delinearize_index(thread_id, shape)
     for i, key in enumerate(index.keys()):
         new_index[key].start += nd_index[i]
         new_index[key].size = load_elems_per_thread if i == len(index.keys()) - 1 else 1
+        new_index[key].stride = 1
     return new_index
 
 
@@ -150,6 +151,7 @@ def add_optimized_nodes(
                         ).add_to_graph(custom.graph)
                         write.index = read.index
                         optimized_writes[custom_user.memory].append(write)
+                        write.vector_shapes = custom.vector_shapes
                         break
     return optimized_writes
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -939,13 +939,9 @@ def get_mfma_load_elems_per_thread(mfma_variant: MMAType) -> int:
             return 4
         case MMAType.F32_32x32x8_F16 | MMAType.I32_32x32x8_I8:
             return 4
-        case MMAType.F32_16x16x32_F8 | MMAType.I32_16x16x32_I8:
+        case MMAType.F32_16x16x32_F8 | MMAType.F32_16x16x32_K4_F8 | MMAType.I32_16x16x32_I8:
             return 8
-        case MMAType.F32_32x32x16_F8 | MMAType.I32_32x32x16_I8:
-            return 8
-        case MMAType.F32_16x16x32_K4_F8:
-            return 8
-        case MMAType.F32_32x32x16_K4_F8:
+        case MMAType.F32_32x32x16_F8 | MMAType.F32_32x32x16_K4_F8 | MMAType.I32_32x32x16_I8:
             return 8
 
 
@@ -955,13 +951,9 @@ def get_mfma_store_elems_per_thread(mfma_variant: MMAType) -> int:
             return 4
         case MMAType.F32_32x32x8_F16 | MMAType.I32_32x32x8_I8:
             return 16
-        case MMAType.F32_16x16x32_F8 | MMAType.I32_16x16x32_I8:
+        case MMAType.F32_16x16x32_F8 | MMAType.F32_16x16x32_K4_F8 | MMAType.I32_16x16x32_I8:
             return 4
-        case MMAType.F32_32x32x16_F8 | MMAType.I32_32x32x16_I8:
-            return 16
-        case MMAType.F32_16x16x32_K4_F8:
-            return 4
-        case MMAType.F32_32x32x16_K4_F8:
+        case MMAType.F32_32x32x16_F8 | MMAType.F32_32x32x16_K4_F8 | MMAType.I32_32x32x16_I8:
             return 16
 
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -945,6 +945,8 @@ def get_mfma_load_elems_per_thread(mfma_variant: MMAType) -> int:
             return 8
         case MMAType.F32_16x16x32_K4_F8:
             return 8
+        case MMAType.F32_32x32x16_K4_F8:
+            return 8
 
 
 def get_mfma_store_elems_per_thread(mfma_variant: MMAType) -> int:
@@ -959,6 +961,8 @@ def get_mfma_store_elems_per_thread(mfma_variant: MMAType) -> int:
             return 16
         case MMAType.F32_16x16x32_K4_F8:
             return 4
+        case MMAType.F32_32x32x16_K4_F8:
+            return 16
 
 
 def all_equal(input_list: list[Any]) -> bool:

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -917,6 +917,8 @@ def get_mfma_load_elems_per_thread(mfma_variant: MMAType) -> int:
             return 8
         case MMAType.F32_32x32x16_F8 | MMAType.I32_32x32x16_I8:
             return 8
+        case MMAType.F32_16x16x32_K4_F8:
+            return 8
 
 
 def get_mfma_store_elems_per_thread(mfma_variant: MMAType) -> int:
@@ -929,6 +931,8 @@ def get_mfma_store_elems_per_thread(mfma_variant: MMAType) -> int:
             return 4
         case MMAType.F32_32x32x16_F8 | MMAType.I32_32x32x16_I8:
             return 16
+        case MMAType.F32_16x16x32_K4_F8:
+            return 4
 
 
 def all_equal(input_list: list[Any]) -> bool:

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -28,6 +28,7 @@ from .utils import (
     compile_and_invoke,
     safe_subs,
     remove_chained_getresult,
+    remove_chained_extractslice,
     subs_idxc,
 )
 from .minimize_global_loads import minimize_global_loads
@@ -38,6 +39,7 @@ from ..lang.global_symbols import *
 from ..ops import wave_ops
 from ..ops.wave_ops import Reduction, CustomOp, get_custom
 from .index_sequence_analysis import (
+    partition_ops_with_gpr_offsets,
     partition_strided_operators,
     set_node_indices,
     set_post_expansion_indices,
@@ -254,7 +256,9 @@ class LaunchableWave(Launchable):
         apply_shared_memory_indexing_corrections(graph, self.constraints)
 
         # Partition strided operators.
+        partition_ops_with_gpr_offsets(graph, self.constraints)
         partition_strided_operators(graph, self.constraints)
+        remove_chained_extractslice(graph)
 
         # Decompose reduce Ops.
         decompose_reduce_ops(graph, self.constraints, idxc.subs)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -638,7 +638,7 @@ def testF8Gemm(
                 )
         iree_ref = torch.zeros(shape[0], shape[1], dtype=torch.float32)
         generate_iree_ref("mmt_f8", [a, b], [iree_ref], config, run_bench=run_bench)
-        assert_close(c, iree_ref, check_device=False)
+        assert_close(c, iree_ref, atol=3e-5, rtol=3e-4, check_device=False)
 
 
 @require_e2e

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -524,6 +524,7 @@ def testCDNA3IntGemm(
     "mfma_variant",
     [
         MMAType.F32_16x16x32_F8,
+        MMAType.F32_16x16x32_K4_F8,
         MMAType.F32_32x32x16_F8,
     ],
 )

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -526,6 +526,7 @@ def testCDNA3IntGemm(
         MMAType.F32_16x16x32_F8,
         MMAType.F32_16x16x32_K4_F8,
         MMAType.F32_32x32x16_F8,
+        MMAType.F32_32x32x16_K4_F8,
     ],
 )
 def testF8Gemm(


### PR DESCRIPTION
In order to enable Fp8 attention, we first need introduce the same 16x16x32xf8 intrinsic with k-Width=4. This is required S.T we can use it for the second gemm/contraction in attention so that the layouts between the gemms will match and we won't have to do a round trip to shared memory. 

 Since the native size of 16x16x32xf8 is kWidth=8, this new virtual intrinsic with k-Width=4, will need to do two interleaved reads of 4xf8 instead of a single 8xf8 read. This interleaved reads will looks something like:
 
 ```
 [0, 0, 0, 0, 16, 16, 16, 16, 32, 32, 32, 32, 48, 48, 48, 48, 0, 0, 0, 0, 16, 16, 16, 16, 32, 32, 32, 32, 48, 48, 48, 48]
 Where the entry represent the lane it is owned by. 
 ```
 
 We can see that in this case, since lane0 needs data from index [0:4) and index[16:20), we'd need to do two separate reads (into two "VGPR"s) and combined them later on with insert_slices. Each of this contiguous chunk we'd consider/call
VGPR chunks. 

Below is a feature list that we need to implement to support the above use cases:
1. Introduce a new virtual 16x16x32_F8 intrinsic/layout that has the strided/interleaved VGPR reads
2. Spin out the VGPR splitting from `partition_strided_operators` into a standalone `partition_ops_with_gpr_offsets`
3. Add support to handle Read(Originally just handled write) for `partition_ops_with_gpr_offsets`
4. Implement canonicalization pattern to handle chained of extract slice in `remove_chained_extractslice`. This is to have cleaner code and conserve the structure of output IR that is impacted from the split of `partition_strided_operators`.
5. Modify `minimize_global_loads` to also overwrite indices with GPR_OFFSET.
