### PR TITLE
[TKW] Add `create_vmfb_file` option

### DIFF
--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -572,23 +572,25 @@ def compile_and_invoke(
     dump_vmfb_file = config.get("dump_vmfb_file", None)
     if dump_vmfb_file is not None:
         _write_file(dump_vmfb_file, "wb", res)
-    if inplace:
-        # Select device as the GPU, where input tensors are coming from.
-        device_uuid = get_device_uuid(kernel_inputs + kernel_outputs)
-        device = f"{device}://GPU-{device_uuid}"
-    rt_config = rt.Config(device)
-    device = rt_config.device
-    vm_instance = rt_config.vm_instance
-    mod = rt.VmModule.copy_buffer(vm_instance, res)
 
-    vm_modules = [
-        mod,
-        rt.create_hal_module(vm_instance, device),
-    ]
-    ctx = rt.SystemContext(
-        vm_modules=vm_modules,
-        config=rt_config,
-    )
+    if run or run_bench:
+        if inplace:
+            # Select device as the GPU, where input tensors are coming from.
+            device_uuid = get_device_uuid(kernel_inputs + kernel_outputs)
+            device = f"{device}://GPU-{device_uuid}"
+        rt_config = rt.Config(device)
+        device = rt_config.device
+        vm_instance = rt_config.vm_instance
+        mod = rt.VmModule.copy_buffer(vm_instance, res)
+
+        vm_modules = [
+            mod,
+            rt.create_hal_module(vm_instance, device),
+        ]
+        ctx = rt.SystemContext(
+            vm_modules=vm_modules,
+            config=rt_config,
+        )
 
     if run:
         func = mod.lookup_function(func_name)

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -336,8 +336,8 @@ class LaunchableWave(Launchable):
 
         run = kwargs.get("run", False)
         run_bench = kwargs.get("run_bench", False)
-        dry_run = kwargs.get("dry_run", False)
-        if run or run_bench or dry_run:
+        create_vmfb_file = kwargs.get("create_vmfb_file", None)
+        if run or run_bench or create_vmfb_file:
             # TODO: cache compiled code
             dynamic_symbols = kwargs.get("dynamic_symbols", [])
             host_codegen.isolated_test_call(
@@ -373,6 +373,7 @@ class LaunchableWave(Launchable):
                 kernel_dynamic_dims,
                 run,
                 run_bench,
+                create_vmfb_file=create_vmfb_file,
                 inplace=True,
             )
 

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -336,7 +336,8 @@ class LaunchableWave(Launchable):
 
         run = kwargs.get("run", False)
         run_bench = kwargs.get("run_bench", False)
-        if run or run_bench:
+        dry_run = kwargs.get("dry_run", False)
+        if run or run_bench or dry_run:
             # TODO: cache compiled code
             dynamic_symbols = kwargs.get("dynamic_symbols", [])
             host_codegen.isolated_test_call(


### PR DESCRIPTION
Add a `create_vmfb_file` flag to run full IREE pipeline to get vmfb file without actually invoking anything.

This is a quick hack to get iree-kernel-benchmark going until we have a proper AOT compilation API.