### PR TITLE
Add evoformer example

### DIFF
--- a/iree/turbine/kernel/_support/dtype.py
+++ b/iree/turbine/kernel/_support/dtype.py
@@ -1,5 +1,6 @@
 __all__ = [
     "DataType",
+    "bf16",
     "bool",
     "i4",
     "i8",
@@ -17,7 +18,16 @@ __all__ = [
 ]
 
 _INT_TYPES = ["i1", "i4", "i8", "i16", "i32", "i64"]
-_FLOAT_TYPES = ["f16", "f32", "f64", "f8E5M2", "f8E5M2FNUZ", "f8E4M3FN", "f8E4M3FNUZ"]
+_FLOAT_TYPES = [
+    "bf16",
+    "f16",
+    "f32",
+    "f64",
+    "f8E5M2",
+    "f8E5M2FNUZ",
+    "f8E4M3FN",
+    "f8E4M3FNUZ",
+]
 _INDEX_TYPES = ["index"]
 
 
@@ -55,9 +65,12 @@ class DataType:
             return 64
         if "f8" in self._name:
             return 8
+        if "bf16" in self._name:
+            return 16
         return int(self._name[1:])
 
 
+bf16 = DataType("bf16")
 bool = DataType("bool", "i1")
 i4 = DataType("i4")
 i8 = DataType("i8")

--- a/iree/turbine/kernel/lang/__init__.py
+++ b/iree/turbine/kernel/lang/__init__.py
@@ -13,6 +13,7 @@ from .._support.indexing import (
 )
 
 from .._support.dtype import (
+    DataType,
     bf16,
     bool,
     i4,

--- a/iree/turbine/kernel/lang/__init__.py
+++ b/iree/turbine/kernel/lang/__init__.py
@@ -13,6 +13,7 @@ from .._support.indexing import (
 )
 
 from .._support.dtype import (
+    bf16,
     bool,
     i4,
     i8,

--- a/iree/turbine/kernel/lang/global_symbols.py
+++ b/iree/turbine/kernel/lang/global_symbols.py
@@ -1,4 +1,5 @@
 from .._support.indexing import index_symbol
+import sys
 
 # Global symbols used throughout the code.
 
@@ -6,12 +7,31 @@ from .._support.indexing import index_symbol
 GLOBAL_ADDRESS_SPACE = index_symbol("$GLOBAL_ADDRESS_SPACE")
 SHARED_ADDRESS_SPACE = index_symbol("$SHARED_ADDRESS_SPACE")
 
+
 # Distribution symbols.
 WORKGROUP_0 = index_symbol("$WG0")
 WORKGROUP_1 = index_symbol("$WG1")
 WORKGROUP_2 = index_symbol("$WG2")
-WORKGROUP_3 = index_symbol("$WG3")
-WORKGROUP_4 = index_symbol("$WG4")
+
+
+def create_additional_workgroup_symbols():
+    """
+    Since we can have a large number of workgroups, we create
+    symbols for them dynamically. However, only WORKGROUP_0,
+    WORKGROUP_1, and WORKGROUP_2 will persist during code generation,
+    so we generate those symbols statically.
+    """
+    max_workgroups = 5
+    for i in range(3, max_workgroups):
+        globals()[f"WORKGROUP_{i}"] = index_symbol(f"$WG{i}")
+
+
+def get_workgroup_symbol(i: int):
+    assert i >= 0, "Workgroup index must be non-negative."
+    return index_symbol(f"$WG{i}")
+
+
+create_additional_workgroup_symbols()
 
 THREAD_0 = index_symbol("$T0")
 THREAD_1 = index_symbol("$T1")

--- a/iree/turbine/kernel/lang/global_symbols.py
+++ b/iree/turbine/kernel/lang/global_symbols.py
@@ -1,5 +1,4 @@
 from .._support.indexing import index_symbol
-import sys
 
 # Global symbols used throughout the code.
 
@@ -14,24 +13,13 @@ WORKGROUP_1 = index_symbol("$WG1")
 WORKGROUP_2 = index_symbol("$WG2")
 
 
-def create_additional_workgroup_symbols():
-    """
-    Since we can have a large number of workgroups, we create
-    symbols for them dynamically. However, only WORKGROUP_0,
-    WORKGROUP_1, and WORKGROUP_2 will persist during code generation,
-    so we generate those symbols statically.
-    """
-    max_workgroups = 5
-    for i in range(3, max_workgroups):
-        globals()[f"WORKGROUP_{i}"] = index_symbol(f"$WG{i}")
-
-
 def get_workgroup_symbol(i: int):
     assert i >= 0, "Workgroup index must be non-negative."
+    symbol_name = f"WORKGROUP_{i}"
+    if symbol_name not in globals():
+        globals()[symbol_name] = index_symbol(f"$WG{i}")
     return index_symbol(f"$WG{i}")
 
-
-create_additional_workgroup_symbols()
 
 THREAD_0 = index_symbol("$T0")
 THREAD_1 = index_symbol("$T1")

--- a/iree/turbine/kernel/lang/global_symbols.py
+++ b/iree/turbine/kernel/lang/global_symbols.py
@@ -10,6 +10,8 @@ SHARED_ADDRESS_SPACE = index_symbol("$SHARED_ADDRESS_SPACE")
 WORKGROUP_0 = index_symbol("$WG0")
 WORKGROUP_1 = index_symbol("$WG1")
 WORKGROUP_2 = index_symbol("$WG2")
+WORKGROUP_3 = index_symbol("$WG3")
+WORKGROUP_4 = index_symbol("$WG4")
 
 THREAD_0 = index_symbol("$T0")
 THREAD_1 = index_symbol("$T1")

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -328,6 +328,24 @@ class WorkgroupConstraint(Constraint):
     tile_size: IndexExpr
     workgroup_dim: int
 
+    def __post_init__(self):
+        self.wg_dim = None
+        match self.workgroup_dim:
+            case 0:
+                self.wg_dim = WORKGROUP_0
+            case 1:
+                self.wg_dim = WORKGROUP_1
+            case 2:
+                self.wg_dim = WORKGROUP_2
+            case 3:
+                self.wg_dim = WORKGROUP_3
+            case 4:
+                self.wg_dim = WORKGROUP_4
+            case _:
+                raise ValueError(
+                    "Invalid workgroup dimension. Expected 0, 1, 2, 3 or 4."
+                )
+
     @property
     def count(self) -> IndexExpr:
         """
@@ -336,16 +354,7 @@ class WorkgroupConstraint(Constraint):
         return ceiling(self.dim / self.tile_size)
 
     def apply(self) -> IndexSequence:
-        match self.workgroup_dim:
-            case 0:
-                wg_dim = WORKGROUP_0
-            case 1:
-                wg_dim = WORKGROUP_1
-            case 2:
-                wg_dim = WORKGROUP_2
-            case _:
-                raise ValueError("Invalid workgroup dimension. Expected 0, 1 or 2.")
-        return IndexSequence(wg_dim * self.tile_size, 1)
+        return IndexSequence(self.wg_dim * self.tile_size, 1)
 
 
 def get_grid_shape(wg_constraints: list[WorkgroupConstraint]) -> list[IndexExpr]:

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -130,9 +130,17 @@ class HardwareConstraint(Constraint):
                 return (16, 16, 16)
             case MMAType.F32_32x32x8_F16 | MMAType.I32_32x32x8_I8:
                 return (32, 32, 8)
-            case MMAType.F32_16x16x32_F8 | MMAType.F32_16x16x32_K4_F8 | MMAType.I32_16x16x32_I8:
+            case (
+                MMAType.F32_16x16x32_F8
+                | MMAType.F32_16x16x32_K4_F8
+                | MMAType.I32_16x16x32_I8
+            ):
                 return (16, 16, 32)
-            case MMAType.F32_32x32x16_F8 | MMAType.F32_32x32x16_K4_F8 | MMAType.I32_32x32x16_I8:
+            case (
+                MMAType.F32_32x32x16_F8
+                | MMAType.F32_32x32x16_K4_F8
+                | MMAType.I32_32x32x16_I8
+            ):
                 return (32, 32, 16)
             case _:
                 return ()
@@ -234,7 +242,11 @@ class HardwareConstraint(Constraint):
                     1,  # N
                     1,  # K
                 ]
-            case MMAType.F32_16x16x32_F8 | MMAType.F32_16x16x32_K4_F8 | MMAType.I32_16x16x32_I8:
+            case (
+                MMAType.F32_16x16x32_F8
+                | MMAType.F32_16x16x32_K4_F8
+                | MMAType.I32_16x16x32_I8
+            ):
                 offset = [
                     Piecewise(
                         (lane % 16, ~MMA_ACC), (4 * floor(lane / 16), MMA_ACC)
@@ -262,7 +274,11 @@ class HardwareConstraint(Constraint):
                         + 4 * floor(lane / 16)
                         + (GPR_NUM % 4),  # K
                     ]
-            case MMAType.F32_32x32x16_F8 | MMAType.F32_32x32x16_K4_F8 | MMAType.I32_32x32x16_I8:
+            case (
+                MMAType.F32_32x32x16_F8
+                | MMAType.F32_32x32x16_K4_F8
+                | MMAType.I32_32x32x16_I8
+            ):
                 offset = [
                     Piecewise(
                         (lane % 32, ~MMA_ACC),
@@ -331,16 +347,8 @@ class WorkgroupConstraint(Constraint):
     def __post_init__(self):
         self.wg_dim = None
         match self.workgroup_dim:
-            case 0:
-                self.wg_dim = WORKGROUP_0
-            case 1:
-                self.wg_dim = WORKGROUP_1
-            case 2:
-                self.wg_dim = WORKGROUP_2
-            case 3:
-                self.wg_dim = WORKGROUP_3
-            case 4:
-                self.wg_dim = WORKGROUP_4
+            case 0 | 1 | 2 | 3 | 4:
+                self.wg_dim = get_workgroup_symbol(self.workgroup_dim)
             case _:
                 raise ValueError(
                     "Invalid workgroup dimension. Expected 0, 1, 2, 3 or 4."

--- a/iree/turbine/kernel/wave/templates/evoformer.py
+++ b/iree/turbine/kernel/wave/templates/evoformer.py
@@ -1,0 +1,207 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel._support.dtype import DataType
+from iree.turbine.kernel.wave.utils import (
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+)
+
+
+def get_evoformer_kernel(
+    batch: tuple[int, int],
+    n: tuple[int, int],
+    kv_seq_len: tuple[int, int],
+    heads: tuple[int, int],
+    head_dim: tuple[int, int],
+    q_seq_len: tuple[int, int],
+    v_dim: tuple[int, int],
+    mfma_variant: MMAType,
+    datatype: DataType,
+):
+    assert datatype in [tkl.f16, tkl.bf16], f"Unsupported datatype: {datatype}"
+
+    # Input sizes
+    B = tkl.sym.B
+    BN = tkl.sym.BN
+    M = tkl.sym.M
+    H = tkl.sym.H
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_BN = tkl.sym.BLOCK_BN
+    BLOCK_H = tkl.sym.BLOCK_H
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.WorkgroupConstraint(BN, BLOCK_BN, 3)]
+    constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 4)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    if mfma_variant == MMAType.F32_16x16x16_F16:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant == MMAType.F32_32x32x8_F16:
+        Mvec = 32
+        Nvec = 32
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0, BN: 0, H: 0, M: Mvec, N: Nvec},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    l = tkw.IndexMapping.iterator(3)
+    m = tkw.IndexMapping.iterator(4)
+    # [B, BN, M, H, K1] -> [B, BN, H, M, K1]
+    q_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, M: l, K1: m},
+        outputs={B: i, BN: j, H: k, M: l, K1: m},
+    )
+    # [B, BN, K2, H, K1] -> [B, BN, H, K2, K1]
+    k_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, K2: l, K1: m},
+        outputs={B: i, BN: j, H: k, K2: l, K1: m},
+    )
+    # [B, BN, N, H, K2] -> [B, BN, H, N, K2]
+    v_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, K2: m},
+        outputs={B: i, BN: j, H: k, N: l, K2: m},
+    )
+    # [B, BN, H, N, M] -> [B, BN, M, H, N]
+    o_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, M: m},
+        outputs={B: i, BN: j, H: k, N: l, M: m},
+    )
+
+    @tkw.wave(constraints)
+    def evoformer_fwd(
+        q: tkl.Memory[B, BN, M, H, K1, ADDRESS_SPACE, datatype],
+        k: tkl.Memory[B, BN, K2, H, K1, ADDRESS_SPACE, datatype],
+        v: tkl.Memory[B, BN, N, H, K2, ADDRESS_SPACE, datatype],
+        mask: tkl.Memory[B, BN, K2, GLOBAL_ADDRESS_SPACE, datatype],
+        bias: tkl.Memory[B, H, M, K2, GLOBAL_ADDRESS_SPACE, datatype],
+        c: tkl.Memory[B, BN, M, H, N, GLOBAL_ADDRESS_SPACE, datatype],
+    ):
+        c_reg = tkl.Register[B, BN, H, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, BN, H, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, BN, H, M, tkl.f32](-1e6)
+
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, BN, H, M, tkl.f32],
+            partial_sum: tkl.Register[B, BN, H, M, tkl.f32],
+            acc: tkl.Register[B, BN, H, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, BN, H, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(
+                q, mapping=q_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            if datatype == tkl.bf16:
+                q_reg = tkw.cast(tkw.cast(q_reg, tkl.f32), tkl.f16)
+            k_reg = tkw.read(
+                k, mapping=k_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            if datatype == tkl.bf16:
+                k_reg = tkw.cast(tkw.cast(k_reg, tkl.f32), tkl.f16)
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, BN, H, M, K2])
+            mask_reg = tkw.read(mask, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_mask_reg = tkw.cast(mask_reg, tkl.f32)
+            y_j = x_j + casted_mask_reg
+            bias_reg = tkw.read(bias, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_bias_reg = tkw.cast(bias_reg, tkl.f32)
+            z_j = y_j + casted_bias_reg
+            m_j = tkw.max(z_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(z_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(
+                v, mapping=v_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            if datatype == tkl.bf16:
+                v_reg = tkw.cast(tkw.cast(v_reg, tkl.f32), tkl.f16)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        casted = tkw.cast(res, datatype)
+        tkw.write(
+            casted, c, mapping=o_mapping, elements_per_thread=STORE_ELEMS_PER_THREAD
+        )
+
+    SHAPE = 0
+    TILE_SIZE = 1
+
+    symbols = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        B: batch[SHAPE],
+        BN: n[SHAPE],
+        K2: kv_seq_len[SHAPE],
+        H: heads[SHAPE],
+        K1: head_dim[SHAPE],
+        M: q_seq_len[SHAPE],
+        N: v_dim[SHAPE],
+        BLOCK_B: batch[TILE_SIZE],
+        BLOCK_BN: n[TILE_SIZE],
+        BLOCK_H: heads[TILE_SIZE],
+        BLOCK_M: q_seq_len[TILE_SIZE],
+        BLOCK_N: v_dim[TILE_SIZE],
+        BLOCK_K2: kv_seq_len[TILE_SIZE],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        VALU_DELAY: 1,
+        SHUFFLE_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+        VALU_UNITS: 2,
+        SHUFFLE_UNITS: 2,
+    }
+
+    return evoformer_fwd, symbols

--- a/iree/turbine/kernel/wave/templates/evoformer.py
+++ b/iree/turbine/kernel/wave/templates/evoformer.py
@@ -190,18 +190,6 @@ def get_evoformer_kernel(
         BLOCK_M: q_seq_len[TILE_SIZE],
         BLOCK_N: v_dim[TILE_SIZE],
         BLOCK_K2: kv_seq_len[TILE_SIZE],
-        READ_SHARED_DELAY: 1,
-        WRITE_SHARED_DELAY: 1,
-        READ_GLOBAL_DELAY: 2,
-        WRITE_GLOBAL_DELAY: 2,
-        MMA_DELAY: 1,
-        VALU_DELAY: 1,
-        SHUFFLE_DELAY: 1,
-        SHARED_MEMORY_UNITS: 4,
-        GLOBAL_MEMORY_UNITS: 4,
-        MMA_UNITS: 4,
-        VALU_UNITS: 2,
-        SHUFFLE_UNITS: 2,
     }
 
     return evoformer_fwd, symbols

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -232,7 +232,9 @@ def remove_chained_extractslice(trace: CapturedTrace):
                 get_custom(node).graph.erase_node(src_extract.fx_node)
 
 
-def delinearize_index(index: IndexExpr, shape: list[int]) -> list[IndexExpr]:
+def delinearize_index(
+    index: IndexExpr, shape: list[int | IndexExpr]
+) -> list[IndexExpr]:
     """
     Delinearizes a 1D index into a multi-dimensional index
     based on the shapes provided. The returned array contains

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -30,6 +30,7 @@ from .utils import (
     remove_chained_getresult,
     remove_chained_extractslice,
     subs_idxc,
+    delinearize_index,
 )
 from .minimize_global_loads import minimize_global_loads
 from .decompose_reduce_ops import decompose_reduce_ops
@@ -207,6 +208,23 @@ class LaunchableWave(Launchable):
                 if tiling_constraint.dim == get_custom(reduction).axis:
                     reduction.count = subs_idxc(tiling_constraint.count)
 
+    def initialize_workgroup_constraints(self, trace: CapturedTrace) -> None:
+        """
+        For kernels that distribute more than three dimensions among workgroups,
+        we need to update the workgroup constraints for dimensions >= 2
+        with the appropriate workgroup index.
+        """
+        workgroup_dims = {x.workgroup_dim: x for x in self.workgroup_constraints}
+        if all(x <= 2 for x in workgroup_dims.keys()):
+            return
+        shape = [
+            subs_idxc(workgroup_dims[i].count)
+            for i in range(2, max(workgroup_dims.keys()) + 1)
+        ]
+        new_workgroup_dims = delinearize_index(WORKGROUP_2, shape)
+        for i in range(2, max(workgroup_dims.keys()) + 1):
+            workgroup_dims[i].wg_dim = new_workgroup_dims[i - 2]
+
     def _trace_and_get_kernel_signature(
         self,
         args,
@@ -220,6 +238,7 @@ class LaunchableWave(Launchable):
         self.create_induction_vars(graph)
         self.initialize_wave_constraints(graph)
         self.initialize_reductions(graph)
+        self.initialize_workgroup_constraints(graph)
 
         idxc = IndexingContext.current()
         idxc.finalize()
@@ -286,10 +305,14 @@ class LaunchableWave(Launchable):
 
         # Determine grid shape.
         self.grid_type.dims = [1, 1, 1]
+        max_workgroup_dim = 2
         for constraint in self.workgroup_constraints:
-            self.grid_type.dims[constraint.workgroup_dim] = safe_subs(
-                constraint.count, idxc.subs
+            dim = (
+                constraint.workgroup_dim
+                if constraint.workgroup_dim < max_workgroup_dim
+                else max_workgroup_dim
             )
+            self.grid_type.dims[dim] *= safe_subs(constraint.count, idxc.subs)
         grid = self.grid_type
 
         root_graph = graph.get_root_graph()

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -15,12 +15,16 @@ import torch
 
 # Input sizes
 B = tkl.sym.B
+BN = tkl.sym.BN
 M = tkl.sym.M
+H = tkl.sym.H
 N = tkl.sym.N
 K1 = tkl.sym.K1
 K2 = tkl.sym.K2
 # Workgroup tile sizes
 BLOCK_B = tkl.sym.BLOCK_B
+BLOCK_BN = tkl.sym.BLOCK_BN
+BLOCK_H = tkl.sym.BLOCK_H
 BLOCK_M = tkl.sym.BLOCK_M
 BLOCK_N = tkl.sym.BLOCK_N
 BLOCK_K2 = tkl.sym.BLOCK_K2
@@ -29,6 +33,179 @@ ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
 # Other hyperparameters
 LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
 STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+
+@run_test
+def test_evoformer():
+    # B, BN, K2, H, K1, M, N
+    shape = (1, 256, 256, 4, 32, 256, 32)
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.WorkgroupConstraint(BN, BLOCK_BN, 3)]
+    constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 4)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    mfma_variant = tkw.MMAType.F32_16x16x16_F16
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0, BN: 0, H: 0, M: 16, N: 16},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    l = tkw.IndexMapping.iterator(3)
+    m = tkw.IndexMapping.iterator(4)
+    # [B, BN, M, H, K1] -> [B, BN, H, M, K1]
+    q_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, M: l, K1: m},
+        outputs={B: i, BN: j, H: k, M: l, K1: m},
+    )
+    # [B, BN, K2, H, K1] -> [B, BN, H, K2, K1]
+    k_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, K2: l, K1: m},
+        outputs={B: i, BN: j, H: k, K2: l, K1: m},
+    )
+    # [B, BN, K2, H, N] -> [B, BN, H, N, K2]
+    v_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, K2: m},
+        outputs={B: i, BN: j, H: k, N: l, K2: m},
+    )
+    # [B, BN, H, N, M] -> [B, BN, M, H, N]
+    o_mapping = tkw.IndexMapping(
+        num_iterators=5,
+        inputs={B: i, BN: j, H: k, N: l, M: m},
+        outputs={B: i, BN: j, H: k, N: l, M: m},
+    )
+
+    @tkw.wave(constraints)
+    def evoformer(
+        q: tkl.Memory[B, BN, M, H, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, BN, K2, H, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, BN, K2, H, N, ADDRESS_SPACE, tkl.f16],
+        mask: tkl.Memory[B, BN, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        bias: tkl.Memory[B, H, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, BN, M, H, N, GLOBAL_ADDRESS_SPACE, tkl.f16],
+    ):
+        c_reg = tkl.Register[B, BN, H, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, BN, H, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, BN, H, M, tkl.f32](-1e6)
+
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, BN, H, M, tkl.f32],
+            partial_sum: tkl.Register[B, BN, H, M, tkl.f32],
+            acc: tkl.Register[B, BN, H, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, M, tkl.f32],
+            tkl.Register[B, BN, H, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, BN, H, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(
+                q, mapping=q_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            k_reg = tkw.read(
+                k, mapping=k_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, BN, H, M, K2])
+            mask_reg = tkw.read(mask, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_mask_reg = tkw.cast(mask_reg, tkl.f32)
+            y_j = x_j + casted_mask_reg
+            bias_reg = tkw.read(bias, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            casted_bias_reg = tkw.cast(bias_reg, tkl.f32)
+            z_j = y_j + casted_bias_reg
+            m_j = tkw.max(z_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(z_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(
+                v, mapping=v_mapping, elements_per_thread=LOAD_ELEMS_PER_THREAD
+            )
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        casted = tkw.cast(res, tkl.f16)
+        tkw.write(
+            casted, c, mapping=o_mapping, elements_per_thread=STORE_ELEMS_PER_THREAD
+        )
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        B: shape[0],
+        BN: shape[1],
+        K2: shape[2],
+        H: shape[3],
+        K1: shape[4],
+        M: shape[5],
+        N: shape[6],
+        BLOCK_B: 1,
+        BLOCK_BN: 1,
+        BLOCK_H: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 32,
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        VALU_DELAY: 1,
+        SHUFFLE_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+        VALU_UNITS: 2,
+        SHUFFLE_UNITS: 2,
+    }
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=False,
+        run_bench=False,
+        schedule=False,
+        use_scheduling_barriers=False,
+    ):
+        torch.manual_seed(0)
+        q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
+        output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        print(evoformer(q, k, v, output).module_op)
+
+        # CHECK:            func.func @evoformer
+        # CHECK:                {{.*}} = scf.for
+        # CHECK-COUNT-5:            {{.*}} = vector.load
+        # CHECK-COUNT-1:            vector.store {{.*}}
+        # CHECK-COUNT-4:            {{.*}} = vector.load
+        # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma
+        # CHECK-COUNT-2:            {{.*}} = vector.load
+        # CHECK-COUNT-2:            {{.*}} = arith.extf
+        # CHECK-COUNT-4:            {{.*}} = arith.addf
+        # CHECK-COUNT-4:            {{.*}} = vector.load
+        # CHECK-COUNT-4:            {{.*}} = arith.extf
+        # CHECK-COUNT-4:            {{.*}} = arith.addf
 
 
 # This test sets all the dimensions except K1 to be dynamic.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pytest==8.0.0
 pytest-xdist==3.5.0
 lit==18.1.7
 mypy==1.8.0
+ml_dtypes==0.5.0
 setuptools
 wheel
 

--- a/tests/kernel/wave/constraints_test.py
+++ b/tests/kernel/wave/constraints_test.py
@@ -44,9 +44,9 @@ class ConstraintsTest(unittest.TestCase):
         # Checking invalid workgroup dimension
         with pytest.raises(
             ValueError,
-            match="Invalid workgroup dimension. Expected 0, 1 or 2.",
+            match="Invalid workgroup dimension. Expected 0, 1, 2, 3 or 4.",
         ):
-            WorkgroupConstraint(N, BLOCK_N, 3).apply()
+            WorkgroupConstraint(N, BLOCK_N, 100).apply()
 
     def testTilingConstraint(self):
         constraints: list[TilingConstraint] = [TilingConstraint(M, BLOCK_M)]

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -1,0 +1,154 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import torch
+from torch.nn import functional as F
+import math
+import iree.turbine.kernel as tk
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.utils import (
+    get_default_run_config,
+    get_default_arch,
+    device_randn,
+    device_zeros,
+    device_randint,
+)
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.templates.evoformer import get_evoformer_kernel
+from iree.turbine.kernel._support.dtype import DataType
+import os
+
+_run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
+require_e2e = pytest.mark.skipif(not _run_e2e, reason="e2e tests are disabled")
+require_cdna3 = pytest.mark.skipif(
+    "gfx94" not in get_default_arch(), reason="Default device is not CDNA3"
+)
+# Whether to dump the generated MLIR module.
+test_dump_generated_mlir = int(os.environ.get("WAVE_DUMP_MLIR", 0))
+# Whether to use scheduling group barriers (needs LLVM fix).
+enable_scheduling_barriers = int(os.environ.get("WAVE_USE_SCHED_BARRIERS", 0))
+
+# Add test shapes for validation and performance testing.
+perf_test = lambda *a: pytest.param(*a, marks=pytest.mark.perf_only)
+default_test_shapes = []
+# Order of shapes: (B, BN, K2, H, K1, M, N)
+default_test_shapes = [(1, 256, 256, 4, 32, 256, 32), (1, 512, 256, 8, 8, 256, 8)]
+default_test_shapes += [perf_test(x) for x in default_test_shapes]
+default_tile_sizes = [(1, 1, 32, 1, None, 64, 64)]
+
+
+# From: https://github.com/microsoft/DeepSpeed/blob/master/tests/unit/ops/deepspeed4science/test_DS4Sci_EvoformerAttention.py
+def attention_reference(
+    q_input: torch.Tensor,
+    k_input: torch.Tensor,
+    v_input: torch.Tensor,
+    biases: list[torch.Tensor],
+    sm_scale: float,
+) -> torch.Tensor:
+    q = q_input.transpose(-2, -3)
+    k = k_input.transpose(-2, -3)
+    v = v_input.transpose(-2, -3)
+    k_t = k.transpose(-1, -2)
+    a = torch.matmul(q, k_t) * sm_scale
+
+    for b in biases:
+        a += b
+
+    a = F.softmax(a, dim=-1)
+    a_v = torch.matmul(a, v)
+    o = a_v.transpose(-2, -3)
+
+    return o
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", default_test_shapes)
+@pytest.mark.parametrize("tile_sizes", default_tile_sizes)
+@pytest.mark.parametrize("enable_scheduling", [False])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_32x32x8_F16,
+    ],
+)
+@pytest.mark.parametrize("dtype", [tkl.f16, tkl.bf16])
+def testEvoformerAttentionForward(
+    shape: tuple[int],
+    tile_sizes: tuple[int],
+    enable_scheduling: bool,
+    mfma_variant: MMAType,
+    dtype: DataType,
+    request,
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    shapes_and_tile_sizes = [(x, y) for x, y in zip(shape, tile_sizes)]
+    evoformer_fwd, symbols = get_evoformer_kernel(
+        *shapes_and_tile_sizes, mfma_variant, dtype
+    )
+
+    config = get_default_run_config()
+    if run_bench:
+        config["benchmark_batch_size"] = 1000
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    with tk.gen.TestLaunchContext(
+        symbols,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+    ):
+        torch.manual_seed(0)
+        if dtype == tkl.bf16:
+            torch_dtype = torch.bfloat16
+        else:
+            torch_dtype = torch.float16
+        batch, n, kv_seq_len, heads, head_dim, q_seq_len, v_dim = shape
+        q = device_randn(batch, n, q_seq_len, heads, head_dim, dtype=torch_dtype)
+        k = device_randn(batch, n, kv_seq_len, heads, head_dim, dtype=torch_dtype)
+        v = device_randn(batch, n, kv_seq_len, heads, v_dim, dtype=torch_dtype)
+        mask = device_randint(0, 2, (batch, n, kv_seq_len), dtype=torch_dtype)
+        mask_bias = 1e9 * (mask - 1)
+        bias = device_randn(batch, heads, q_seq_len, kv_seq_len, dtype=torch_dtype)
+        output = device_zeros(batch, n, q_seq_len, heads, v_dim, dtype=torch_dtype)
+        log2e = 1.44269504089
+        dk_sqrt = math.sqrt(1.0 / shape[4])
+        # TODO: Add scaling of QK as part of kernel.
+        # TODO: Add v-permute as part of kernel.
+        mb = evoformer_fwd(
+            q * dk_sqrt * log2e,
+            k,
+            v.permute([0, 1, 4, 3, 2]),
+            mask_bias,
+            bias * log2e,
+            output,
+        )
+
+        mask_bias = mask_bias.view([batch, n, 1, 1, kv_seq_len])
+        bias = bias.view([batch, 1, heads, q_seq_len, kv_seq_len])
+        torch_ref = attention_reference(q, k, v, [mask_bias, bias], dk_sqrt)
+
+        if test_dump_generated_mlir:
+            filename = f"wave_evoformer_{'x'.join(map(str, shape))}.mlir"
+            with open(filename, "w") as f:
+                f.write(mb.module_op.get_asm())
+
+        eps = 1e-2 if output.dtype == torch.float16 else 5e-2
+        print(f"Max diff: {torch.max(torch.abs(torch_ref - output)).item()}")
+        assert (
+            torch.max(torch.abs(torch_ref - output)).item() < eps
+        ), f"out eps: {torch.max(torch.abs(torch_ref - output))}"

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -41,7 +41,7 @@ default_test_shapes = []
 # Order of shapes: (B, BN, K2, H, K1, M, N)
 default_test_shapes = [(1, 256, 256, 4, 32, 256, 32), (1, 512, 256, 8, 8, 256, 8)]
 default_test_shapes += [perf_test(x) for x in default_test_shapes]
-default_tile_sizes = [(1, 1, 32, 1, None, 64, 64)]
+default_tile_sizes = [(1, 1, 32, 1, None, 64, 32)]
 
 
 # From: https://github.com/microsoft/DeepSpeed/blob/master/tests/unit/ops/deepspeed4science/test_DS4Sci_EvoformerAttention.py

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -22,7 +22,7 @@ from iree.turbine.kernel.wave.utils import (
 )
 from iree.turbine.kernel.wave.constraints import MMAType
 from iree.turbine.kernel.wave.templates.evoformer import get_evoformer_kernel
-from iree.turbine.kernel._support.dtype import DataType
+from iree.turbine.kernel.lang import DataType
 import os
 
 _run_e2e = int(os.environ.get("WAVE_RUN_E2E_TESTS", 0))
@@ -151,7 +151,6 @@ def testEvoformerAttentionForward(
                 f.write(mb.module_op.get_asm())
 
         eps = 1e-2 if output.dtype == torch.float16 else 5e-2
-        print(f"Max diff: {torch.max(torch.abs(torch_ref - output)).item()}")
         assert (
             torch.max(torch.abs(torch_ref - output)).item() < eps
         ), f"out eps: {torch.max(torch.abs(torch_ref - output))}"

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -18,6 +18,7 @@ from iree.turbine.kernel.wave.utils import (
     device_randn,
     device_zeros,
     device_randint,
+    get_default_scheduling_params,
 )
 from iree.turbine.kernel.wave.constraints import MMAType
 from iree.turbine.kernel.wave.templates.evoformer import get_evoformer_kernel
@@ -92,6 +93,8 @@ def testEvoformerAttentionForward(
     evoformer_fwd, symbols = get_evoformer_kernel(
         *shapes_and_tile_sizes, mfma_variant, dtype
     )
+
+    symbols.update(get_default_scheduling_params())
 
     config = get_default_run_config()
     if run_bench:


### PR DESCRIPTION
 This PR adds an e2e test for the evoformer for
  specific shapes and dtypes. It also adds support
  for bf16 types.