### PR TITLE
[WIP] Propagate dim index

### DIFF
--- a/iree/turbine/kernel/_support/indexing.py
+++ b/iree/turbine/kernel/_support/indexing.py
@@ -430,3 +430,6 @@ class IndexSequence:
         if isinstance(self.size, int) and self.size <= 1:
             return f"{self.start}"
         return f"{self.start} : {self.size} : {self.stride}"
+
+    def __hash__(self):
+        return hash((self.start, self.size, self.stride))

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1349,6 +1349,10 @@ class ReduceOp(CustomOp, ABC):
     def reduction_dim(self) -> IndexSymbol:
         return self.dim
 
+    @property
+    def elements_per_thread(self) -> int:
+        return 1
+
 
 # TODO: Add support for more shuffle types.
 @define_op("shuffle")

--- a/iree/turbine/kernel/wave/thread_shape_analysis.py
+++ b/iree/turbine/kernel/wave/thread_shape_analysis.py
@@ -197,7 +197,7 @@ def determine_thread_shapes(trace: CapturedTrace):
                 bwd_slice = capture_backward_slice(custom.init, propagatable_op)
             reduce_dims = frozenset(
                 [
-                    DimIndex(dim, IndexSequence(seq.start, 1, 1))
+                    DimIndex(dim, process_seq(IndexSequence(seq.start, 1, 1)))
                     for dim, seq in custom.index.items()
                     if dim != custom.dim
                 ]

--- a/iree/turbine/kernel/wave/thread_shape_analysis.py
+++ b/iree/turbine/kernel/wave/thread_shape_analysis.py
@@ -25,17 +25,14 @@ class DimIndex:
 
     @property
     def size(self) -> IndexExpr:
-        if isinstance(self.seq, int):
-            return self.seq
-        return subs_idxc(self.seq).size
+        return self.seq.size
 
     def __hash__(self):
         return hash((self.dim, self.seq))
 
 
 def process_seq(seq):
-    return seq
-    return IndexSequence(seq.start, seq.size, 1)
+    return subs_idxc(seq)
 
 
 def get_dim_indices(indices: list[IndexSequence]):


### PR DESCRIPTION
Refactor `thread_shape_analysis` to take into account entire index instead of just elements per thread count.