### PR TITLE
Add ml_dtypes as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         f"iree-base-runtime{get_version_spec('iree-base-runtime')}",
         "torch>=2.3.0",
         f"Jinja2{get_version_spec('Jinja2')}",
+        f"ml_dtypes{get_version_spec('ml_dtypes')}",
     ],
     extras_require={
         "testing": [


### PR DESCRIPTION
This will provide access to ML dtypes
like bfloat16 that are not supported by
numpy.