### PR TITLE
[TKW] Enable each MMA to have it's own intrinsic

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -865,6 +865,7 @@ class MMA(CustomOp):
     lhs: fx.Node
     rhs: fx.Node
     acc: fx.Node
+    mma_type: Optional["MMAType"] = None
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -888,7 +888,7 @@ def emit_mfma(
 @handle_op(mma)
 def handle_mma(emitter: WaveEmitter, node: fx.Node):
     try:
-        lhs, rhs, acc = node.args
+        lhs, rhs, acc, mma_type = node.args
         acc = cast_vector(emitter, acc)
         values = [cast_vector(emitter, val) for val in [lhs, rhs]]
     except ValueError as e:
@@ -904,7 +904,7 @@ def handle_mma(emitter: WaveEmitter, node: fx.Node):
     if not hardware_constraints:
         raise CodegenError("No hardware constraints found.")
 
-    m, n, k = hardware_constraints[0].mma_matrix_shapes
+    m, n, k = hardware_constraints[0].mma_matrix_shapes(mma_type)
     result = emit_mfma(m, n, k, vector_type, acc, values)
     emitter.bind_node_proxy(node, IRProxyValue(result))
 

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -121,10 +121,11 @@ class HardwareConstraint(Constraint):
             case _:
                 raise ValueError("Invalid workgroup dimension. Expected 0, 1 or 2.")
 
-    @property
-    def mma_matrix_shapes(self) -> tuple[int]:
+    def mma_matrix_shapes(self, mma_type: Optional[MMAType]) -> tuple[int]:
         # TODO: Eventually the shapes and indices should be provided by a tool
-        match self.mma_type:
+        if mma_type == None:
+            mma_type = self.mma_type
+        match mma_type:
             case MMAType.F32_16x16x16_F16 | MMAType.I32_16x16x16_I8:
                 return (16, 16, 16)
             case MMAType.F32_32x32x8_F16 | MMAType.I32_32x32x8_I8:
@@ -179,13 +180,16 @@ class HardwareConstraint(Constraint):
         elements_per_thread: int | IndexSymbol,
         stride: int,
         is_mma_dim: bool,
+        mma_type: MMAType,
     ) -> IndexSequence:
         if not is_mma_dim:
             return self.compute_access_pattern_using_vector_shapes(
                 dim, constraint_index, elements_per_thread, stride
             )
         lane = self.linearized_thread_id % self.threads_per_wave
-        match self.mma_type:
+        if mma_type == None:
+            mma_type = self.mma_type
+        match mma_type:
             # (M x K, N x K) -> M x N
             case MMAType.F32_16x16x16_F16 | MMAType.I32_16x16x16_I8:
                 offset = [
@@ -248,7 +252,7 @@ class HardwareConstraint(Constraint):
                     1,  # N
                     1,  # K
                 ]
-                if self.mma_type == MMAType.F32_16x16x32_K4_F8:
+                if mma_type == MMAType.F32_16x16x32_K4_F8:
                     offset = [
                         Piecewise(
                             (lane % 16, ~MMA_ACC), (4 * floor(lane / 16), MMA_ACC)
@@ -282,7 +286,7 @@ class HardwareConstraint(Constraint):
                     1,  # N
                     1,  # K
                 ]
-                if self.mma_type == MMAType.F32_32x32x16_K4_F8:
+                if mma_type == MMAType.F32_32x32x16_K4_F8:
                     offset = [
                         Piecewise(
                             (lane % 32, ~MMA_ACC),

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -439,8 +439,9 @@ def set_node_index(
                         # dependence in the dimensional index.
                         # TODO: Evaluate if this is a valid case.
                         continue
+                mma_type = anchor.mma_type if anchor else None
                 index_seq = constraint.apply(
-                    dim, *inputs, anchor and dim in mma_index[anchor]
+                    dim, *inputs, anchor and dim in mma_index[anchor], mma_type
                 )
                 if anchor and dim in mma_index[anchor]:
                     index_seq = specialize_index_sequence(

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -291,9 +291,9 @@ def get_mma_dimensional_mapping(
         mapping[custom][n] = MMAOperand.N
         mapping[custom][k] = MMAOperand.K
         custom.vector_shapes = {
-            m: hardware_constraint.mma_matrix_shapes[0],
-            n: hardware_constraint.mma_matrix_shapes[1],
-            k: hardware_constraint.mma_matrix_shapes[2],
+            m: hardware_constraint.mma_matrix_shapes(custom.mma_type)[0],
+            n: hardware_constraint.mma_matrix_shapes(custom.mma_type)[1],
+            k: hardware_constraint.mma_matrix_shapes(custom.mma_type)[2],
         }
         if hardware_constraint.vector_shapes:
             custom.vector_shapes.update(hardware_constraint.vector_shapes)

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -310,21 +310,21 @@ def test_gemm():
         # CHECK-SAME: (%b, 4, None, (), None)
 
         # CHECK-NEXT: %mma_0_0_0
-        # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
+        # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0, None)
         # CHECK-NEXT: %mma_0_0_1
-        # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0)
+        # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0, None)
         # CHECK-NEXT: %mma_1_1_0
-        # CHECK-SAME: (%read_1_0_0, %read_0_1_0, %acc_1_1_0)
+        # CHECK-SAME: (%read_1_0_0, %read_0_1_0, %acc_1_1_0, None)
         # CHECK-NEXT: %mma_1_1_1
-        # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_1_1_0)
+        # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_1_1_0, None)
         # CHECK-NEXT: %mma_1_0_0
-        # CHECK-SAME: (%read_1_0_0, %read_0_0_0, %acc_1_0_0)
+        # CHECK-SAME: (%read_1_0_0, %read_0_0_0, %acc_1_0_0, None)
         # CHECK-NEXT: %mma_1_0_1
-        # CHECK-SAME: (%read_1_0_1, %read_0_0_1, %mma_1_0_0)
+        # CHECK-SAME: (%read_1_0_1, %read_0_0_1, %mma_1_0_0, None)
         # CHECK-NEXT: %mma_0_1_0
-        # CHECK-SAME: (%read_0_0_0, %read_0_1_0, %acc_0_1_0)
+        # CHECK-SAME: (%read_0_0_0, %read_0_1_0, %acc_0_1_0, None)
         # CHECK-NEXT: %mma_0_1_1
-        # CHECK-SAME: (%read_0_0_1, %read_0_1_1, %mma_0_1_0)
+        # CHECK-SAME: (%read_0_0_1, %read_0_1_1, %mma_0_1_0, None)
         # CHECK-NEXT: return [mma_0_0_1, mma_0_1_1, mma_1_0_1, mma_1_1_1]
 
         # Custom format:
@@ -497,21 +497,21 @@ def test_batched_gemm():
         # CHECK-SAME: (%b, 4, None, (), None)
 
         # CHECK-NEXT: %mma_0_0_0
-        # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
+        # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0, None)
         # CHECK-NEXT: %mma_0_0_1
-        # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0)
+        # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0, None)
         # CHECK-NEXT: %mma_1_1_0
-        # CHECK-SAME: (%read_1_0_0, %read_0_1_0, %acc_1_1_0)
+        # CHECK-SAME: (%read_1_0_0, %read_0_1_0, %acc_1_1_0, None)
         # CHECK-NEXT: %mma_1_1_1
-        # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_1_1_0)
+        # CHECK-SAME: (%read_1_0_1, %read_0_1_1, %mma_1_1_0, None)
         # CHECK-NEXT: %mma_1_0_0
-        # CHECK-SAME: (%read_1_0_0, %read_0_0_0, %acc_1_0_0)
+        # CHECK-SAME: (%read_1_0_0, %read_0_0_0, %acc_1_0_0, None)
         # CHECK-NEXT: %mma_1_0_1
-        # CHECK-SAME: (%read_1_0_1, %read_0_0_1, %mma_1_0_0)
+        # CHECK-SAME: (%read_1_0_1, %read_0_0_1, %mma_1_0_0, None)
         # CHECK-NEXT: %mma_0_1_0
-        # CHECK-SAME: (%read_0_0_0, %read_0_1_0, %acc_0_1_0)
+        # CHECK-SAME: (%read_0_0_0, %read_0_1_0, %acc_0_1_0, None)
         # CHECK-NEXT: %mma_0_1_1
-        # CHECK-SAME: (%read_0_0_1, %read_0_1_1, %mma_0_1_0)
+        # CHECK-SAME: (%read_0_0_1, %read_0_1_1, %mma_0_1_0, None)
         # CHECK-NEXT: return [mma_0_0_1, mma_0_1_1, mma_1_0_1, mma_1_1_1]
 
         # Custom format:
@@ -610,21 +610,21 @@ def test_gemm_non_direct_acc():
         # CHECK: %add_0_1_0
         # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.add](args = (%exp2_0_0_0, %acc_0_1_0), kwargs = {})
         # CHECK: %mma_0_0_0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_0, %read_0_0_0, %add_0_0_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_0, %read_0_0_0, %add_0_0_0, None), kwargs = {})
         # CHECK: %mma_0_0_1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_1, %read_0_0_1, %mma_0_0_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_1, %read_0_0_1, %mma_0_0_0, None), kwargs = {})
         # CHECK: %mma_1_1_0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_0, %read_0_1_0, %add_1_1_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_0, %read_0_1_0, %add_1_1_0, None), kwargs = {})
         # CHECK: %mma_1_1_1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_1, %read_0_1_1, %mma_1_1_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_1, %read_0_1_1, %mma_1_1_0, None), kwargs = {})
         # CHECK: %mma_1_0_0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_0, %read_0_0_0, %add_1_0_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_0, %read_0_0_0, %add_1_0_0, None), kwargs = {})
         # CHECK: %mma_1_0_1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_1, %read_0_0_1, %mma_1_0_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_1_0_1, %read_0_0_1, %mma_1_0_0, None), kwargs = {})
         # CHECK: %mma_0_1_0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_0, %read_0_1_0, %add_0_1_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_0, %read_0_1_0, %add_0_1_0, None), kwargs = {})
         # CHECK: %mma_0_1_1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_1, %read_0_1_1, %mma_0_1_0), kwargs = {})
+        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_0_0_1, %read_0_1_1, %mma_0_1_0, None), kwargs = {})
 
 
 @tkw.wave_trace_only()
@@ -739,9 +739,9 @@ def test_gemm_reduction_expansion_only():
         # CHECK-SAME: (%b, 4, None, (), None)
 
         # CHECK-NEXT: %mma_0_0_0
-        # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0)
+        # CHECK-SAME: (%read_0_0_0, %read_0_0_0, %acc_0_0_0, None)
         # CHECK-NEXT: %mma_0_0_1
-        # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0)
+        # CHECK-SAME: (%read_0_0_1, %read_0_0_1, %mma_0_0_0, None)
 
         # CHECK-NEXT: return [mma_0_0_1]
 
@@ -932,13 +932,13 @@ def test_chained_gemm_32x32x8():
         # CHECK: %read_shared_0_0_3
         # CHECK-SAME: (args = (%k, 4, None, (), None)
         # CHECK: %mma_0_0_0
-        # CHECK-SAME: (args = (%read_shared_0_0_0, %read_0_0_0, %register)
+        # CHECK-SAME: (args = (%read_shared_0_0_0, %read_0_0_0, %register, None)
         # CHECK: %mma_0_0_1
-        # CHECK-SAME: (args = (%read_shared_0_0_1, %read_0_0_1, %mma_0_0_0)
+        # CHECK-SAME: (args = (%read_shared_0_0_1, %read_0_0_1, %mma_0_0_0, None)
         # CHECK: %mma_0_0_2
-        # CHECK-SAME: (args = (%read_shared_0_0_2, %read_0_0_2, %mma_0_0_1)
+        # CHECK-SAME: (args = (%read_shared_0_0_2, %read_0_0_2, %mma_0_0_1, None)
         # CHECK: %mma_0_0_3
-        # CHECK-SAME: (args = (%read_shared_0_0_3, %read_0_0_3, %mma_0_0_2)
+        # CHECK-SAME: (args = (%read_shared_0_0_3, %read_0_0_3, %mma_0_0_2, None)
         # CHECK: %permute_0_0
         # CHECK-SAME: (args = (%mma_0_0_3, [B, M, K2])
         # CHECK: %cast_0_0
@@ -961,13 +961,13 @@ def test_chained_gemm_32x32x8():
         # CHECK: %reshape_0_0_3
         # CHECK-SAME: (args = ([%cast_0_0], {K2: 32, M: 32, K1: 8, B: 0})
         # CHECK: %mma_0_0_0
-        # CHECK-SAME: (args = (%reshape_0_0_0, %read_shared_0_0_0, %acc_0_0_0)
+        # CHECK-SAME: (args = (%reshape_0_0_0, %read_shared_0_0_0, %acc_0_0_0, None)
         # CHECK: %mma_0_0_1
-        # CHECK-SAME: (args = (%reshape_0_0_1, %read_shared_0_0_1, %mma_0_0_0)
+        # CHECK-SAME: (args = (%reshape_0_0_1, %read_shared_0_0_1, %mma_0_0_0, None)
         # CHECK: %mma_0_0_2
-        # CHECK-SAME: (args = (%reshape_0_0_2, %read_shared_0_0_2, %mma_0_0_1)
+        # CHECK-SAME: (args = (%reshape_0_0_2, %read_shared_0_0_2, %mma_0_0_1, None)
         # CHECK: %mma_0_0_3
-        # CHECK-SAME: (args = (%reshape_0_0_3, %read_shared_0_0_3, %mma_0_0_2)
+        # CHECK-SAME: (args = (%reshape_0_0_3, %read_shared_0_0_3, %mma_0_0_2, None)
         # CHECK: return [mma_0_0_3]
 
 

--- a/lit_tests/kernel/wave/promotion.py
+++ b/lit_tests/kernel/wave/promotion.py
@@ -207,7 +207,7 @@ def test_gemm():
         # CHECK-NEXT: %read_3
         # CHECK-SAME: (%allocate_1, 4, None, (), [%write_1])
         # CHECK-NEXT: %mma
-        # CHECK-SAME: (%read_2, %read_3, %acc)
+        # CHECK-SAME: (%read_2, %read_3, %acc, None)
 
 
 if __name__ == "__main__":

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -120,7 +120,7 @@ def test_gemm_pipelined():
         # CHECK-NEXT: %rotating_reg_5
         # CHECK-NEXT: %rotating_reg_6
         # CHECK-NEXT: %mma_1_1_1
-        # CHECK-SAME: (%rotating_reg_1, %rotating_reg_4, %rotating_reg_6)
+        # CHECK-SAME: (%rotating_reg_1, %rotating_reg_4, %rotating_reg_6, None)
         # CHECK-NEXT: %read_shared_0_0_0
         # CHECK-NEXT: %read_shared_0_0_1
         # CHECK-NEXT: %read_4
@@ -130,29 +130,29 @@ def test_gemm_pipelined():
         # CHECK-NEXT: %read_shared_1_0_0
         # CHECK-NEXT: %read_shared_1_0_1
         # CHECK-NEXT: %mma_0_0_0
-        # CHECK-SAME: (%read_shared_0_0_0, %read_shared_0_0_1, %acc_0_0_0)
+        # CHECK-SAME: (%read_shared_0_0_0, %read_shared_0_0_1, %acc_0_0_0, None)
         # CHECK-NEXT: %mma_0_1_0
-        # CHECK-SAME: (%read_shared_0_0_0, %rotating_reg_3, %acc_0_1_0)
+        # CHECK-SAME: (%read_shared_0_0_0, %rotating_reg_3, %acc_0_1_0, None)
         # CHECK-NEXT: %scheduling_group_barrier
         # CHECK-SAME: ({Operation.READ_SHARED: 2, Operation.MMA: 2}, 0)
         # CHECK-NEXT: %mma_0_0_1
-        # CHECK-SAME: (%rotating_reg_0, %rotating_reg_2, %mma_0_0_0)
+        # CHECK-SAME: (%rotating_reg_0, %rotating_reg_2, %mma_0_0_0, None)
         # CHECK-NEXT: %mma_1_0_0
-        # CHECK-SAME: (%read_shared_1_0_0, %read_shared_0_0_1, %acc_1_0_0)
+        # CHECK-SAME: (%read_shared_1_0_0, %read_shared_0_0_1, %acc_1_0_0, None)
         # CHECK-NEXT: %write_2
         # CHECK-NEXT: %write_3
         # CHECK-NEXT: %scheduling_group_barrier
         # CHECK-SAME: ({Operation.MMA: 2, Operation.WRITE_SHARED: 2}, 0)
         # CHECK-NEXT: %mma_1_0_1
-        # CHECK-SAME: (%read_shared_1_0_1, %rotating_reg_2, %mma_1_0_0)
+        # CHECK-SAME: (%read_shared_1_0_1, %rotating_reg_2, %mma_1_0_0, None)
         # CHECK-NEXT: %mma_0_1_1
-        # CHECK-SAME: (%rotating_reg_0, %rotating_reg_5, %mma_0_1_0)
+        # CHECK-SAME: (%rotating_reg_0, %rotating_reg_5, %mma_0_1_0, None)
         # CHECK-NEXT: %read_shared_0_1_0
         # CHECK-NEXT: %read_shared_0_1_1
         # CHECK-NEXT: %scheduling_group_barrier
         # CHECK-SAME: ({Operation.MMA: 2, Operation.READ_SHARED: 2}, 0)
         # CHECK-NEXT: %mma_1_1_0
-        # CHECK-SAME: (%read_shared_1_0_0, %rotating_reg_3, %mma_1_1_1)
+        # CHECK-SAME: (%read_shared_1_0_0, %rotating_reg_3, %mma_1_1_1, None)
         # CHECK-NEXT: %read_shared_0_0_2
         # CHECK-NEXT: %read_shared_0_0_3
         # CHECK-NEXT: %scheduling_group_barrier
@@ -184,23 +184,23 @@ def test_gemm_pipelined():
         # CHECK-NEXT: %read_shared_1_0_0
         # CHECK-NEXT: %read_shared_1_0_1
         # CHECK-NEXT: %mma_0_0_0
-        # CHECK-SAME: (%read_shared_0_0_0, %read_shared_0_0_3, %register_0_0_0)
+        # CHECK-SAME: (%read_shared_0_0_0, %read_shared_0_0_3, %register_0_0_0, None)
         # CHECK-NEXT: %mma_0_1_0
-        # CHECK-SAME: (%read_shared_0_0_0, %read_shared_0_1_0, %register_0_1_0)
+        # CHECK-SAME: (%read_shared_0_0_0, %read_shared_0_1_0, %register_0_1_0, None)
         # CHECK-NEXT: %mma_0_0_1
-        # CHECK-SAME: (%read_shared_0_0_1, %read_shared_0_0_2, %mma_0_0_0)
+        # CHECK-SAME: (%read_shared_0_0_1, %read_shared_0_0_2, %mma_0_0_0, None)
         # CHECK-NEXT: %mma_1_0_0
-        # CHECK-SAME: (%read_shared_1_0_0, %read_shared_0_0_3, %register_1_0_0)
+        # CHECK-SAME: (%read_shared_1_0_0, %read_shared_0_0_3, %register_1_0_0, None)
         # CHECK-NEXT: %write_4
         # CHECK-NEXT: %write_5
         # CHECK-NEXT: %mma_1_0_1
-        # CHECK-SAME: (%read_shared_1_0_1, %read_shared_0_0_2, %mma_1_0_0)
+        # CHECK-SAME: (%read_shared_1_0_1, %read_shared_0_0_2, %mma_1_0_0, None)
         # CHECK-NEXT: %mma_0_1_1
-        # CHECK-SAME: (%read_shared_0_0_1, %read_shared_0_1_1, %mma_0_1_0)
+        # CHECK-SAME: (%read_shared_0_0_1, %read_shared_0_1_1, %mma_0_1_0, None)
         # CHECK-NEXT: %read_shared_0_1_2
         # CHECK-NEXT: %read_shared_0_1_3
         # CHECK-NEXT: %mma_1_1_0
-        # CHECK-SAME: (%read_shared_1_0_0, %read_shared_0_1_0, %register_1_1_0)
+        # CHECK-SAME: (%read_shared_1_0_0, %read_shared_0_1_0, %register_1_1_0, None)
         # CHECK-NEXT: %read_shared_0_0_4
         # CHECK-NEXT: %read_shared_0_0_5
         # CHECK-NEXT: %reduction_1
@@ -216,27 +216,27 @@ def test_gemm_pipelined():
         # CHECK-NEXT: %get_result_9
         # CHECK-NEXT: %get_result_10
         # CHECK-NEXT: %mma_1_1_1
-        # CHECK-SAME: (%get_result_5, %get_result_8, %get_result_10)
+        # CHECK-SAME: (%get_result_5, %get_result_8, %get_result_10, None)
         # CHECK-NEXT: %read_shared_0_0_6
         # CHECK-NEXT: %read_shared_0_0_7
         # CHECK-NEXT: %read_shared_1_0_2
         # CHECK-NEXT: %read_shared_1_0_3
         # CHECK-NEXT: %mma_0_0_2
-        # CHECK-SAME: (%read_shared_0_0_6, %read_shared_0_0_7, %getresult_0_0_0)
+        # CHECK-SAME: (%read_shared_0_0_6, %read_shared_0_0_7, %getresult_0_0_0, None)
         # CHECK-NEXT: %mma_0_1_2
-        # CHECK-SAME: (%read_shared_0_0_6, %get_result_7, %getresult_0_1_0)
+        # CHECK-SAME: (%read_shared_0_0_6, %get_result_7, %getresult_0_1_0, None)
         # CHECK-NEXT: %mma_0_0_3
-        # CHECK-SAME: (%get_result_4, %get_result_6, %mma_0_0_2)
+        # CHECK-SAME: (%get_result_4, %get_result_6, %mma_0_0_2, None)
         # CHECK-NEXT: %mma_1_0_2
-        # CHECK-SAME: (%read_shared_1_0_2, %read_shared_0_0_7, %getresult_1_0_0)
+        # CHECK-SAME: (%read_shared_1_0_2, %read_shared_0_0_7, %getresult_1_0_0, None)
         # CHECK-NEXT: %mma_1_0_3
-        # CHECK-SAME: (%read_shared_1_0_3, %get_result_6, %mma_1_0_2)
+        # CHECK-SAME: (%read_shared_1_0_3, %get_result_6, %mma_1_0_2, None)
         # CHECK-NEXT: %mma_0_1_3
-        # CHECK-SAME: (%get_result_4, %get_result_9, %mma_0_1_2)
+        # CHECK-SAME: (%get_result_4, %get_result_9, %mma_0_1_2, None)
         # CHECK-NEXT: %mma_1_1_2
-        # CHECK-SAME: (%read_shared_1_0_2, %get_result_7, %mma_1_1_1)
+        # CHECK-SAME: (%read_shared_1_0_2, %get_result_7, %mma_1_1_1, None)
         # CHECK-NEXT: %mma_1_1_3
-        # CHECK-SAME: (%read_shared_1_0_3, %get_result_9, %mma_1_1_2)
+        # CHECK-SAME: (%read_shared_1_0_3, %get_result_9, %mma_1_1_2, None)
         # CHECK-NEXT: %write_0_0_0
         # CHECK-NEXT: %write_1_1_0
         # CHECK-NEXT: %write_1_0_0

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -224,7 +224,7 @@ def testChainedGemm(
         (MMAType.F32_16x16x32_F8, MMAType.F32_16x16x32_K4_F8),
     ],
 )
-def testChainedGemm_f8(
+def testChainedGemmF8(
     shape: tuple[int], enable_scheduling: bool, mfma_variant: tuple[MMAType], request
 ):
     run_bench = request.config.getoption("--runperf")
@@ -342,6 +342,7 @@ def testChainedGemm_f8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
+        torch.manual_seed(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -357,7 +358,7 @@ def testChainedGemm_f8(
         generate_iree_ref(
             "chain_mmt_f8", [q, k, v], [iree_ref], config, run_bench=run_bench
         )
-        assert_close(output, iree_ref, check_device=False)
+        assert_close(output, iree_ref, atol=7e-5, rtol=2e-3, check_device=False)
 
 
 @require_e2e
@@ -560,3 +561,174 @@ def testAttention(
                 f.write(mb.module_op.get_asm())
 
         assert_allclose(output, torch_ref)
+
+
+@require_e2e
+@require_cdna3
+@pytest.mark.parametrize("shape", get_test_shapes("test_attention"))
+@pytest.mark.parametrize("enable_scheduling", [False, True])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        (MMAType.F32_32x32x16_F8, MMAType.F32_32x32x16_K4_F8),
+        (MMAType.F32_16x16x32_F8, MMAType.F32_16x16x32_K4_F8),
+    ],
+)
+def testAttentionF8(
+    shape: tuple[int], enable_scheduling: bool, mfma_variant: tuple[MMAType], request
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 1)]
+    if mfma_variant[0] == MMAType.F32_16x16x32_F8:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant[0] == MMAType.F32_32x32x16_F8:
+        Mvec = 32
+        Nvec = 32
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(4, 1, 1),
+            mma_type=mfma_variant[0],
+            vector_shapes={B: 0, M: Mvec, N: Nvec},
+        )
+    ]
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    )
+
+    @tkw.wave(constraints)
+    def base_attention(
+        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, M, tkl.f32],
+            partial_sum: tkl.Register[B, M, tkl.f32],
+            acc: tkl.Register[B, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            q_reg = tkw.cast(q_reg, tkl.f8e4m3fnuz)
+            k_reg = tkw.cast(k_reg, tkl.f8e4m3fnuz)
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
+            m_j = tkw.max(x_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f8e4m3fnuz)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            v_reg = tkw.cast(v_reg, tkl.f8e4m3fnuz)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc, mfma_variant[1])
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant[0]),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant[1]),
+        BLOCK_B: 1,
+        BLOCK_M: 128,
+        BLOCK_N: 64,
+        BLOCK_K2: 64,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K1: shape[3],
+        K2: shape[4],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        VALU_DELAY: 1,
+        SHUFFLE_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+        VALU_UNITS: 2,
+        SHUFFLE_UNITS: 2,
+    }
+    config = get_default_run_config()
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+    ):
+        torch.manual_seed(0)
+        q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)
+        output = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        log2e = 1.44269504089
+        dk_sqrt = math.sqrt(1.0 / shape[3])
+        # TODO: Add scaling of QK as part of kernel.
+        # TODO: Add variant of non-transposed V attention kernel.
+        mb = base_attention(q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output)
+        torch_ref = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=None
+        )
+        if test_dump_generated_mlir:
+            filename = f"wave_attention_{'x'.join(map(str, shape))}.mlir"
+            with open(filename, "w") as f:
+                f.write(mb.module_op.get_asm())
+        rmse = torch.sqrt(torch.mean(torch.square(output - torch_ref)))
+        assert rmse <= 0.006

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -657,11 +657,11 @@ def testAttentionF8(
             e_delta = tkw.exp2(x_j - m_j)
             e_init = partial_sum * e_delta_max
             d_j = tkw.sum(e_delta, e_init, dim=K2)
-            imm_f16 = tkw.cast(e_delta, tkl.f8e4m3fnuz)
+            imm_f8 = tkw.cast(e_delta, tkl.f8e4m3fnuz)
             v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             v_reg = tkw.cast(v_reg, tkl.f8e4m3fnuz)
             new_acc = acc * e_delta_max
-            acc = tkw.mma(v_reg, imm_f16, new_acc, mfma_variant[1])
+            acc = tkw.mma(v_reg, imm_f8, new_acc, mfma_variant[1])
             return m_j, d_j, acc
 
         # repeat represents the results of the loop


### PR DESCRIPTION
In order to align layouts in chained gemm or attention inFP8, we'd need to use different intrinsics for the 1st and 2nd mma. In order to achieve this, we'd need to do:

1. Set optional MMA_Type as an arg in tkw.mma
2. Modify index_seq_analysis and constraints to use the MMAOp's intrinsic type as opposed to the hw_constraint type when available.