### PR TITLE
[TKW] Detect contiguous access pattern in mapped reads/writes

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -976,6 +976,35 @@ class Read(CustomOp):
         if is_shared_mem_access(self):
             self.index = align_index_vars(self.index, constraints)
 
+    def has_identity_mapping(self) -> bool:
+        mapping = self.mapping
+        if mapping is None:
+            return True
+
+        mem_shape = self.memory.type.symbolic_shape
+        if mapping.is_identity() and mapping.input_shape == mem_shape:
+            return True
+
+        return False
+
+    def is_contiguous_vec(self) -> bool:
+        if self.has_identity_mapping():
+            return True
+
+        mapping = self.mapping
+
+        mem_shape = self.memory.type.symbolic_shape
+
+        from ..wave.utils import check_is_mapping_contiguous
+
+        return check_is_mapping_contiguous(
+            mapping=mapping,
+            symbolc_shape=mem_shape,
+            index=self.index,
+            elements_per_thread=self.elements_per_thread,
+            is_read=True,
+        )
+
 
 @define_op("reduction")
 @dataclass
@@ -1151,6 +1180,34 @@ class Write(CustomOp):
 
         if is_shared_mem_access(self):
             self.index = align_index_vars(self.index, constraints)
+
+    def has_identity_mapping(self) -> bool:
+        mapping = self.mapping
+        if mapping is None:
+            return True
+
+        mem_shape = self.memory.type.symbolic_shape
+        if mapping.is_identity() and mapping.output_shape == mem_shape:
+            return True
+
+        return False
+
+    def is_contiguous_vec(self) -> bool:
+        if self.has_identity_mapping():
+            return True
+        mapping = self.mapping
+
+        mem_shape = self.memory.type.symbolic_shape
+
+        from ..wave.utils import check_is_mapping_contiguous
+
+        return check_is_mapping_contiguous(
+            mapping=mapping,
+            symbolc_shape=mem_shape,
+            index=self.index,
+            elements_per_thread=self.elements_per_thread,
+            is_read=False,
+        )
 
 
 @define_py_op(operator.getitem)

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -977,6 +977,7 @@ class Read(CustomOp):
             self.index = align_index_vars(self.index, constraints)
 
     def has_identity_mapping(self) -> bool:
+        """Check if mapping between input memory and output register is identity."""
         mapping = self.mapping
         if mapping is None:
             return True
@@ -988,6 +989,9 @@ class Read(CustomOp):
         return False
 
     def is_contiguous_vec(self) -> bool:
+        """Check if op can be lowered to contiguous vector ops
+
+        If False we will have to lower it to gather"""
         if self.has_identity_mapping():
             return True
 
@@ -1182,6 +1186,7 @@ class Write(CustomOp):
             self.index = align_index_vars(self.index, constraints)
 
     def has_identity_mapping(self) -> bool:
+        """Check if mapping between input register and output memory is identity."""
         mapping = self.mapping
         if mapping is None:
             return True
@@ -1193,6 +1198,9 @@ class Write(CustomOp):
         return False
 
     def is_contiguous_vec(self) -> bool:
+        """Check if op can be lowered to contiguous vector ops
+
+        If False we will have to lower it to gather"""
         if self.has_identity_mapping():
             return True
         mapping = self.mapping

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -610,9 +610,9 @@ def _construct_gather_scatter_indices(
 
     # As we only support identity input/output mapping for now, we can directly
     # substitute iterators with corresponding expanded index.
-    subs = list(idxc.subs.items()) + [
+    subs = [
         (sym, expr.start) for sym, expr in zip(iters.keys(), index.values())
-    ]
+    ] + list(idxc.subs.items())
 
     # Contruct input/output index, substituting iterators in input mapping with
     # expanded index.

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -758,6 +758,9 @@ def _construct_gather_scatter_indices(
         {key: m.subs(subs) for key, m in zip(symbolc_shape, index_mapping)}
     )
     for i in range(1, elements_per_thread, 1):
+        if mapping.num_dynamic_vals != 0:
+            is_contiguous = False
+            break
         subs[-1] = (subs[-1][0], subs[-1][1] + 1)
         next_result_index = {
             key: m.subs(subs) for key, m in zip(symbolc_shape, index_mapping)

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -596,6 +596,117 @@ def _build_mask(
     return mask
 
 
+def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
+    def check_mul(mul):
+        ret = None
+        for arg in mul.args:
+            if arg.is_number:
+                if ret is not None:
+                    return None
+
+                ret = arg
+                continue
+
+            if not isinstance(arg, (sympy.floor, sympy.Mod)):
+                return None
+
+        return ret
+
+    def transform_mod(expr):
+        if not isinstance(expr, sympy.Mod):
+            return None
+
+        p, q = expr.args
+        if not q.is_number:
+            return None
+
+        if not isinstance(p, sympy.Add):
+            return None
+
+        c = None
+        terms = []
+        mult = None
+        for arg in p.args:
+            if arg.is_number:
+                if c is not None:
+                    return None
+
+                c = arg
+                continue
+
+            if not isinstance(arg, sympy.Mul):
+                return None
+
+            m = check_mul(arg)
+            if (m is None) or (q % m != 0):
+                return None
+
+            mult = m if (mult is None) or (m < mult) else mult
+            terms.append(arg)
+
+        if c >= mult:
+            return None
+
+        return (sum(terms) % q) + c
+
+    def check_mul_rational(mul):
+        ret = None
+        for arg in mul.args:
+            if isinstance(arg, sympy.Rational):
+                if ret is not None:
+                    return None
+
+                ret = arg
+                continue
+
+            if not isinstance(arg, (sympy.floor, sympy.Mod)):
+                return None
+
+        return ret
+
+    def transform_floor(expr):
+        if not isinstance(expr, sympy.floor):
+            return None
+
+        expr = expr.args[0]
+        if not isinstance(expr, sympy.Add):
+            return None
+
+        c = None
+        for arg in expr.args:
+            if isinstance(arg, sympy.Rational):
+                if c is not None:
+                    return None
+
+                c = arg
+
+        if c is None:
+            return None
+
+        terms = []
+        for arg in expr.args:
+            if isinstance(arg, sympy.Rational):
+                continue
+
+            if not isinstance(arg, sympy.Mul):
+                return None
+
+            r = check_mul_rational(arg)
+            if r is None:
+                return None
+
+            if r < c:
+                return None
+
+            terms.append(arg)
+
+        return sympy.floor(sum(terms))
+
+    expr = expr.replace(lambda e: transform_mod(e) is not None, transform_mod)
+    expr = expr.replace(lambda e: transform_floor(e) is not None, transform_floor)
+    return sympy.simplify(expr)
+
+
 def _construct_gather_scatter_indices(
     emitter: WaveEmitter,
     symbolc_shape: tuple[IndexExpr],
@@ -639,30 +750,20 @@ def _construct_gather_scatter_indices(
 
     start_indices = _get_start_indices(result_index)
 
-    prev_indices = start_indices
-    subs1 = [
-        (THREAD_0, 0),
-        (THREAD_1, 0),
-        (THREAD_2, 0),
-        (WORKGROUP_0, 0),
-        (WORKGROUP_1, 0),
-        (WORKGROUP_2, 0),
-    ]
-    subs1 += [(k, 0) for k in emitter.get_induction_vars_and_syms()[1]]
-
     expected_diff = [0] * len(start_indices)
     expected_diff[-1] = 1
     is_contiguous = True
+    subs[-1] = (subs[-1][0], (subs[-1][1] // elements_per_thread) * elements_per_thread)
+    prev_indices = _get_start_indices(
+        {key: m.subs(subs) for key, m in zip(symbolc_shape, index_mapping)}
+    )
     for i in range(1, elements_per_thread, 1):
         subs[-1] = (subs[-1][0], subs[-1][1] + 1)
         next_result_index = {
             key: m.subs(subs) for key, m in zip(symbolc_shape, index_mapping)
         }
         next_indices = _get_start_indices(next_result_index)
-        diff = [
-            sympy.simplify(a.subs(subs1) - b.subs(subs1))
-            for a, b in zip(next_indices, prev_indices)
-        ]
+        diff = [_simplify_sympy_expr(a - b) for a, b in zip(next_indices, prev_indices)]
         if diff != expected_diff:
             is_contiguous = False
             break

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1077,6 +1077,8 @@ def _get_start_indices(
 
 
 def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
+    """Apply custom sympy simplifications"""
+
     def check_mul(mul):
         ret = None
         for arg in mul.args:
@@ -1093,6 +1095,11 @@ def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
         return ret
 
     def transform_mod(expr):
+        """Move constant outside of Mod expr
+
+        Example:
+        (floor(a) * 4 + 3) % 16 -> (floor(a) * 4) % 16 + 3
+        """
         if not isinstance(expr, sympy.Mod):
             return None
 
@@ -1145,6 +1152,11 @@ def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
         return ret
 
     def transform_floor(expr):
+        """Simplify rational addition inside floor expr
+
+        Example:
+        floor(floor(a)/3 + 1/6) -> floor(floor(a)/3)
+        """
         if not isinstance(expr, sympy.floor):
             return None
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1250,13 +1250,19 @@ def check_is_mapping_contiguous(
     expected_diff[-1] = 1
 
     # Assume fastest changing dim increments in elements_per_thread between individual ops,
-    # This is needed for sympy simplifications.
+    # This is tranform exressions floor(x/a + 1/b) into floor(floor(x/ept)*ept/a + 1/b)
+    # which is required for further sympy simplifications.
     subs[-1] = (subs[-1][0], (subs[-1][1] // elements_per_thread) * elements_per_thread)
+
+    # Construct indices for vector element 0
     prev_indices = _get_start_indices(
         {key: m.subs(subs) for key, m in zip(symbolc_shape, index_mapping)}
     )
+
+    # Construct indices for vector elements [1, 2, ..., elements_per_thread - 1]
+    # and compare with previous ones.
     for i in range(1, elements_per_thread, 1):
-        # Increment fastests changing dim in unmapped index by one and apply mapping.
+        # Increment fastest changing dim in unmapped index by one and apply mapping.
         subs[-1] = (subs[-1][0], subs[-1][1] + 1)
         next_result_index = {
             key: m.subs(subs) for key, m in zip(symbolc_shape, index_mapping)

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1211,6 +1211,10 @@ def check_is_mapping_contiguous(
     if elements_per_thread == 1:
         return True
 
+    # TODO: Better dyn vals analysis.
+    if mapping.num_dynamic_vals != 0:
+        return False
+
     if is_read:
         assert (
             mapping.is_output_identity()
@@ -1221,10 +1225,6 @@ def check_is_mapping_contiguous(
             mapping.is_input_identity()
         ), "non-identity input mapping is not supported yet"
         index_mapping = mapping.map_output_indices(symbolc_shape)
-
-    # TODO: Better dyn vals analysis.
-    if mapping.num_dynamic_vals != 0:
-        return False
 
     index_mapping = tuple(subs_idxc(i) for i in index_mapping)
 
@@ -1238,7 +1238,6 @@ def check_is_mapping_contiguous(
     # diff 1 in fastest changing dim and 0s in every other.
     expected_diff = [0] * len(index_mapping)
     expected_diff[-1] = 1
-    is_contiguous = True
 
     # Assume fastest changing dim increments in elements_per_thread between individual ops,
     # This is needed for sympy simplifications.

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1244,8 +1244,6 @@ def check_is_mapping_contiguous(
 
     subs = [(sym, expr.start) for sym, expr in zip(iters.keys(), index.values())]
 
-    result_index = {key: m.subs(subs) for key, m in zip(symbolc_shape, index_mapping)}
-
     # Iterate over elements_per_thread end check if every subsequent read have
     # diff 1 in fastest changing dim and 0s in every other.
     expected_diff = [0] * len(index_mapping)

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1083,13 +1083,19 @@ def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
         ret = None
         for arg in mul.args:
             if arg.is_number:
+                if arg < 0:
+                    return None
+
                 if ret is not None:
                     return None
 
                 ret = arg
                 continue
 
-            if not isinstance(arg, (sympy.floor, sympy.Mod)):
+            if not (isinstance(arg, (sympy.floor, sympy.Mod)) or arg.is_integer):
+                return None
+
+            if not arg.is_nonnegative:
                 return None
 
         return ret
@@ -1104,7 +1110,7 @@ def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
             return None
 
         p, q = expr.args
-        if not q.is_number:
+        if not q.is_number or q < 0:
             return None
 
         if not isinstance(p, sympy.Add):
@@ -1143,10 +1149,16 @@ def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
                 if ret is not None:
                     return None
 
+                if arg.p < 0 or arg.q < 0:
+                    return None
+
                 ret = arg
                 continue
 
-            if not isinstance(arg, (sympy.floor, sympy.Mod)):
+            if not (isinstance(arg, (sympy.floor, sympy.Mod)) or arg.is_integer):
+                return None
+
+            if not arg.is_nonnegative:
                 return None
 
         return ret
@@ -1184,10 +1196,10 @@ def _simplify_sympy_expr(expr: IndexExpr) -> IndexExpr:
                 return None
 
             r = check_mul_rational(arg)
-            if r is None:
+            if r is None or r.p != 1:
                 return None
 
-            if r < c:
+            if r <= c:
                 return None
 
             terms.append(arg)

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -165,7 +165,9 @@ class LaunchableWave(Launchable):
         reduction_nodes = trace.walk(is_reduction)
         for node in reduction_nodes:
             custom = get_custom(node)
-            self.induction_vars[custom] = tkl.IndexSymbol("$ARG" + str(custom.axis))
+            self.induction_vars[custom] = tkl.IndexSymbol(
+                "$ARG" + str(custom.axis), integer=True, nonnegative=True
+            )
             for tiling_constraint in self.tiling_constraints:
                 if tiling_constraint.dim == custom.axis:
                     tiling_constraint.induction_var = self.induction_vars[custom]

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -406,7 +406,7 @@ def test_read_write_dynamic_mapping():
     k = tkw.IndexMapping.dynamic_val(0)
     mapping = tkw.IndexMapping(
         num_iterators=2,
-        inputs={M: k, N: j},
+        inputs={M: i, N: k},
         outputs={M: i, N: j},
         dynamic_val_mappings={M: i, N: j},
     )
@@ -435,23 +435,26 @@ def test_read_write_dynamic_mapping():
         # CHECK-LABEL:    func.func @test
         # CHECK-SAME:       (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding)
         # CHECK-DAG:        %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<16xf16>
-        # CHECK-DAG:        %[[CST0:.*]] = arith.constant dense<16> : vector<16xindex>
-        # CHECK-DAG:        %[[CST1:.*]] = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
-        # CHECK-DAG:        %[[C0:.*]] = arith.constant 0 : index
+        # CHECK-DAG:        %[[D0:.*]] = arith.constant 0 : index
+        # CHECK-DAG:        %[[C16:.*]] = arith.constant 16 : index
+        # CHECK-DAG:        %[[C32:.*]] = arith.constant 32 : index
+        # CHECK-DAG:        %[[C64:.*]] = arith.constant 64 : index
+        # CHECK-DAG:        %[[C256:.*]] = arith.constant 256 : index
         # CHECK:            %[[D0:.*]] = stream.binding.subspan %[[ARG1]][%[[C0]]] : !stream.binding -> memref<16x16xi32, strided<[16, 1], offset: ?>>
         # CHECK:            %[[D9:.*]] = vector.load %[[D0]][%[[D5:.*]], %[[D8:.*]]] : memref<16x16xi32, strided<[16, 1], offset: ?>>, vector<16xi32>
         # CHECK:            %[[D10:.*]] = stream.binding.subspan %[[ARG0]][%[[C0]]] : !stream.binding -> memref<16x16xf16, strided<[16, 1], offset: ?>>
         # CHECK:            %[[D11:.*]] = arith.index_cast %[[D9]] : vector<16xi32> to vector<16xindex>
-        # CHECK-DAG:        %[[D18:.*]] = vector.constant_mask [16] : vector<16xi1>
-        # CHECK:            %[[D12:.*]] = arith.muli %[[D11]], %[[CST0]] overflow<nsw, nuw> : vector<16xindex>
-        # CHECK:            %[[D13:.*]] = vector.splat %{{.*}} : vector<16xindex>
-        # CHECK:            %[[D14:.*]] = arith.addi %[[D13]], %[[D12]] overflow<nsw, nuw> : vector<16xindex>
-        # CHECK:            %[[D15:.*]] = vector.splat %{{.*}} : vector<16xindex>
-        # CHECK:            %[[D16:.*]] = arith.addi %[[D14]], %[[D15]] overflow<nsw, nuw> : vector<16xindex>
-        # CHECK:            %[[D17:.*]] = arith.addi %[[D16]], %[[CST1]] overflow<nsw, nuw> : vector<16xindex>
-        # CHECK:            %[[D19:.*]] = vector.gather %[[D10]][%[[C0]], %[[C0]]] [%[[D17]]], %[[D18]], %[[CST]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xindex>, vector<16xi1>, vector<16xf16> into vector<16xf16>
-        # CHECK:            %[[D20:.*]] = stream.binding.subspan %[[ARG2]][%[[C0]]] : !stream.binding -> memref<16x16xf16, strided<[16, 1], offset: ?>>
-        # CHECK:            vector.store %[[D19]], %[[D20]][%[[D5]], %[[D8]]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xf16>
+        # CHECK-DAG:        %[[D12:.*]] = vector.constant_mask [16] : vector<16xi1>
+        # CHECK:            %[[D13:.*]] = arith.muli %{{.*}}, %[[C16]] overflow<nsw, nuw> : index
+        # CHECK:            %[[D14:.*]] = arith.muli %{{.*}}, %[[C256]] overflow<nsw, nuw> : index
+        # CHECK:            %[[D15:.*]] = arith.muli %{{.*}}, %[[C256]] overflow<nsw, nuw> : index
+        # CHECK:            %[[D16:.*]] = arith.addi %[[D15]], %[[D14]] overflow<nsw, nuw> : index
+        # CHECK:            %[[D17:.*]] = arith.addi %[[D16]], %[[D13]] overflow<nsw, nuw> : index
+        # CHECK:            %[[D18:.*]] = vector.splat %[[D17]] : vector<16xindex>
+        # CHECK:            %[[D19:.*]] = arith.addi %[[D18]], %[[D11]] overflow<nsw, nuw> : vector<16xindex>
+        # CHECK:            %[[D20:.*]] = vector.gather %[[D10]][%[[C0]], %[[C0]]] [%[[D19]]], %[[D12]], %[[CST]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xindex>, vector<16xi1>, vector<16xf16> into vector<16xf16>
+        # CHECK:            %[[D21:.*]] = stream.binding.subspan %[[ARG2]][%[[C0]]] : !stream.binding -> memref<16x16xf16, strided<[16, 1], offset: ?>>
+        # CHECK:            vector.store %[[D20]], %[[D21]][%[[D5]], %[[D8]]] : memref<16x16xf16, strided<[16, 1], offset: ?>>, vector<16xf16>
 
 
 @run_test

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1754,12 +1754,7 @@ def test_igemm():
     )
     w_mapping = tkw.IndexMapping(
         num_iterators=2,
-        inputs={
-            NF: i * BLOCK_N,
-            C: j % C,
-            HF: (j // C) % WF,
-            WF: (j // C) // WF,
-        },
+        inputs={NF: i % NF, C: j % C, HF: (j // C) % WF, WF: (j // C) // WF},
         outputs={NF: i, K: j},
     )
     out_mapping = tkw.IndexMapping(
@@ -1852,8 +1847,10 @@ def test_igemm():
         # CHECK-LABEL: func @conv
         #  CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
 
-        # Check we are setting gather start indices to 0
-        #      CHECK: %{{.*}} = vector.gather %{{.*}}[%[[C0]], %[[C0]], %[[C0]], %[[C0]]] [%{{.*}}], %{{.*}}, %{{.*}} : memref<2x64x64x640xf16
+        # Input load must be contiguous.
+        #      CHECK: %{{.*}} = vector.maskedload %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}], %{{.*}}, %{{.*}} : memref<2x64x64x640xf16
+
+        # Weights are done via gather, check we are setting gather start indices to 0.
         #      CHECK: %{{.*}} = vector.gather %{{.*}}[%[[C0]], %[[C0]], %[[C0]], %[[C0]]] [%{{.*}}], %{{.*}}, %{{.*}} : memref<3x3x640x640xf16
         #      CHECK: %{{.*}} = vector.gather %{{.*}}[%[[C0]], %[[C0]], %[[C0]], %[[C0]]] [%{{.*}}], %{{.*}}, %{{.*}} : memref<3x3x640x640xf16
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -151,7 +151,7 @@ def test_read_mapped():
         # CHECK-DAG:        %[[C17:.+]] = arith.constant 17 : index
         # CHECK:            %[[D7:.+]] = arith.muli %[[THREAD_ID_Y]], %[[C17]] overflow<nsw, nuw> : index
         # CHECK:            %[[D8:.+]] = arith.addi %[[D7]], %[[D6]] overflow<nsw, nuw> : index
-        # CHECK:            %[[CST:.+]] = arith.constant dense<[0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240]> : vector<16xindex>
+        # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<[0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240]> : vector<16xindex>
         # CHECK-DAG:        %[[CST_2:.+]] = arith.constant 0.000000e+00 : f16
         # CHECK:            %[[D9:.+]] = vector.splat %[[CST_2]] : vector<16xf16>
         # CHECK:            %[[D10:.+]] = vector.gather %[[ARR]][%[[D5]], %[[D8]]] [%[[CST]]], %[[MASK]], %[[D9]] :

--- a/tests/kernel/wave/wave_utils_test.py
+++ b/tests/kernel/wave/wave_utils_test.py
@@ -4,23 +4,24 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import logging
-import unittest
 from iree.turbine.kernel.lang import sym
-from iree.turbine.kernel.wave.utils import delinearize_index
+from iree.turbine.kernel.wave.utils import delinearize_index, _simplify_sympy_expr
+import sympy
 import numpy as np
 
 M = sym.M
 
 
-class UtilsTest(unittest.TestCase):
-    def testDelinearizeIndex(self):
-        shape = [5, 4, 3]
-        nd_index = delinearize_index(M, shape)
-        np_nd_index = np.unravel_index(23, shape)
-        assert np.equal([x.subs({M: 23}) for x in nd_index], np_nd_index).all()
+def test_delinearize_index():
+    shape = [5, 4, 3]
+    nd_index = delinearize_index(M, shape)
+    np_nd_index = np.unravel_index(23, shape)
+    assert np.equal([x.subs({M: 23}) for x in nd_index], np_nd_index).all()
 
 
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    unittest.main()
+def test_custom_sympy_simplifications():
+    mod_expr = sympy.sympify("(floor(a) * 4 + 3) % 16")
+    assert str(_simplify_sympy_expr(mod_expr)) == "4*(Mod(floor(a), 4)) + 3"
+
+    floor_expr = sympy.sympify("floor(floor(a)/3 + 1/6)")
+    assert str(_simplify_sympy_expr(floor_expr)) == "floor(floor(a)/3)"

--- a/tests/kernel/wave/wave_utils_test.py
+++ b/tests/kernel/wave/wave_utils_test.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import pytest
 from iree.turbine.kernel.lang import sym
 from iree.turbine.kernel.wave.utils import delinearize_index, _simplify_sympy_expr
 import sympy
@@ -20,8 +21,111 @@ def test_delinearize_index():
 
 
 def test_custom_sympy_simplifications():
-    mod_expr = sympy.sympify("(floor(a) * 4 + 3) % 16")
-    assert str(_simplify_sympy_expr(mod_expr)) == "4*(Mod(floor(a), 4)) + 3"
+    a = sympy.Symbol("a", integer=True, nonnegative=True)
+    mod_expr = (sympy.floor(a) * 4 + 3) % 16
+    assert str(_simplify_sympy_expr(mod_expr)) == "4*(Mod(a, 4)) + 3"
 
-    floor_expr = sympy.sympify("floor(floor(a)/3 + 1/6)")
-    assert str(_simplify_sympy_expr(floor_expr)) == "floor(floor(a)/3)"
+    floor_expr = sympy.floor(sympy.floor(a) / 3 + sympy.sympify(1) / 6)
+    assert str(_simplify_sympy_expr(floor_expr)) == "floor(a/3)"
+
+
+@pytest.mark.skip("Too slow")
+def test_fuzz_custom_sympy_simplifications_mod():
+    x = sympy.Symbol("x", integer=True, nonnegative=True)
+    a = sympy.Symbol("a")
+    b = sympy.Symbol("b")
+    c = sympy.Symbol("c")
+
+    import random
+
+    expr = (sympy.floor(x) * a + b) % c
+    total = 0
+    outer_num_iters = 1000
+    for i in range(outer_num_iters):
+
+        a_val = random.randint(2, 50)
+        b_val = random.randint(1, a_val - 1)
+        c_val = a_val * random.randint(1, 10)
+
+        vals = [a_val, b_val, c_val]
+        expr = expr.subs({a: vals[0], b: vals[1], c: vals[2]})
+        expr = sympy.simplify(expr)
+
+        expr2 = _simplify_sympy_expr(expr)
+
+        if i % 50 == 0 and i > 0:
+            print(f"{100*i/outer_num_iters}%")
+
+        if expr == expr2:
+            print("skip", vals)
+            continue
+
+        vals2 = vals + [0, 1]
+        for j in range(100):
+            val = vals2[j] if j < len(vals2) else random.randint(0, c_val * 2)
+            if expr.subs({x: val}) != expr2.subs({x: val}):
+                print(f"Failed: {vals}, {val}")
+
+            assert expr.subs({x: val}) == expr2.subs({x: val})
+            total += 1
+
+    print(f"Sucess: {total} checks")
+
+
+@pytest.mark.skip("Too slow")
+def test_fuzz_custom_sympy_simplifications_floor():
+    x = sympy.Symbol("x", integer=True, nonnegative=True)
+    a = sympy.Symbol("a")
+    b = sympy.Symbol("b")
+    c = sympy.Symbol("c")
+    d = sympy.Symbol("d")
+
+    import random
+
+    orig_expr = sympy.floor(sympy.floor(x) * a / b + c / d)
+
+    def check_specific(*vals):
+        expr1 = orig_expr.subs({a: vals[0], b: vals[1], c: vals[2], d: vals[3]})
+        expr1 = sympy.simplify(expr1)
+
+        expr2 = _simplify_sympy_expr(expr1)
+        assert expr1.subs({x: vals[4]}) == expr2.subs({x: vals[4]})
+
+    check_specific(10, 11, 6, 10, 6)
+    check_specific(8, 5, 1, 5, 8)
+
+    total = 0
+    outer_num_iters = 500
+    for i in range(outer_num_iters):
+        while True:
+            a_val = 1  # random.randint(1, 10)
+            b_val = random.randint(1, 10)
+            if b_val == a_val:
+                b_val += 1
+
+            c_val = random.randint(1, 10)
+            d_val = random.randint(1, 10)
+            if d_val == c_val:
+                d_val += 1
+
+            vals = [a_val, b_val, c_val, d_val]
+            expr = orig_expr.subs({a: vals[0], b: vals[1], c: vals[2], d: vals[3]})
+            expr = sympy.simplify(expr)
+
+            expr2 = _simplify_sympy_expr(expr)
+            if expr != expr2:
+                break
+
+        if i % 50 == 0 and i > 0:
+            print(f"{100*i/outer_num_iters}%")
+
+        vals2 = vals + [-1, 0, 1]
+        for j in range(100):
+            val = vals2[j] if j < len(vals2) else random.randint(0, c_val * 2)
+            if expr.subs({x: val}) != expr2.subs({x: val}):
+                print(f"Failed: {vals}, {val}")
+
+            assert expr.subs({x: val}) == expr2.subs({x: val})
+            total += 1
+
+    print(f"Sucess: {total} checks")


### PR DESCRIPTION
Add utility to detect contiguous access pattern in mapped reads/writes so we can use contiguous vector ops instead of gathers/scatters during lowering.

Iterate over `elements_per_thread` and check if every subsequent mapped index have only diff of 1 in fastest changing dim.

Also, it need some custom sympy simplifications to successfully work on IGEMM conv.