### PR TITLE
Add support for dynamic parallel dims in GEMMs

### DIFF
--- a/iree/turbine/kernel/wave/__init__.py
+++ b/iree/turbine/kernel/wave/__init__.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ..ops.wave_ops import *
+from .assumptions import *
 from .constraints import *
 from .wave import *
 from .wave import IndexMapping

--- a/iree/turbine/kernel/wave/assumptions.py
+++ b/iree/turbine/kernel/wave/assumptions.py
@@ -1,0 +1,29 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from .._support.indexing import IndexExpr
+
+
+@dataclass
+class Assumption:
+    """
+    Assumptions are sympy assumptions that can be used to
+    make decisions during code generation. These can be
+    statements such as bounds on sympy variables. For example,
+    we can state that
+
+    Assumption(M < 64)
+
+    and then later make queries based on this assumption, such as
+
+    evaluate(M > 70) -> False
+    evaluate(M < 32) -> None (because we cannot say one way or the other)
+    evaluate(M < 70) -> True
+
+    """
+
+    expr: IndexExpr

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -17,6 +17,7 @@ from ..ops.wave_ops import (
     Reshape,
 )
 from .constraints import Constraint, HardwareConstraint, WorkgroupConstraint
+from .assumptions import Assumption
 from .._support.tracing import CapturedTrace, IndexingContext
 from .._support.indexing import IndexSymbol, IndexSequence
 from ..lang.global_symbols import *
@@ -260,7 +261,7 @@ def set_node_index(
         c.dim: c for c in constraints if isinstance(c, WorkgroupConstraint)
     }
     other_constraints = [
-        c for c in constraints if not isinstance(c, HardwareConstraint)
+        c for c in constraints if not isinstance(c, (HardwareConstraint, Assumption))
     ]
     # Apply hardware constraint first since it dictates the stride and size.
     sorted_constraints = hardware_constraint + other_constraints

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -256,11 +256,6 @@ class LaunchableWave(Launchable):
         # Partition strided operators.
         partition_strided_operators(graph, self.constraints)
 
-        # Align sizes to WG/Tile sizes
-        # This pass changes indexing keys, which can interfere with other passes,
-        # so it should be called close to the end of pipeline.
-        align_index_sizes(graph, self.constraints)
-
         # Decompose reduce Ops.
         decompose_reduce_ops(graph, self.constraints, idxc.subs)
 
@@ -277,6 +272,11 @@ class LaunchableWave(Launchable):
         if kwargs.get("schedule", False):
             use_scheduling_barriers = kwargs.get("use_scheduling_barriers", False)
             schedule_graph(graph, self.constraints, use_scheduling_barriers)
+
+        # Align sizes to WG/Tile sizes
+        # This pass changes indexing keys, which can interfere with other passes,
+        # so it should be called close to the end of pipeline.
+        align_index_sizes(graph, self.constraints)
 
         # Add shared memory barriers.
         add_shared_memory_barriers(graph)

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -404,14 +404,8 @@ def test_dynamic_copy():
         a = torch.randn(16, 16, dtype=torch.float16)
         print(test(a).module_op)
 
-    # CHECK:        stream.executable.export public @test workgroups(%[[ARG0:.*]]: index, %[[ARG1:.*]]:
-    # CHECK-SAME:       index) -> (index, index, index) {
-    # CHECK-DAG:        %[[C1:.+]] = arith.constant 1 : index
-    # CHECK-DAG:        %[[C16:.+]] = arith.constant 16 : index
-    # CHECK:            %[[D0:.+]] = arith.ceildivsi %[[ARG0]], %[[C16]] : index
-    # CHECK:            %[[D1:.+]] = arith.ceildivsi %[[ARG1]], %[[C16]] : index
-    # CHECK:            stream.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
-    # CHECK:          }
+    # TODO: Add stream.executable workgroup check once we lower ceildiv using arith-expand.
+
     # CHECK:          func.func @test(%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index)
     # CHECK-SAME:       attributes {translation_info = #[[TRANSLATION:.+]]} {
     # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf16>
@@ -1170,6 +1164,102 @@ def test_gemm_pipelined():
         # CHECK-COUNT-4:    amdgpu.mfma
         # CHECK-COUNT-1:    amdgpu.lds_barrier
         # CHECK-COUNT-6:    vector.load
+        # CHECK-COUNT-3:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+        # CHECK-COUNT-4:    vector.load
+        # CHECK-COUNT-1:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+        # CHECK-COUNT-4:    amdgpu.mfma
+        # CHECK-COUNT-1:    amdgpu.lds_barrier
+        # CHECK-COUNT-2:    vector.store
+        # CHECK-COUNT-2:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
+        # CHECK-COUNT-1:    scf.yield
+        # CHECK-COUNT-4:    amdgpu.mfma
+        # CHECK-COUNT-1:    amdgpu.lds_barrier
+        # CHECK-COUNT-8:    vector.load
+        # CHECK-COUNT-8:    amdgpu.mfma
+
+
+@run_test
+def test_dynamic_gemm_pipelined():
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def dynamic_gemm_pipelined(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        @tkw.reduction(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    with tk.gen.TestLaunchContext(
+        {
+            BLOCK_M: 64,
+            BLOCK_N: 64,
+            BLOCK_K: 32,
+            LOAD_ELEMS_PER_THREAD: 4,
+            STORE_ELEMS_PER_THREAD: 4,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+            READ_SHARED_DELAY: 1,
+            WRITE_SHARED_DELAY: 1,
+            READ_GLOBAL_DELAY: 2,
+            WRITE_GLOBAL_DELAY: 2,
+            MMA_DELAY: 1,
+            VALU_DELAY: 1,
+            SHUFFLE_DELAY: 1,
+            SHARED_MEMORY_UNITS: 4,
+            GLOBAL_MEMORY_UNITS: 4,
+            MMA_UNITS: 4,
+            VALU_UNITS: 8,
+            SHUFFLE_UNITS: 8,
+        },
+        canonicalize=True,
+        schedule=True,
+        use_scheduling_barriers=True,
+        dynamic_symbols=(M, N, K),
+        dynamic_symbols_map={M: 64, N: 128, K: 32},
+    ):
+        a = torch.randn(64, 32, dtype=torch.float16)
+        b = torch.randn(128, 32, dtype=torch.float16)
+        c = torch.zeros(64, 128, dtype=torch.float32)
+        print(dynamic_gemm_pipelined(a, b, c).module_op)
+
+        # CHECK:          func.func @dynamic_gemm_pipelined
+        # CHECK-COUNT-2:    vector.maskedload
+        # CHECK-COUNT-2:    vector.store
+        # CHECK-COUNT-1:    amdgpu.lds_barrier
+        # CHECK-COUNT-4:    vector.load
+        # CHECK-COUNT-2:    vector.maskedload
+        # CHECK-COUNT-4:    vector.load
+        # CHECK-COUNT-4:    amdgpu.mfma
+        # CHECK-COUNT-1:    amdgpu.lds_barrier
+        # CHECK-COUNT-2:    vector.store
+        # CHECK-COUNT-1:    arith.maxsi
+        # CHECK-COUNT-1:    scf.for
+        # CHECK-COUNT-4:    amdgpu.mfma
+        # CHECK-COUNT-1:    amdgpu.lds_barrier
+        # CHECK-COUNT-4:    vector.load
+        # CHECK-COUNT-2:    vector.maskedload
         # CHECK-COUNT-3:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"
         # CHECK-COUNT-4:    vector.load
         # CHECK-COUNT-1:    llvm.call_intrinsic "llvm.amdgcn.sched.group.barrier"

--- a/tests/kernel/wave/assumptions_test.py
+++ b/tests/kernel/wave/assumptions_test.py
@@ -1,0 +1,35 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import pytest
+import unittest
+from iree.turbine.kernel.lang import sym
+from iree.turbine.kernel.wave.assumptions import Assumption
+from iree.turbine.kernel.wave.utils import evaluate_with_assumptions
+from iree.turbine.kernel._support.indexing import IndexingContext
+from iree.turbine.kernel._support.context import push
+
+M = sym.M
+N = sym.N
+BLOCK_N = sym.BLOCK_N
+BLOCK_M = sym.BLOCK_K
+I = sym.I
+
+
+class AssumptionsTest(unittest.TestCase):
+    def testAssumption(self):
+        push(IndexingContext, IndexingContext())
+        constraints: list[Assumption] = []
+        constraints.append(Assumption(M < 64))
+        assert evaluate_with_assumptions(constraints, M > 70) == False
+        assert evaluate_with_assumptions(constraints, M < 70) == True
+        assert evaluate_with_assumptions(constraints, M < 32) is None
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -107,6 +107,11 @@ def testGemm(
         )
     ]
 
+    # With dynamic dimensions, we need to add an assumption on how big
+    # the reduction dimension is to determine whether we can schedule or not.
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K > BLOCK_K * 4)]
+
     # Wave-level micro-kernel.
     # Since warps are not directly addressable, there is no
     # explicit notion of a warp id (like a workgroup or thread id).


### PR DESCRIPTION
This PR adds tests for dynamic M and N dims in
GEMMs. This works out of the box for the most part
    and just requires moving the align index pass
    after scheduling.
