### PR TITLE
Add evoformer example

### DIFF
--- a/iree/turbine/kernel/lang/global_symbols.py
+++ b/iree/turbine/kernel/lang/global_symbols.py
@@ -10,6 +10,8 @@ SHARED_ADDRESS_SPACE = index_symbol("$SHARED_ADDRESS_SPACE")
 WORKGROUP_0 = index_symbol("$WG0")
 WORKGROUP_1 = index_symbol("$WG1")
 WORKGROUP_2 = index_symbol("$WG2")
+WORKGROUP_3 = index_symbol("$WG3")
+WORKGROUP_4 = index_symbol("$WG4")
 
 THREAD_0 = index_symbol("$T0")
 THREAD_1 = index_symbol("$T1")

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -328,6 +328,24 @@ class WorkgroupConstraint(Constraint):
     tile_size: IndexExpr
     workgroup_dim: int
 
+    def __post_init__(self):
+        self.wg_dim = None
+        match self.workgroup_dim:
+            case 0:
+                self.wg_dim = WORKGROUP_0
+            case 1:
+                self.wg_dim = WORKGROUP_1
+            case 2:
+                self.wg_dim = WORKGROUP_2
+            case 3:
+                self.wg_dim = WORKGROUP_3
+            case 4:
+                self.wg_dim = WORKGROUP_4
+            case _:
+                raise ValueError(
+                    "Invalid workgroup dimension. Expected 0, 1, 2, 3 or 4."
+                )
+
     @property
     def count(self) -> IndexExpr:
         """
@@ -336,16 +354,7 @@ class WorkgroupConstraint(Constraint):
         return ceiling(self.dim / self.tile_size)
 
     def apply(self) -> IndexSequence:
-        match self.workgroup_dim:
-            case 0:
-                wg_dim = WORKGROUP_0
-            case 1:
-                wg_dim = WORKGROUP_1
-            case 2:
-                wg_dim = WORKGROUP_2
-            case _:
-                raise ValueError("Invalid workgroup dimension. Expected 0, 1 or 2.")
-        return IndexSequence(wg_dim * self.tile_size, 1)
+        return IndexSequence(self.wg_dim * self.tile_size, 1)
 
 
 def get_grid_shape(wg_constraints: list[WorkgroupConstraint]) -> list[IndexExpr]:

--- a/iree/turbine/kernel/wave/thread_shape_analysis.py
+++ b/iree/turbine/kernel/wave/thread_shape_analysis.py
@@ -41,6 +41,9 @@ def get_custom_dim_sizes(custom: CustomOp):
 def set_index_size(custom: CustomOp, target_dim_sizes: list[DimSize]):
     for target in target_dim_sizes:
         if target.dim not in custom.index:
+            # Allow target dimensions to be missing in the source index only if they are unit dims.
+            if target.size == 1:
+                continue
             raise NotImplementedError(
                 "NYI: Handle when source target index size is not found in target/user index."
             )
@@ -66,6 +69,17 @@ def propagatable_op(node: fx.Node):
     return not isinstance(custom_node, nonPropagatableTypes) or isinstance(
         custom_node, legalSubtypes
     )
+
+
+def propagate_resolutions(
+    custom_node: CustomOp, dst_op: CustomOp = None
+) -> list[fx.Node]:
+    propagated_resolutions = capture_forward_slice(custom_node.fx_node, propagatable_op)
+    if dst_op:
+        for node in propagated_resolutions:
+            get_custom(node).index = dst_op.index
+    resolved_resolutions = capture_backward_slice(custom_node.fx_node, propagatable_op)
+    return propagated_resolutions.union(resolved_resolutions)
 
 
 def handle_binaryop_conflict(custom_node: CustomOp) -> list[fx.Node]:
@@ -95,15 +109,7 @@ def handle_binaryop_conflict(custom_node: CustomOp) -> list[fx.Node]:
         custom_broadcast = get_custom(broadcast)
         custom_broadcast.vector_shapes = broadcast_src.vector_shapes
         custom_node.update_arg(broadcast_idx, custom_broadcast.fx_node)
-    propagated_resolutions = capture_forward_slice(
-        custom_broadcast.fx_node, propagatable_op
-    )
-    for node in propagated_resolutions:
-        get_custom(node).index = dst_op.index
-    resolved_resolutions = capture_backward_slice(
-        custom_broadcast.fx_node, propagatable_op
-    )
-    return propagated_resolutions.union(resolved_resolutions)
+    return propagate_resolutions(custom_broadcast, dst_op)
 
 
 # Returns True iff all conflicts are handled succesfully.
@@ -120,6 +126,26 @@ def handle_conflicts(conflicted_ops: set[CustomOp]):
     # such as broadcast.
     all_conflicts_resolved = cummulative_resolved.issuperset(conflicted_ops)
     return all_conflicts_resolved
+
+
+def need_conflict_resolution(
+    op_to_thread_sizes: dict[CustomOp, set[frozenset[DimSize]]],
+    conflicted_ops: set[CustomOp],
+    target_index_size: frozenset[DimSize],
+):
+    """
+    Determine if we need to resolve conflicts. We need to resolve conflicts
+    only if the sizes along non-unit dims are not identical.
+    """
+    for op in conflicted_ops:
+        if op not in op_to_thread_sizes:
+            continue
+        different_shapes = op_to_thread_sizes[op].symmetric_difference(
+            target_index_size
+        )
+        if any([dim.size != 1 for dim in different_shapes]):
+            return True
+    return False
 
 
 ###############################################################################
@@ -235,11 +261,18 @@ def determine_thread_shapes(trace: CapturedTrace):
 
     # Go through each index-size buckets, and apply the index-size to ops in the bucket.
     cummulative_set = set()
+    # Maintains the last thread size that was set for an op.
+    ops_to_thread_sizes: dict[CustomOp, frozenset[DimSize]] = {}
     for target_index_size, target_ops in thread_size_to_ops.items():
         # Try to handle conflicts and remove from target set if successfully handled.
         if not cummulative_set.isdisjoint(target_ops):
             conflicted_ops = cummulative_set.intersection(target_ops)
-            if handle_conflicts(conflicted_ops) == False:
+            if (
+                need_conflict_resolution(
+                    ops_to_thread_sizes, conflicted_ops, target_index_size
+                )
+                and handle_conflicts(conflicted_ops) == False
+            ):
                 raise NotImplementedError("Failed to handle conflicting thread shape.")
             target_ops = target_ops.difference(conflicted_ops)
         cummulative_set = cummulative_set.union(target_ops)
@@ -247,3 +280,4 @@ def determine_thread_shapes(trace: CapturedTrace):
         for user in target_ops:
             custom_user = get_custom(user)
             set_index_size(custom_user, target_index_size)
+            ops_to_thread_sizes[user] = target_index_size

--- a/iree/turbine/kernel/wave/thread_shape_analysis.py
+++ b/iree/turbine/kernel/wave/thread_shape_analysis.py
@@ -94,7 +94,6 @@ def handle_binaryop_conflict(custom_node: CustomOp) -> list[fx.Node]:
         )
         custom_broadcast = get_custom(broadcast)
         custom_broadcast.vector_shapes = broadcast_src.vector_shapes
-        custom_broadcast.anchor = broadcast_src.anchor
         custom_node.update_arg(broadcast_idx, custom_broadcast.fx_node)
     propagated_resolutions = capture_forward_slice(
         custom_broadcast.fx_node, propagatable_op

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -213,7 +213,9 @@ def remove_chained_extractslice(trace: CapturedTrace):
                 get_custom(node).graph.erase_node(src_extract.fx_node)
 
 
-def delinearize_index(index: IndexExpr, shape: list[int]) -> list[IndexExpr]:
+def delinearize_index(
+    index: IndexExpr, shape: list[int | IndexExpr]
+) -> list[IndexExpr]:
     """
     Delinearizes a 1D index into a multi-dimensional index
     based on the shapes provided. The returned array contains

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -15,12 +15,16 @@ import torch
 
 # Input sizes
 B = tkl.sym.B
+BN = tkl.sym.BN
 M = tkl.sym.M
+H = tkl.sym.H
 N = tkl.sym.N
 K1 = tkl.sym.K1
 K2 = tkl.sym.K2
 # Workgroup tile sizes
 BLOCK_B = tkl.sym.BLOCK_B
+BLOCK_BN = tkl.sym.BLOCK_BN
+BLOCK_H = tkl.sym.BLOCK_H
 BLOCK_M = tkl.sym.BLOCK_M
 BLOCK_N = tkl.sym.BLOCK_N
 BLOCK_K2 = tkl.sym.BLOCK_K2
@@ -29,6 +33,182 @@ ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
 # Other hyperparameters
 LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
 STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+
+@run_test
+def test_evoformer():
+    # B, BN, K2, H, K1, M, N
+    shape = (1, 256, 256, 4, 32, 256, 32)
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.WorkgroupConstraint(BN, BLOCK_BN, 3)]
+    constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 4)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    mfma_variant = tkw.MMAType.F32_16x16x16_F16
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0, BN: 0, H: 0, M: 16, N: 16},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    l = tkw.IndexMapping.iterator(3)
+    m = tkw.IndexMapping.iterator(4)
+    # [B, BN, M, H, K1] -> [B, BN, H, M, K1]
+    q_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, M: l, K1: m},
+        outputs={B: i, BN: j, H: k, M: l, K1: m},
+    )
+    # [B, BN, K2, H, K1] -> [B, BN, H, K2, K1]
+    k_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, K2: l, K1: m},
+        outputs={B: i, BN: j, H: k, K2: l, K1: m},
+    )
+    # [B, BN, K2, H, N] -> [B, BN, H, N, K2]
+    v_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, K2: m},
+        outputs={B: i, BN: j, H: k, N: l, K2: m},
+    )
+    # [B, BN, H, N, M] -> [B, BN, M, H, N]
+    o_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, M: m},
+        outputs={B: i, BN: j, H: k, N: l, M: m},
+    )
+
+    @tkw.wave(constraints)
+    def evoformer(
+        q: tkl.Memory[B, BN, M, H, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, BN, K2, H, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, BN, K2, H, N, ADDRESS_SPACE, tkl.f16],
+        mask: tkl.Memory[B, BN, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        bias: tkl.Memory[B, H, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, BN, M, H, N, GLOBAL_ADDRESS_SPACE, tkl.f16],
+    ):
+        c_reg = tkl.Register[B, BN, H, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, BN, H, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, BN, H, M, tkl.f32](-1e6)
+
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, BN, H, M, tkl.f32],
+            partial_sum: tkl.Register[B, BN, H, M, tkl.f32],
+            acc: tkl.Register[B, BN, H, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, BN, H, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(
+                q, mapping=q_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            k_reg = tkw.read(
+                k, mapping=k_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, BN, H, M, K2])
+            mask_reg = tkw.read(mask, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_mask_reg = tkw.cast(mask_reg, tkl.f32)
+            y_j = x_j + casted_mask_reg
+            bias_reg = tkw.read(bias, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_bias_reg = tkw.cast(bias_reg, tkl.f32)
+            z_j = y_j + casted_bias_reg
+            m_j = tkw.max(z_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(z_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(
+                v, mapping=v_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        casted = tkw.cast(res, tkl.f16)
+        tkw.write(
+            casted, c, mapping=o_mapping, elements_per_thread=STORE_ELEMS_PER_THREAD
+        )
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        B: shape[0],
+        BN: shape[1],
+        K2: shape[2],
+        H: shape[3],
+        K1: shape[4],
+        M: shape[5],
+        N: shape[6],
+        BLOCK_B: 1,
+        BLOCK_BN: 1,
+        BLOCK_H: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 32,
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        VALU_DELAY: 1,
+        SHUFFLE_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+        VALU_UNITS: 2,
+        SHUFFLE_UNITS: 2,
+    }
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=False,
+        run_bench=False,
+        schedule=False,
+        use_scheduling_barriers=False,
+    ):
+        torch.manual_seed(0)
+        q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
+        output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        print(evoformer(q, k, v, output).module_op)
+
+        # CHECK:            func.func @evoformer
+        # CHECK:                {{.*}} = scf.for
+        # CHECK-COUNT-1:            {{.*}} = vector.gather
+        # CHECK-COUNT-1:            vector.store {{.*}}
+        # CHECK-COUNT-4:            {{.*}} = vector.load
+        # CHECK-COUNT-1:            {{.*}} = vector.gather
+        # CHECK-COUNT-1:            vector.store {{.*}}
+        # CHECK-COUNT-4:            {{.*}} = vector.load
+        # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma
+        # CHECK-COUNT-2:            {{.*}} = vector.load
+        # CHECK-COUNT-2:            {{.*}} = arith.extf
+        # CHECK-COUNT-4:            {{.*}} = arith.addf
+        # CHECK-COUNT-4:            {{.*}} = vector.load
+        # CHECK-COUNT-4:            {{.*}} = arith.extf
+        # CHECK-COUNT-4:            {{.*}} = arith.addf
 
 
 # This test sets all the dimensions except K1 to be dynamic.

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -529,3 +529,127 @@ def test_attention():
         # CHECK-COUNT-16:           {{.*}} = amdgpu.mfma
         # CHECK-COUNT-8:            {{.*}} = gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            {{.*}} = amdgpu.mfma
+
+
+@run_test
+def test_attention_bias():
+    shape = (8, 128, 128, 64, 256)
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    mfma_variant = tkw.MMAType.F32_16x16x16_F16
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0, M: 16, N: 16},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    )
+
+    @tkw.wave(constraints)
+    def base_attention_bias(
+        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        bias: tkl.Memory[B, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, M, tkl.f32],
+            partial_sum: tkl.Register[B, M, tkl.f32],
+            acc: tkl.Register[B, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # b_reg: tkw.Register[B, N, K, tkl.f16]
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # acc: tkw.Register[B, N, M, tkl.f32]
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
+            bias_reg = tkw.read(bias, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            x_j = x_j + bias_reg
+            m_j = tkw.max(x_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        BLOCK_B: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 32,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K1: shape[3],
+        K2: shape[4],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+    }
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=False,
+        run_bench=False,
+        schedule=False,
+        use_scheduling_barriers=False,
+    ):
+        torch.manual_seed(0)
+        q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
+        output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        print(base_attention_bias(q, k, v, output).module_op)
+
+        # CHECK:            func.func @base_attention_bias
+        # CHECK:                {{.*}} = scf.for
+        # CHECK-COUNT-16:           {{.*}} = amdgpu.mfma
+        # CHECK-COUNT-4:            {{.*}} = vector.load
+        # CHECK-COUNT-4:            {{.*}} = arith.addf
+        # CHECK-COUNT-8:            {{.*}} = gpu.shuffle xor {{.*}}
+        # CHECK-COUNT-8:            {{.*}} = amdgpu.mfma

--- a/tests/kernel/wave/constraints_test.py
+++ b/tests/kernel/wave/constraints_test.py
@@ -44,9 +44,9 @@ class ConstraintsTest(unittest.TestCase):
         # Checking invalid workgroup dimension
         with pytest.raises(
             ValueError,
-            match="Invalid workgroup dimension. Expected 0, 1 or 2.",
+            match="Invalid workgroup dimension. Expected 0, 1, 2, 3 or 4.",
         ):
-            WorkgroupConstraint(N, BLOCK_N, 3).apply()
+            WorkgroupConstraint(N, BLOCK_N, 100).apply()
 
     def testTilingConstraint(self):
         constraints: list[TilingConstraint] = [TilingConstraint(M, BLOCK_M)]

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -7,6 +7,7 @@
 import logging
 import pytest
 import torch
+from torch.nn import functional as F
 import math
 import unittest
 import iree.turbine.kernel as tk
@@ -564,6 +565,220 @@ def testAttention(
 
 
 @require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_attention"))
+@pytest.mark.parametrize("enable_scheduling", [False])
+@pytest.mark.parametrize("dynamic_dims", [False, True])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x16_F16,
+        MMAType.F32_32x32x8_F16,
+    ],
+)
+def testAttentionBias(
+    shape: tuple[int],
+    enable_scheduling: bool,
+    dynamic_dims: bool,
+    mfma_variant: MMAType,
+    request,
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 1)]
+
+    if mfma_variant == MMAType.F32_16x16x16_F16:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant == MMAType.F32_32x32x8_F16:
+        Mvec = 32
+        Nvec = 32
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(4, 1, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0, M: Mvec, N: Nvec},
+        )
+    ]
+
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K2 > BLOCK_K2 * 4)]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    )
+
+    @tkw.wave(constraints)
+    def base_attention_bias(
+        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        bias: tkl.Memory[B, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, M, tkl.f32],
+            partial_sum: tkl.Register[B, M, tkl.f32],
+            acc: tkl.Register[B, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # b_reg: tkw.Register[B, N, K, tkl.f16]
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # acc: tkw.Register[B, N, M, tkl.f32]
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
+            bias_reg = tkw.read(bias, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            x_j = x_j + bias_reg
+            m_j = tkw.max(x_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        BLOCK_B: 1,
+        BLOCK_M: 128,
+        BLOCK_N: 64,
+        BLOCK_K2: 64,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K1: shape[3],
+        K2: shape[4],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        VALU_DELAY: 1,
+        SHUFFLE_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+        VALU_UNITS: 2,
+        SHUFFLE_UNITS: 2,
+    }
+    config = get_default_run_config()
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+    if dynamic_dims:
+        dynamic_symbols_map[M] = hyperparams[M]
+        dynamic_symbols_map[N] = hyperparams[N]
+        dynamic_symbols_map[B] = hyperparams[B]
+        dynamic_symbols_map[K2] = hyperparams[K2]
+        dynamic_symbols.append(M)
+        dynamic_symbols.append(N)
+        dynamic_symbols.append(B)
+        dynamic_symbols.append(K2)
+        del hyperparams[M]
+        del hyperparams[N]
+        del hyperparams[B]
+        del hyperparams[K2]
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+    ):
+        torch.manual_seed(0)
+        q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)
+        bias = device_randn(shape[0], shape[1], shape[4], dtype=torch.float32)
+        output = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        log2e = 1.44269504089
+        dk_sqrt = math.sqrt(1.0 / shape[3])
+        # TODO: Add scaling of QK as part of kernel.
+        # TODO: Add variant of non-transposed V attention kernel.
+        mb = base_attention_bias(
+            q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), bias * log2e, output
+        )
+        k_t = k.transpose(-1, -2)
+        a = torch.matmul(q, k_t) * dk_sqrt
+        a += bias
+        a = F.softmax(a, dim=-1)
+        torch_ref = torch.matmul(a, v)
+
+        if test_dump_generated_mlir:
+            filename = f"wave_attention_{'x'.join(map(str, shape))}.mlir"
+            with open(filename, "w") as f:
+                f.write(mb.module_op.get_asm())
+
+        if "gfx94" in config["target"]:
+            assert_allclose(output, torch_ref, atol=2e-3, rtol=5e-3)
+        else:
+            # TODO: Determine why the error is higher on gfx90.
+            assert_allclose(output, torch_ref, atol=3e-3, rtol=8e-1)
+
+
+@require_e2e
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("test_attention"))
 @pytest.mark.parametrize("enable_scheduling", [False, True])
@@ -633,6 +848,7 @@ def testAttentionF8(
         c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
         init_sum = tkl.Register[B, M, tkl.f32](0.0)
         init_max = tkl.Register[B, M, tkl.f32](-1e6)
+
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
         @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -1,0 +1,336 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import pytest
+import torch
+from torch.nn import functional as F
+import math
+import unittest
+import iree.turbine.kernel as tk
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
+from iree.turbine.kernel.wave.utils import (
+    get_default_run_config,
+    get_default_arch,
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+    device_randn,
+    device_zeros,
+    device_randint,
+)
+from iree.turbine.kernel.wave.constraints import MMAType
+import os
+import json
+from torch.testing import assert_close, assert_allclose
+
+_run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
+require_e2e = pytest.mark.skipif(not _run_e2e, reason="e2e tests are disabled")
+require_cdna3 = pytest.mark.skipif(
+    "gfx94" not in get_default_arch(), reason="Default device is not CDNA3"
+)
+# Whether to dump the generated MLIR module.
+test_dump_generated_mlir = int(os.environ.get("WAVE_DUMP_MLIR", 0))
+# Whether to use scheduling group barriers (needs LLVM fix).
+enable_scheduling_barriers = int(os.environ.get("WAVE_USE_SCHED_BARRIERS", 0))
+
+# Add test shapes for validation and performance testing.
+perf_test = lambda *a: pytest.param(*a, marks=pytest.mark.perf_only)
+default_test_shapes = {}
+# Order of shapes: (B, BN, K2, H, K1, M, N)
+default_test_shapes["test_attention"] = [
+    (1, 256, 256, 4, 32, 256, 32),
+]
+default_test_shapes["test_attention"] += [
+    perf_test(x) for x in default_test_shapes["test_attention"]
+]
+
+
+user_specified_test_shapes = ""
+
+test_params_path = os.environ.get("TEST_PARAMS_PATH", None)
+
+if test_params_path:
+    with open(test_params_path, "r") as file:
+        user_specified_test_shapes = json.load(file)
+
+
+def get_test_shapes(test_name: str) -> list[tuple[int]]:
+    if test_name in user_specified_test_shapes:
+        return user_specified_test_shapes[test_name]
+    return default_test_shapes[test_name]
+
+
+# From: https://github.com/microsoft/DeepSpeed/blob/master/tests/unit/ops/deepspeed4science/test_DS4Sci_EvoformerAttention.py
+def attention_reference(
+    q_input: torch.Tensor,
+    k_input: torch.Tensor,
+    v_input: torch.Tensor,
+    biases: list[torch.Tensor],
+    sm_scale: float,
+) -> torch.Tensor:
+    q = q_input.transpose(-2, -3)
+    k = k_input.transpose(-2, -3)
+    v = v_input.transpose(-2, -3)
+    k_t = k.transpose(-1, -2)
+    a = torch.matmul(q, k_t) * sm_scale
+
+    for b in biases:
+        a += b
+
+    a = F.softmax(a, dim=-1)
+    a_v = torch.matmul(a, v)
+    o = a_v.transpose(-2, -3)
+
+    return o
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_attention"))
+@pytest.mark.parametrize("enable_scheduling", [False])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x16_F16,
+        MMAType.F32_32x32x8_F16,
+    ],
+)
+def testEvoformerAttentionForward(
+    shape: tuple[int],
+    enable_scheduling: bool,
+    mfma_variant: MMAType,
+    request,
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    B = tkl.sym.B
+    BN = tkl.sym.BN
+    M = tkl.sym.M
+    H = tkl.sym.H
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_BN = tkl.sym.BLOCK_BN
+    BLOCK_H = tkl.sym.BLOCK_H
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.WorkgroupConstraint(BN, BLOCK_BN, 3)]
+    constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 4)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    if mfma_variant == MMAType.F32_16x16x16_F16:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant == MMAType.F32_32x32x8_F16:
+        Mvec = 32
+        Nvec = 32
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0, BN: 0, H: 0, M: Mvec, N: Nvec},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    l = tkw.IndexMapping.iterator(3)
+    m = tkw.IndexMapping.iterator(4)
+    # [B, BN, M, H, K1] -> [B, BN, H, M, K1]
+    q_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, M: l, K1: m},
+        outputs={B: i, BN: j, H: k, M: l, K1: m},
+    )
+    # [B, BN, K2, H, K1] -> [B, BN, H, K2, K1]
+    k_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, K2: l, K1: m},
+        outputs={B: i, BN: j, H: k, K2: l, K1: m},
+    )
+    # [B, BN, N, H, K2] -> [B, BN, H, N, K2]
+    v_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, K2: m},
+        outputs={B: i, BN: j, H: k, N: l, K2: m},
+    )
+    # [B, BN, H, N, M] -> [B, BN, M, H, N]
+    o_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, M: m},
+        outputs={B: i, BN: j, H: k, N: l, M: m},
+    )
+
+    @tkw.wave(constraints)
+    def evoformer_fwd(
+        q: tkl.Memory[B, BN, M, H, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, BN, K2, H, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, BN, N, H, K2, ADDRESS_SPACE, tkl.f16],
+        mask: tkl.Memory[B, BN, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        bias: tkl.Memory[B, H, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, BN, M, H, N, GLOBAL_ADDRESS_SPACE, tkl.f16],
+    ):
+        c_reg = tkl.Register[B, BN, H, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, BN, H, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, BN, H, M, tkl.f32](-1e6)
+
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, BN, H, M, tkl.f32],
+            partial_sum: tkl.Register[B, BN, H, M, tkl.f32],
+            acc: tkl.Register[B, BN, H, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, BN, H, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(
+                q, mapping=q_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            k_reg = tkw.read(
+                k, mapping=k_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, BN, H, M, K2])
+            mask_reg = tkw.read(mask, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_mask_reg = tkw.cast(mask_reg, tkl.f32)
+            y_j = x_j + casted_mask_reg
+            bias_reg = tkw.read(bias, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_bias_reg = tkw.cast(bias_reg, tkl.f32)
+            z_j = y_j + casted_bias_reg
+            m_j = tkw.max(z_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(z_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(
+                v, mapping=v_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        casted = tkw.cast(res, tkl.f16)
+        tkw.write(
+            casted, c, mapping=o_mapping, elements_per_thread=STORE_ELEMS_PER_THREAD
+        )
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        B: shape[0],
+        BN: shape[1],
+        K2: shape[2],
+        H: shape[3],
+        K1: shape[4],
+        M: shape[5],
+        N: shape[6],
+        BLOCK_B: 1,
+        BLOCK_BN: 1,
+        BLOCK_H: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 32,
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        VALU_DELAY: 1,
+        SHUFFLE_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+        VALU_UNITS: 2,
+        SHUFFLE_UNITS: 2,
+    }
+    config = get_default_run_config()
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+    ):
+        torch.manual_seed(0)
+        batch, n, kv_seq_len, heads, head_dim, q_seq_len, v_dim = shape
+        # q: tkl.Memory[B, BN, M, H, K1, ADDRESS_SPACE, tkl.f16],
+        q = device_randn(batch, n, q_seq_len, heads, head_dim, dtype=torch.float16)
+        # k: tkl.Memory[B, BN, K2, H, K1, ADDRESS_SPACE, tkl.f16],
+        k = device_randn(batch, n, kv_seq_len, heads, head_dim, dtype=torch.float16)
+        # v: tkl.Memory[B, BN, K2, H, N, ADDRESS_SPACE, tkl.f16],
+        v = device_randn(batch, n, kv_seq_len, heads, v_dim, dtype=torch.float16)
+        # mask: tkl.Memory[B, BN, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        mask = device_randint(0, 2, (batch, n, kv_seq_len), dtype=torch.float16)
+        mask_bias = 1e9 * (mask - 1)
+        # bias: tkl.Memory[B, H, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        bias = device_randn(batch, heads, q_seq_len, kv_seq_len, dtype=torch.float16)
+        # output: tkl.Memory[B, BN, M, H, N, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        output = device_zeros(batch, n, q_seq_len, heads, v_dim, dtype=torch.float16)
+        log2e = 1.44269504089
+        dk_sqrt = math.sqrt(1.0 / shape[4])
+        # TODO: Add scaling of QK as part of kernel.
+        mb = evoformer_fwd(
+            q * dk_sqrt * log2e,
+            k,
+            v.permute([0, 1, 4, 3, 2]),
+            mask_bias,
+            bias * log2e,
+            output,
+        )
+
+        mask_bias = mask_bias.view([batch, n, 1, 1, kv_seq_len])
+        bias = bias.view([batch, 1, heads, q_seq_len, kv_seq_len])
+        torch_ref = attention_reference(q, k, v, [mask_bias, bias], dk_sqrt)
+
+        if test_dump_generated_mlir:
+            filename = f"wave_evoformer_{'x'.join(map(str, shape))}.mlir"
+            with open(filename, "w") as f:
+                f.write(mb.module_op.get_asm())
+
+        eps = 1e-2 if output.dtype == torch.float16 else 5e-2
+        print(f"Max diff: {torch.max(torch.abs(torch_ref - output)).item()}")
+        assert (
+            torch.max(torch.abs(torch_ref - output)).item() < eps
+        ), f"out eps: {torch.max(torch.abs(torch_ref - output))}"


### PR DESCRIPTION
This PR adds a sample evoformer kernel. To get this to be functional, the following changes were needed
1. Enabling multiple batch dimensions by delinearizing workgroup_dim_2
2. Modifications to thread shape analysis to allow edge cases
