### PR TITLE
Fix type annotation on function

### DIFF
--- a/iree/turbine/kernel/wave/thread_shape_analysis.py
+++ b/iree/turbine/kernel/wave/thread_shape_analysis.py
@@ -129,7 +129,7 @@ def need_conflict_resolution(
     op_to_thread_sizes: dict[CustomOp, set[frozenset[DimSize]]],
     conflicted_ops: set[CustomOp],
     target_index_size: frozenset[DimSize],
-):
+) -> bool:
     """
     Determine if we need to resolve conflicts. We need to resolve conflicts
     only if the sizes along non-unit dims are not identical.


### PR DESCRIPTION
This PR fixes the type annotation of
a function in thread_shape_analysis to
capture the output type.