### PR TITLE
Add support for waves_per_eu flag

### DIFF
--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -557,6 +557,9 @@ def compile_and_invoke(
         "--iree-vm-target-truncate-unsupported-floats",
     ]
 
+    if config.get("waves_per_eu", None) is not None:
+        flags.append(f"--iree-hip-waves-per-eu={config['waves_per_eu']}")
+
     # TODO: More targets/backends support.
     if backend == "rocm":
         target = config["target"]

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -97,6 +97,7 @@ def testEvoformerAttentionForward(
     symbols.update(get_default_scheduling_params())
 
     config = get_default_run_config()
+    config["waves_per_eu"] = 2
     if run_bench:
         config["benchmark_batch_size"] = 1000
         config["benchmark_repetitions"] = 3


### PR DESCRIPTION
The waves_per_eu flag is a optimization hint
that specifies the minimum number of waves per
execution unit.