### PR TITLE
[TKW] Clear cache after every test for robustify test

### DIFF
--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -987,6 +987,11 @@ def device_zeros(*args, **kwargs):
     return to_default_device(torch.zeros(*args, **kwargs))
 
 
+def initialize_seed_and_cache(seed: Optional[int] = 0):
+    torch.cuda.empty_cache()
+    torch.manual_seed(seed)
+
+
 def get_assumptions(constraints: list[Constraint]) -> list[Assumption]:
     assumptions: list[Assumption] = []
     for constraint in constraints:

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -13,10 +13,7 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.iree_utils import (
-    generate_iree_ref,
-    initialize_seed_and_cache,
-)
+from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
 from iree.turbine.kernel.wave.utils import (
     get_default_run_config,
     get_default_arch,
@@ -24,6 +21,7 @@ from iree.turbine.kernel.wave.utils import (
     get_mfma_store_elems_per_thread,
     device_randn,
     device_zeros,
+    initialize_seed_and_cache,
 )
 from iree.turbine.kernel.wave.constraints import MMAType
 import os
@@ -196,7 +194,7 @@ def testChainedGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -346,7 +344,7 @@ def testChainedGemmF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -545,7 +543,7 @@ def testAttention(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)
@@ -717,7 +715,7 @@ def testAttentionF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -13,7 +13,10 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
+from iree.turbine.kernel.wave.iree_utils import (
+    generate_iree_ref,
+    initialize_seed_and_cache,
+)
 from iree.turbine.kernel.wave.utils import (
     get_default_run_config,
     get_default_arch,
@@ -193,8 +196,7 @@ def testChainedGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -344,8 +346,7 @@ def testChainedGemmF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -544,8 +545,7 @@ def testAttention(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)
@@ -717,8 +717,7 @@ def testAttentionF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -194,7 +194,7 @@ def testChainedGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -344,7 +344,7 @@ def testChainedGemmF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -543,7 +543,7 @@ def testAttention(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)
@@ -715,7 +715,7 @@ def testAttentionF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -193,6 +193,8 @@ def testChainedGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
+        torch.cuda.empty_cache()
+        torch.manual_seed(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = device_randn(shape[0], shape[2], shape[4], dtype=torch.float16)
@@ -342,6 +344,7 @@ def testChainedGemmF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
+        torch.cuda.empty_cache()
         torch.manual_seed(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
@@ -541,6 +544,7 @@ def testAttention(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
+        torch.cuda.empty_cache()
         torch.manual_seed(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
@@ -713,6 +717,7 @@ def testAttentionF8(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
+        torch.cuda.empty_cache()
         torch.manual_seed(0)
         q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -9,10 +9,7 @@ import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.wave.wave_sim import wave_sim
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.iree_utils import (
-    generate_iree_ref,
-    initialize_seed_and_cache,
-)
+from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
 from iree.turbine.kernel.wave.utils import (
     get_default_arch,
     get_default_run_config,
@@ -20,6 +17,7 @@ from iree.turbine.kernel.wave.utils import (
     device_randint,
     device_randperm,
     device_zeros,
+    initialize_seed_and_cache,
 )
 import torch
 from torch.testing import assert_close

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -105,6 +105,8 @@ def test_copy(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape, dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -162,6 +164,8 @@ def test_dynamic_copy(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape, dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -221,6 +225,8 @@ def test_transpose_read(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape[::-1], dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -279,6 +285,8 @@ def test_transpose_write(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape[::-1], dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -353,6 +361,8 @@ def test_offset_read(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     a = device_randn(shape, dtype=torch.float16)
     off = device_randint(shape[0], shape, dtype=torch.int32)
     out = device_zeros(shape, dtype=torch.float16)
@@ -430,6 +440,8 @@ def test_offset_write(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     a = device_randn(shape, dtype=torch.float16)
     off = (
         device_randperm(shape[1], dtype=torch.int32)
@@ -492,6 +504,7 @@ def test_reduce_sum(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
     torch.manual_seed(1)
     a = device_randn(shape, dtype=torch.float16)
     b = device_randn(shape, dtype=torch.float16)
@@ -564,6 +577,7 @@ def test_toy_online_softmax(shape):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
     torch.manual_seed(1)
     a = device_randn(shape, dtype=torch.float32)
     b = device_randn(shape, dtype=torch.float32)
@@ -663,6 +677,8 @@ def test_im2col(request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     h_out = (h + 2 * padding - hf) // stride + 1
     w_out = (w + 2 * padding - wf) // stride + 1
     res_shape = (h_out * w_out * n, hf * wf * c)
@@ -904,6 +920,7 @@ def test_igemm_conv(n, h, w, c, hf, wf, nf, stride, mem_space, layout, request):
     cf = c
     padding = 0  # TODO: only pad=0 is supported for now
 
+    torch.cuda.empty_cache()
     torch.manual_seed(1)
     x = device_randn(n, c, h, w, dtype=torch.float16)
     we = device_randn(nf, cf, hf, wf, dtype=torch.float16)
@@ -1115,6 +1132,8 @@ def test_cast(shape, request):
 
     config = get_default_run_config()
 
+    torch.cuda.empty_cache()
+    torch.manual_seed(0)
     a = device_randn(shape, dtype=torch.float32)
     b = device_zeros(shape, dtype=torch.float16)
     with tk.gen.TestLaunchContext(

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -9,7 +9,10 @@ import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.wave.wave_sim import wave_sim
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
+from iree.turbine.kernel.wave.iree_utils import (
+    generate_iree_ref,
+    initialize_seed_and_cache,
+)
 from iree.turbine.kernel.wave.utils import (
     get_default_arch,
     get_default_run_config,
@@ -105,8 +108,7 @@ def test_copy(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape, dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -164,8 +166,7 @@ def test_dynamic_copy(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape, dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -225,8 +226,7 @@ def test_transpose_read(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape[::-1], dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -285,8 +285,7 @@ def test_transpose_write(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape[::-1], dtype=torch.float16)
     with tk.gen.TestLaunchContext(
@@ -361,8 +360,7 @@ def test_offset_read(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     a = device_randn(shape, dtype=torch.float16)
     off = device_randint(shape[0], shape, dtype=torch.int32)
     out = device_zeros(shape, dtype=torch.float16)
@@ -440,8 +438,7 @@ def test_offset_write(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     a = device_randn(shape, dtype=torch.float16)
     off = (
         device_randperm(shape[1], dtype=torch.int32)
@@ -504,8 +501,7 @@ def test_reduce_sum(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(1)
+    initialize_seed_and_cache(1)
     a = device_randn(shape, dtype=torch.float16)
     b = device_randn(shape, dtype=torch.float16)
     c = device_zeros((shape[0],), dtype=torch.float16)
@@ -577,8 +573,7 @@ def test_toy_online_softmax(shape):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(1)
+    initialize_seed_and_cache(1)
     a = device_randn(shape, dtype=torch.float32)
     b = device_randn(shape, dtype=torch.float32)
     c = device_zeros((shape[0],), dtype=torch.float32)
@@ -677,8 +672,7 @@ def test_im2col(request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     h_out = (h + 2 * padding - hf) // stride + 1
     w_out = (w + 2 * padding - wf) // stride + 1
     res_shape = (h_out * w_out * n, hf * wf * c)
@@ -920,8 +914,7 @@ def test_igemm_conv(n, h, w, c, hf, wf, nf, stride, mem_space, layout, request):
     cf = c
     padding = 0  # TODO: only pad=0 is supported for now
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(1)
+    initialize_seed_and_cache(1)
     x = device_randn(n, c, h, w, dtype=torch.float16)
     we = device_randn(nf, cf, hf, wf, dtype=torch.float16)
 
@@ -1132,8 +1125,7 @@ def test_cast(shape, request):
 
     config = get_default_run_config()
 
-    torch.cuda.empty_cache()
-    torch.manual_seed(0)
+    initialize_seed_and_cache(0)
     a = device_randn(shape, dtype=torch.float32)
     b = device_zeros(shape, dtype=torch.float16)
     with tk.gen.TestLaunchContext(

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -12,10 +12,7 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.iree_utils import (
-    generate_iree_ref,
-    initialize_seed_and_cache,
-)
+from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
 from iree.turbine.kernel.wave.utils import (
     get_default_run_config,
     get_default_arch,
@@ -24,6 +21,7 @@ from iree.turbine.kernel.wave.utils import (
     device_randn,
     device_randint,
     device_zeros,
+    initialize_seed_and_cache,
 )
 from iree.turbine.kernel.wave.constraints import MMAType
 import os
@@ -211,7 +209,7 @@ def testGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -371,7 +369,7 @@ def testCDNA2IntGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -500,7 +498,7 @@ def testCDNA3IntGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -628,7 +626,7 @@ def testF8Gemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -748,7 +746,7 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: bool, request):
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_seed_and_cache(0)
+        initialize_test(0)
         a = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         b = device_randn(shape[0], shape[2], shape[3], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -12,7 +12,10 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.iree_utils import generate_iree_ref
+from iree.turbine.kernel.wave.iree_utils import (
+    generate_iree_ref,
+    initialize_seed_and_cache,
+)
 from iree.turbine.kernel.wave.utils import (
     get_default_run_config,
     get_default_arch,
@@ -208,8 +211,7 @@ def testGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -369,8 +371,7 @@ def testCDNA2IntGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -499,8 +500,7 @@ def testCDNA3IntGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -628,8 +628,7 @@ def testF8Gemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -749,8 +748,7 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: bool, request):
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        torch.cuda.empty_cache()
-        torch.manual_seed(0)
+        initialize_seed_and_cache(0)
         a = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         b = device_randn(shape[0], shape[2], shape[3], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -208,6 +208,8 @@ def testGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
+        torch.cuda.empty_cache()
+        torch.manual_seed(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -367,6 +369,8 @@ def testCDNA2IntGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
+        torch.cuda.empty_cache()
+        torch.manual_seed(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -495,6 +499,8 @@ def testCDNA3IntGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
+        torch.cuda.empty_cache()
+        torch.manual_seed(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -622,6 +628,8 @@ def testF8Gemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
+        torch.cuda.empty_cache()
+        torch.manual_seed(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -741,6 +749,8 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: bool, request):
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
+        torch.cuda.empty_cache()
+        torch.manual_seed(0)
         a = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         b = device_randn(shape[0], shape[2], shape[3], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -209,7 +209,7 @@ def testGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -369,7 +369,7 @@ def testCDNA2IntGemm(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -498,7 +498,7 @@ def testCDNA3IntGemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         randint_hi = 4
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
@@ -626,7 +626,7 @@ def testF8Gemm(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
@@ -746,7 +746,7 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: bool, request):
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        initialize_test(0)
+        initialize_seed_and_cache(0)
         a = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         b = device_randn(shape[0], shape[2], shape[3], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)


### PR DESCRIPTION
Tests on MI250 is randomly passing and failing. In order to robustify them, this PR adds manual_seed in places that are missing, and add cuda.clear_cache() to ensure we don't run out of memory.