### PR TITLE
Update LLVM patch instructions

### DIFF
--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -263,10 +263,9 @@ class LaunchableWave(Launchable):
         # Scheduling should always be used with use_scheduling_barriers=True,
         # as this is the only way we can ensure that LLVM enforces our desired schedule.
         # However, due a bug in LLVM, you will need to patch your local LLVM repo
-        # with the following PR: https://github.com/kerbowa/llvm-project/commit/ee52732cddae42deed2e3387a83b20ec05860b4e
+        # with the following commit: https://github.com/kerbowa/llvm-project/commit/ee52732cddae42deed2e3387a83b20ec05860b4e
         # Specifically:
-        # git remote add sched_fixes https://github.com/kerbowa/llvm-project.git
-        # git fetch sched_fixes
+        # git fetch https://github.com/kerbowa/llvm-project.git ee52732cddae42deed2e3387a83b20ec05860b4e
         # git cherry-pick ee52732cddae42deed2e3387a83b20ec05860b4e
         # [Manually resolve conflicts consistent with the PR]
         if kwargs.get("schedule", False):


### PR DESCRIPTION
This updates the instructions for patching LLVM with the fixes to preserve our scheduling decisions.

The old instructions do not fetch the commit anymore. The cherry-pick yielded the error: `fatal: bad object ee52732cddae42deed2e3387a83b20ec05860b4e`.
I changed this to only fetch the relevant commit.