### PR TITLE
Modify codegen lowering to use ceildiv

### DIFF
--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -10,5 +10,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.1.0rc20241121
-iree-base-runtime==3.1.0rc20241121
+iree-base-compiler==3.1.0rc20241122
+iree-base-runtime==3.1.0rc20241122

--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -10,5 +10,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.1.0rc20241120
-iree-base-runtime==3.1.0rc20241120
+iree-base-compiler==3.1.0rc20241121
+iree-base-runtime==3.1.0rc20241121

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -331,18 +331,7 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> OpR
 
     def _ceiling(value):
         if isinstance(value, _Rational):
-            # TODO: This is the expansion of ceildivui, but we should figure
-            # out how to run the arith-expand pass instead of doing this.
-            # ceildivui(x, y) = x == 0 ? 0 : ((x - 1) / y) + 1
-            one = _get_const(1)
-            zero = _get_const(0)
-            lhs_minus_one = arith_d.subi(*_broadcast(value.numerator, one))
-            div = arith_d.divui(*_broadcast(lhs_minus_one, value.denominator))
-            result = arith_d.addi(*_broadcast(div, one))
-            cmp = arith_d.cmpi(
-                arith_d.CmpIPredicate.eq, *_broadcast(value.numerator, zero)
-            )
-            value = arith_d.select(cmp, zero, result)
+            value = arith_d.ceildivsi(*_broadcast(value.numerator, value.denominator))
 
         return value
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -468,8 +468,14 @@ def test_dynamic_copy():
         a = torch.randn(16, 16, dtype=torch.float16)
         print(test(a).module_op)
 
-    # TODO: Add stream.executable workgroup check once we lower ceildiv using arith-expand.
-
+    # CHECK:        stream.executable.export public @test workgroups(%[[ARG0:.*]]: index, %[[ARG1:.*]]:
+    # CHECK-SAME:       index) -> (index, index, index) {
+    # CHECK-DAG:        %[[C1:.+]] = arith.constant 1 : index
+    # CHECK-DAG:        %[[C16:.+]] = arith.constant 16 : index
+    # CHECK:            %[[D0:.+]] = arith.ceildivsi %[[ARG0]], %[[C16]] : index
+    # CHECK:            %[[D1:.+]] = arith.ceildivsi %[[ARG1]], %[[C16]] : index
+    # CHECK:            stream.return %[[D0]], %[[D1]], %[[C1]] : index, index, index
+    # CHECK:          }
     # CHECK:          func.func @test(%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index)
     # CHECK-SAME:       attributes {translation_info = #[[TRANSLATION:.+]]} {
     # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf16>


### PR DESCRIPTION
Previously, ceildiv did not lower through the IREE backend and so we had to manually add the decomposition of ceildiv in codegen. Now, that the upstream PR has landed, we can go back to using ceildiv in codegen.