### PR TITLE
[TKW] Fix to do vectorized reads/writes when possible.

### DIFF
--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -555,9 +555,9 @@ def _get_fastest_index(indices: dict[IndexExpr, IndexSequence]):
 
     index_sizes = [i.size for i in indices.values()]
     # Find the maximum value
-    max_val = max(index_sizes)
+    max_size = max(index_sizes)
     # Find the fastest/most minor index of the maximum value.
-    return len(index_sizes) - 1 - index_sizes[::-1].index(max_val)
+    return max(i for i, size in enumerate(index_sizes) if size == max_size)
 
 
 def _compute_offset(indices: list[IndexExpr], strides: list[IndexExpr]) -> IndexExpr:
@@ -577,7 +577,7 @@ def _build_mask(
 
     idxc = IndexingContext.current()
     fastest_dim = _get_fastest_index(index)
-    last_dim = tuple(index.keys())[fastest_dim]
+    last_dim = list(index)[fastest_dim]
     new_index = {k: _get_start_index(v) for k, v in index.items()}
 
     new_index[last_dim] = new_index[last_dim] + idxc.iota(elements_per_thread)

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -576,7 +576,8 @@ def _build_mask(
         return None
 
     idxc = IndexingContext.current()
-    last_dim = tuple(index.keys())[-1]
+    fastest_dim = _get_fastest_index(index)
+    last_dim = tuple(index.keys())[fastest_dim]
     new_index = {k: _get_start_index(v) for k, v in index.items()}
 
     new_index[last_dim] = new_index[last_dim] + idxc.iota(elements_per_thread)

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -39,6 +39,7 @@ from ...support.logging import get_logger
 import sympy
 from itertools import groupby
 from operator import itemgetter
+from copy import copy
 
 logger = get_logger("turbine.wave.index_sequence_analysis")
 
@@ -171,11 +172,11 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
             for dim in custom.index
         }
         elements_per_thread = subs_idxc(custom.elements_per_thread)
-        gpr_offsets = [
-            v.start for v in simplified_index.values() if v.start.has(GPR_NUM)
+        dim_with_gpr_offsets = [
+            (k, v.start) for k, v in simplified_index.items() if v.start.has(GPR_NUM)
         ]
-        assert len(gpr_offsets) == 1, "Expected only 1-Dim has gpr offsets"
-        gpr_offset_expr = gpr_offsets[0]
+        assert len(dim_with_gpr_offsets) == 1, "Expected only 1-Dim has gpr offsets"
+        gpr_offset_dim, gpr_offset_expr = dim_with_gpr_offsets[0]
         gpr_offsets = [
             gpr_offset_expr.subs({GPR_NUM: i}) for i in range(elements_per_thread)
         ]
@@ -205,14 +206,17 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
             for chunk_id in range(num_gpr_chunks):
                 cur_gpr_start_id = chunk_id * gpr_size
                 # Get updated index with VGPR offset.
-                updated_index_with_gpr_offset = {
-                    dim: IndexSequence(
-                        simplified_index[dim].start.subs({GPR_NUM: cur_gpr_start_id}),
-                        gpr_size,
-                        simplified_index[dim].stride,
-                    )
-                    for dim in simplified_index
-                }
+                updated_index_with_gpr_offset = copy(simplified_index)
+                updated_dim_with_gpr_offset = IndexSequence(
+                    updated_index_with_gpr_offset[gpr_offset_dim].start.subs(
+                        {GPR_NUM: cur_gpr_start_id}
+                    ),
+                    gpr_size,
+                    1,
+                )
+                updated_index_with_gpr_offset[
+                    gpr_offset_dim
+                ] = updated_dim_with_gpr_offset
 
                 # Generate new Read/Write that has contiguous VGPR elements.
                 if isinstance(custom, Write):

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -206,13 +206,21 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
             for chunk_id in range(num_gpr_chunks):
                 cur_gpr_start_id = chunk_id * gpr_size
                 # Get updated index with VGPR offset.
+                output_mapping = list(custom.index.keys())
+                if custom.mapping is not None:
+                    output_mapping = list(custom.mapping.output_mapping.keys())
+                # Modify stride to 1 S.T we can have vectorized read/write
+                # iff gpr_offset_dim is or will be (after mapping) fastest dim.
+                updated_gpr_stride = simplified_index[gpr_offset_dim].stride
+                if output_mapping[-1] is gpr_offset_dim:
+                    updated_gpr_stride = 1
                 updated_index_with_gpr_offset = copy(simplified_index)
                 updated_dim_with_gpr_offset = IndexSequence(
                     updated_index_with_gpr_offset[gpr_offset_dim].start.subs(
                         {GPR_NUM: cur_gpr_start_id}
                     ),
                     gpr_size,
-                    1,
+                    updated_gpr_stride,
                 )
                 updated_index_with_gpr_offset[
                     gpr_offset_dim

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -587,6 +587,8 @@ def test_attention_32x32x8():
         # CHECK:                    {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [8], sizes = [4], strides = [1]}
         # CHECK:                    {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [12], sizes = [4], strides = [1]}
         # CHECK-COUNT-4:            {{.*}} = amdgpu.mfma
+        # CHECK:                    scf.yield
+        # CHECK-COUNT-4:            vector.store {{.*}}: memref<8x128x128xf32{{.*}}>, vector<4xf32>
 
 
 @run_test

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -592,6 +592,144 @@ def test_attention_32x32x8():
 
 
 @run_test
+def test_dynamic_attention_32x32x8():
+    shape = (8, 128, 128, 64, 256)
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+    constraints += [tkw.Assumption(K2 > BLOCK_K2 * 4)]
+
+    mfma_variant = tkw.MMAType.F32_32x32x8_F16
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=mfma_variant,
+            vector_shapes={B: 0, M: 32, N: 32},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    )
+
+    @tkw.wave(constraints)
+    def dynamic_attention_32x32x8(
+        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, M, tkl.f32],
+            partial_sum: tkl.Register[B, M, tkl.f32],
+            acc: tkl.Register[B, N, M, tkl.f32],
+        ) -> (
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, M, tkl.f32],
+            tkl.Register[B, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
+            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
+            m_j = tkw.max(x_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        BLOCK_B: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 64,
+        K1: shape[3],
+        READ_SHARED_DELAY: 1,
+        WRITE_SHARED_DELAY: 1,
+        READ_GLOBAL_DELAY: 2,
+        WRITE_GLOBAL_DELAY: 2,
+        MMA_DELAY: 1,
+        SHARED_MEMORY_UNITS: 4,
+        GLOBAL_MEMORY_UNITS: 4,
+        MMA_UNITS: 4,
+    }
+
+    # Set up dynamic parameters
+    dynamic_symbols_map = {}
+    dynamic_symbols_map[B] = shape[0]
+    dynamic_symbols_map[M] = shape[1]
+    dynamic_symbols_map[N] = shape[2]
+    dynamic_symbols_map[K2] = shape[4]
+    dynamic_symbols = [M, N, B, K2]
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=False,
+        run_bench=False,
+        schedule=False,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+        use_scheduling_barriers=False,
+    ):
+        torch.manual_seed(0)
+        q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+        k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
+        v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
+        output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        print(dynamic_attention_32x32x8(q, k, v, output).module_op)
+
+        # CHECK-LABEL:      func.func @dynamic_attention_32x32x8
+        # CHECK-DAG:            %[[IOTA:.+]] = arith.constant dense<[0, 1, 2, 3]> : vector<4xindex>
+        # CHECK:                {{.*}} = scf.for
+        # CHECK-COUNT-16:           {{.*}} = amdgpu.mfma
+        # CHECK-COUNT-2:            {{.*}} = gpu.shuffle xor {{.*}}
+        # CHECK:                    {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [0], sizes = [4], strides = [1]}
+        # CHECK:                    {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [4], sizes = [4], strides = [1]}
+        # CHECK:                    {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [8], sizes = [4], strides = [1]}
+        # CHECK:                    {{.*}} = vector.extract_strided_slice {{.*}} {offsets = [12], sizes = [4], strides = [1]}
+        # CHECK-COUNT-8:            {{.*}} = amdgpu.mfma
+        # CHECK:                    scf.yield
+
+        # Check for mask generation and masked stor:
+        # CHECK:                %[[INDICES:.+]] = arith.addi %{{.*}}, %[[IOTA]] overflow<nsw, nuw> : vector<4xindex>
+        # CHECK:                %[[BOUNDS:.+]] = vector.splat %{{.*}} : vector<4xindex>
+        # CHECK:                %[[SLT:.+]] = arith.cmpi slt, %[[INDICES]], %[[BOUNDS]] : vector<4xindex>
+        # CHECK:                %[[MASK:.+]] = arith.andi %{{.*}}, %[[SLT]] : vector<4xi1>
+        # CHECK:                vector.maskedstore %{{.*}}[{{.*}}], %[[MASK]], %{{.*}} : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>, vector<4xi1>, vector<4xf32>
+        # CHECK-COUNT-3:        vector.maskedstore {{.*}} : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>, vector<4xi1>, vector<4xf32>
+
+
+@run_test
 def test_attention():
     shape = (8, 128, 128, 64, 256)
     # Expose user-constraints

--- a/lit_tests/kernel/wave/mma.py
+++ b/lit_tests/kernel/wave/mma.py
@@ -148,21 +148,13 @@ def test_mma_32x32x8():
         print(mma_32x32x8(a, b, c).module_op)
 
         # CHECK:          func.func @mma_32x32x8
-        # CHECK-DAG:        %[[C27:.+]] = arith.constant 27 : index
-        # CHECK-DAG:        %[[C26:.+]] = arith.constant 26 : index
-        # CHECK-DAG:        %[[C25:.+]] = arith.constant 25 : index
         # CHECK-DAG:        %[[C24:.+]] = arith.constant 24 : index
-        # CHECK-DAG:        %[[C19:.+]] = arith.constant 19 : index
-        # CHECK-DAG:        %[[C18:.+]] = arith.constant 18 : index
-        # CHECK-DAG:        %[[C17:.+]] = arith.constant 17 : index
         # CHECK-DAG:        %[[C16:.+]] = arith.constant 16 : index
-        # CHECK-DAG:        %[[C11:.+]] = arith.constant 11 : index
-        # CHECK-DAG:        %[[C10:.+]] = arith.constant 10 : index
-        # CHECK-DAG:        %[[C9:.+]] = arith.constant 9 : index
         # CHECK-DAG:        %[[C8:.+]] = arith.constant 8 : index
-        # CHECK-DAG:        %[[C3:.+]] = arith.constant 3 : index
-        # CHECK-DAG:        %[[C2:.+]] = arith.constant 2 : index
-        # CHECK-DAG:        %[[C1:.+]] = arith.constant 1 : index
+        # CHECK-DAG:        %[[C4:.+]] = arith.constant 4 : index
+        # CHECK-DAG:        %[[C64:.+]] = arith.constant 64 : index
+        # CHECK-DAG:        %[[C32:.+]] = arith.constant 32 : index
+        # CHECK-DAG:        %[[C0:.+]] = arith.constant 0 : index
 
         # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
         # CHECK-DAG:        %[[ALLOC:.+]] = memref.alloc() : memref<64x12xf16,
@@ -171,88 +163,28 @@ def test_mma_32x32x8():
         # CHECK:            %[[D20:.+]] = vector.load %[[ALLOC_0]]{{.*}} : memref<64x12xf16,
         # CHECK:            %[[D21:.+]] = amdgpu.mfma %[[D12]] * %[[D20]] + %[[CST]] {blocks = 1 : i32, k = 8 : i32, m = 32 :
         # CHECK-SAME:         i32, n = 32 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
-        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
         # CHECK:            %[[D23:.+]] = stream.binding.subspan {{.*}} : !stream.binding -> memref<128x128xf32,
         # CHECK-SAME:         strided<[128, 1], offset: ?>>
 
         # CHECK-DAG:        vector.store %[[D22]], %[[D23]][{{.*}}, {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D26:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [1], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D27:.+]] = arith.addi {{.*}}, %[[C1]]
+        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK:            %[[D26:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D27:.+]] = arith.addi {{.*}}, %[[C8]]
         # CHECK:            vector.store %[[D26]], %[[D23]][%[[D27]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D28:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [2], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D29:.+]] = arith.addi {{.*}}, %[[C2]]
+        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK:            %[[D28:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D29:.+]] = arith.addi {{.*}}, %[[C16]]
         # CHECK:            vector.store %[[D28]], %[[D23]][%[[D29]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D30:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [3], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D31:.+]] = arith.addi {{.*}}, %[[C3]]
+        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK:            %[[D30:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D31:.+]] = arith.addi {{.*}}, %[[C24]]
         # CHECK:            vector.store %[[D30]], %[[D23]][%[[D31]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D32:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D33:.+]] = arith.addi {{.*}}, %[[C8]]
-        # CHECK:            vector.store %[[D32]], %[[D23]][%[[D33]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D34:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [5], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D35:.+]] = arith.addi {{.*}}, %[[C9]]
-        # CHECK:            vector.store %[[D34]], %[[D23]][%[[D35]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D36:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [6], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D37:.+]] = arith.addi {{.*}}, %[[C10]]
-        # CHECK:            vector.store %[[D36]], %[[D23]][%[[D37]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D38:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [7], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D39:.+]] = arith.addi {{.*}}, %[[C11]]
-        # CHECK:            vector.store %[[D38]], %[[D23]][%[[D39]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D40:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D41:.+]] = arith.addi {{.*}}, %[[C16]]
-        # CHECK:            vector.store %[[D40]], %[[D23]][%[[D41]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D42:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [9], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D43:.+]] = arith.addi {{.*}}, %[[C17]]
-        # CHECK:            vector.store %[[D42]], %[[D23]][%[[D43]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D44:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [10], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D45:.+]] = arith.addi {{.*}}, %[[C18]]
-        # CHECK:            vector.store %[[D44]], %[[D23]][%[[D45]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D46:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [11], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D47:.+]] = arith.addi {{.*}}, %[[C19]]
-        # CHECK:            vector.store %[[D46]], %[[D23]][%[[D47]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D48:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D49:.+]] = arith.addi {{.*}}, %[[C24]]
-        # CHECK:            vector.store %[[D48]], %[[D23]][%[[D49]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D50:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [13], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D51:.+]] = arith.addi {{.*}}, %[[C25]]
-        # CHECK:            vector.store %[[D50]], %[[D23]][%[[D51]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D52:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [14], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D53:.+]] = arith.addi {{.*}}, %[[C26]]
-        # CHECK:            vector.store %[[D52]], %[[D23]][%[[D53]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D54:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [15], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D55:.+]] = arith.addi {{.*}}, %[[C27]]
-        # CHECK:            vector.store %[[D54]], %[[D23]][%[[D55]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK-SAME:         ?>>, vector<4xf32>
 
 
 @run_test
@@ -302,21 +234,13 @@ def test_mma_32x32x16():
         print(mma_32x32x16(a, b, c).module_op)
 
         # CHECK:          func.func @mma_32x32x16
-        # CHECK-DAG:        %[[C27:.+]] = arith.constant 27 : index
-        # CHECK-DAG:        %[[C26:.+]] = arith.constant 26 : index
-        # CHECK-DAG:        %[[C25:.+]] = arith.constant 25 : index
         # CHECK-DAG:        %[[C24:.+]] = arith.constant 24 : index
-        # CHECK-DAG:        %[[C19:.+]] = arith.constant 19 : index
-        # CHECK-DAG:        %[[C18:.+]] = arith.constant 18 : index
-        # CHECK-DAG:        %[[C17:.+]] = arith.constant 17 : index
         # CHECK-DAG:        %[[C16:.+]] = arith.constant 16 : index
-        # CHECK-DAG:        %[[C11:.+]] = arith.constant 11 : index
-        # CHECK-DAG:        %[[C10:.+]] = arith.constant 10 : index
-        # CHECK-DAG:        %[[C9:.+]] = arith.constant 9 : index
+        # CHECK-DAG:        %[[C4:.+]] = arith.constant 4 : index
         # CHECK-DAG:        %[[C8:.+]] = arith.constant 8 : index
-        # CHECK-DAG:        %[[C3:.+]] = arith.constant 3 : index
-        # CHECK-DAG:        %[[C2:.+]] = arith.constant 2 : index
-        # CHECK-DAG:        %[[C1:.+]] = arith.constant 1 : index
+        # CHECK-DAG:        %[[C64:.+]] = arith.constant 64 : index
+        # CHECK-DAG:        %[[C32:.+]] = arith.constant 32 : index
+        # CHECK-DAG:        %[[C0:.+]] = arith.constant 0 : index
 
         # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
         # CHECK-DAG:        %[[ALLOC:.+]] = memref.alloc() : memref<64x24xf8E4M3FNUZ,
@@ -325,88 +249,28 @@ def test_mma_32x32x16():
         # CHECK:            %[[D20:.+]] = vector.load %[[ALLOC_0]]{{.*}} : memref<64x24xf8E4M3FNUZ,
         # CHECK:            %[[D21:.+]] = amdgpu.mfma %[[D12]] * %[[D20]] + %[[CST]] {blocks = 1 : i32, k = 16 : i32, m = 32 :
         # CHECK-SAME:         i32, n = 32 : i32} blgp =  none : vector<8xf8E4M3FNUZ>, vector<8xf8E4M3FNUZ>, vector<16xf32>
-        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
         # CHECK:            %[[D23:.+]] = stream.binding.subspan {{.*}} : !stream.binding -> memref<128x128xf32,
         # CHECK-SAME:         strided<[128, 1], offset: ?>>
 
         # CHECK-DAG:        vector.store %[[D22]], %[[D23]][{{.*}}, {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D26:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [1], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D27:.+]] = arith.addi {{.*}}, %[[C1]]
-        # CHECK:            vector.store %[[D26]], %[[D23]][%[[D27]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D28:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [2], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D29:.+]] = arith.addi {{.*}}, %[[C2]]
-        # CHECK:            vector.store %[[D28]], %[[D23]][%[[D29]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D30:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [3], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D31:.+]] = arith.addi {{.*}}, %[[C3]]
-        # CHECK:            vector.store %[[D30]], %[[D23]][%[[D31]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D32:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D33:.+]] = arith.addi {{.*}}, %[[C8]]
-        # CHECK:            vector.store %[[D32]], %[[D23]][%[[D33]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D34:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [5], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D35:.+]] = arith.addi {{.*}}, %[[C9]]
-        # CHECK:            vector.store %[[D34]], %[[D23]][%[[D35]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D36:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [6], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D37:.+]] = arith.addi {{.*}}, %[[C10]]
-        # CHECK:            vector.store %[[D36]], %[[D23]][%[[D37]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D38:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [7], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D39:.+]] = arith.addi {{.*}}, %[[C11]]
-        # CHECK:            vector.store %[[D38]], %[[D23]][%[[D39]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D40:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D41:.+]] = arith.addi {{.*}}, %[[C16]]
-        # CHECK:            vector.store %[[D40]], %[[D23]][%[[D41]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D42:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [9], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D43:.+]] = arith.addi {{.*}}, %[[C17]]
-        # CHECK:            vector.store %[[D42]], %[[D23]][%[[D43]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D44:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [10], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D45:.+]] = arith.addi {{.*}}, %[[C18]]
-        # CHECK:            vector.store %[[D44]], %[[D23]][%[[D45]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D46:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [11], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D47:.+]] = arith.addi {{.*}}, %[[C19]]
-        # CHECK:            vector.store %[[D46]], %[[D23]][%[[D47]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D48:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D49:.+]] = arith.addi {{.*}}, %[[C24]]
-        # CHECK:            vector.store %[[D48]], %[[D23]][%[[D49]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D50:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [13], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D51:.+]] = arith.addi {{.*}}, %[[C25]]
-        # CHECK:            vector.store %[[D50]], %[[D23]][%[[D51]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D52:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [14], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D53:.+]] = arith.addi {{.*}}, %[[C26]]
-        # CHECK:            vector.store %[[D52]], %[[D23]][%[[D53]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
-        # CHECK:            %[[D54:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [15], sizes = [1], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
-        # CHECK:            %[[D55:.+]] = arith.addi {{.*}}, %[[C27]]
-        # CHECK:            vector.store %[[D54]], %[[D23]][%[[D55]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK:            %[[D27:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D28:.+]] = arith.addi {{.*}}, %[[C8]]
+        # CHECK:            vector.store %[[D27]], %[[D23]][%[[D28]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK:            %[[D29:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D30:.+]] = arith.addi {{.*}}, %[[C16]]
+        # CHECK:            vector.store %[[D29]], %[[D23]][%[[D30]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK:            %[[D31:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [4], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D32:.+]] = arith.addi {{.*}}, %[[C24]]
+        # CHECK:            vector.store %[[D31]], %[[D23]][%[[D32]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<4xf32>
 
 
 @run_test

--- a/lit_tests/kernel/wave/mma.py
+++ b/lit_tests/kernel/wave/mma.py
@@ -148,13 +148,21 @@ def test_mma_32x32x8():
         print(mma_32x32x8(a, b, c).module_op)
 
         # CHECK:          func.func @mma_32x32x8
+        # CHECK-DAG:        %[[C27:.+]] = arith.constant 27 : index
+        # CHECK-DAG:        %[[C26:.+]] = arith.constant 26 : index
+        # CHECK-DAG:        %[[C25:.+]] = arith.constant 25 : index
         # CHECK-DAG:        %[[C24:.+]] = arith.constant 24 : index
+        # CHECK-DAG:        %[[C19:.+]] = arith.constant 19 : index
+        # CHECK-DAG:        %[[C18:.+]] = arith.constant 18 : index
+        # CHECK-DAG:        %[[C17:.+]] = arith.constant 17 : index
         # CHECK-DAG:        %[[C16:.+]] = arith.constant 16 : index
+        # CHECK-DAG:        %[[C11:.+]] = arith.constant 11 : index
+        # CHECK-DAG:        %[[C10:.+]] = arith.constant 10 : index
+        # CHECK-DAG:        %[[C9:.+]] = arith.constant 9 : index
         # CHECK-DAG:        %[[C8:.+]] = arith.constant 8 : index
-        # CHECK-DAG:        %[[C4:.+]] = arith.constant 4 : index
-        # CHECK-DAG:        %[[C64:.+]] = arith.constant 64 : index
-        # CHECK-DAG:        %[[C32:.+]] = arith.constant 32 : index
-        # CHECK-DAG:        %[[C0:.+]] = arith.constant 0 : index
+        # CHECK-DAG:        %[[C3:.+]] = arith.constant 3 : index
+        # CHECK-DAG:        %[[C2:.+]] = arith.constant 2 : index
+        # CHECK-DAG:        %[[C1:.+]] = arith.constant 1 : index
 
         # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
         # CHECK-DAG:        %[[ALLOC:.+]] = memref.alloc() : memref<64x12xf16,
@@ -163,28 +171,88 @@ def test_mma_32x32x8():
         # CHECK:            %[[D20:.+]] = vector.load %[[ALLOC_0]]{{.*}} : memref<64x12xf16,
         # CHECK:            %[[D21:.+]] = amdgpu.mfma %[[D12]] * %[[D20]] + %[[CST]] {blocks = 1 : i32, k = 8 : i32, m = 32 :
         # CHECK-SAME:         i32, n = 32 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
-        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
         # CHECK:            %[[D23:.+]] = stream.binding.subspan {{.*}} : !stream.binding -> memref<128x128xf32,
         # CHECK-SAME:         strided<[128, 1], offset: ?>>
 
         # CHECK-DAG:        vector.store %[[D22]], %[[D23]][{{.*}}, {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
-        # CHECK:            %[[D26:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
-        # CHECK:            %[[D27:.+]] = arith.addi {{.*}}, %[[C8]]
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D26:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [1], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D27:.+]] = arith.addi {{.*}}, %[[C1]]
         # CHECK:            vector.store %[[D26]], %[[D23]][%[[D27]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
-        # CHECK:            %[[D28:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
-        # CHECK:            %[[D29:.+]] = arith.addi {{.*}}, %[[C16]]
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D28:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [2], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D29:.+]] = arith.addi {{.*}}, %[[C2]]
         # CHECK:            vector.store %[[D28]], %[[D23]][%[[D29]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
-        # CHECK:            %[[D30:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
-        # CHECK:            %[[D31:.+]] = arith.addi {{.*}}, %[[C24]]
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D30:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [3], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D31:.+]] = arith.addi {{.*}}, %[[C3]]
         # CHECK:            vector.store %[[D30]], %[[D23]][%[[D31]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D32:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D33:.+]] = arith.addi {{.*}}, %[[C8]]
+        # CHECK:            vector.store %[[D32]], %[[D23]][%[[D33]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D34:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [5], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D35:.+]] = arith.addi {{.*}}, %[[C9]]
+        # CHECK:            vector.store %[[D34]], %[[D23]][%[[D35]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D36:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [6], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D37:.+]] = arith.addi {{.*}}, %[[C10]]
+        # CHECK:            vector.store %[[D36]], %[[D23]][%[[D37]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D38:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [7], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D39:.+]] = arith.addi {{.*}}, %[[C11]]
+        # CHECK:            vector.store %[[D38]], %[[D23]][%[[D39]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D40:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D41:.+]] = arith.addi {{.*}}, %[[C16]]
+        # CHECK:            vector.store %[[D40]], %[[D23]][%[[D41]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D42:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [9], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D43:.+]] = arith.addi {{.*}}, %[[C17]]
+        # CHECK:            vector.store %[[D42]], %[[D23]][%[[D43]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D44:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [10], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D45:.+]] = arith.addi {{.*}}, %[[C18]]
+        # CHECK:            vector.store %[[D44]], %[[D23]][%[[D45]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D46:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [11], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D47:.+]] = arith.addi {{.*}}, %[[C19]]
+        # CHECK:            vector.store %[[D46]], %[[D23]][%[[D47]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D48:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D49:.+]] = arith.addi {{.*}}, %[[C24]]
+        # CHECK:            vector.store %[[D48]], %[[D23]][%[[D49]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D50:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [13], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D51:.+]] = arith.addi {{.*}}, %[[C25]]
+        # CHECK:            vector.store %[[D50]], %[[D23]][%[[D51]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D52:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [14], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D53:.+]] = arith.addi {{.*}}, %[[C26]]
+        # CHECK:            vector.store %[[D52]], %[[D23]][%[[D53]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D54:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [15], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D55:.+]] = arith.addi {{.*}}, %[[C27]]
+        # CHECK:            vector.store %[[D54]], %[[D23]][%[[D55]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
 
 
 @run_test
@@ -234,13 +302,21 @@ def test_mma_32x32x16():
         print(mma_32x32x16(a, b, c).module_op)
 
         # CHECK:          func.func @mma_32x32x16
+        # CHECK-DAG:        %[[C27:.+]] = arith.constant 27 : index
+        # CHECK-DAG:        %[[C26:.+]] = arith.constant 26 : index
+        # CHECK-DAG:        %[[C25:.+]] = arith.constant 25 : index
         # CHECK-DAG:        %[[C24:.+]] = arith.constant 24 : index
+        # CHECK-DAG:        %[[C19:.+]] = arith.constant 19 : index
+        # CHECK-DAG:        %[[C18:.+]] = arith.constant 18 : index
+        # CHECK-DAG:        %[[C17:.+]] = arith.constant 17 : index
         # CHECK-DAG:        %[[C16:.+]] = arith.constant 16 : index
-        # CHECK-DAG:        %[[C4:.+]] = arith.constant 4 : index
+        # CHECK-DAG:        %[[C11:.+]] = arith.constant 11 : index
+        # CHECK-DAG:        %[[C10:.+]] = arith.constant 10 : index
+        # CHECK-DAG:        %[[C9:.+]] = arith.constant 9 : index
         # CHECK-DAG:        %[[C8:.+]] = arith.constant 8 : index
-        # CHECK-DAG:        %[[C64:.+]] = arith.constant 64 : index
-        # CHECK-DAG:        %[[C32:.+]] = arith.constant 32 : index
-        # CHECK-DAG:        %[[C0:.+]] = arith.constant 0 : index
+        # CHECK-DAG:        %[[C3:.+]] = arith.constant 3 : index
+        # CHECK-DAG:        %[[C2:.+]] = arith.constant 2 : index
+        # CHECK-DAG:        %[[C1:.+]] = arith.constant 1 : index
 
         # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>
         # CHECK-DAG:        %[[ALLOC:.+]] = memref.alloc() : memref<64x24xf8E4M3FNUZ,
@@ -249,28 +325,88 @@ def test_mma_32x32x16():
         # CHECK:            %[[D20:.+]] = vector.load %[[ALLOC_0]]{{.*}} : memref<64x24xf8E4M3FNUZ,
         # CHECK:            %[[D21:.+]] = amdgpu.mfma %[[D12]] * %[[D20]] + %[[CST]] {blocks = 1 : i32, k = 16 : i32, m = 32 :
         # CHECK-SAME:         i32, n = 32 : i32} blgp =  none : vector<8xf8E4M3FNUZ>, vector<8xf8E4M3FNUZ>, vector<16xf32>
-        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
+        # CHECK:            %[[D22:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [0], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
         # CHECK:            %[[D23:.+]] = stream.binding.subspan {{.*}} : !stream.binding -> memref<128x128xf32,
         # CHECK-SAME:         strided<[128, 1], offset: ?>>
 
         # CHECK-DAG:        vector.store %[[D22]], %[[D23]][{{.*}}, {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
-        # CHECK:            %[[D27:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
-        # CHECK:            %[[D28:.+]] = arith.addi {{.*}}, %[[C8]]
-        # CHECK:            vector.store %[[D27]], %[[D23]][%[[D28]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
-        # CHECK:            %[[D29:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
-        # CHECK:            %[[D30:.+]] = arith.addi {{.*}}, %[[C16]]
-        # CHECK:            vector.store %[[D29]], %[[D23]][%[[D30]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
-        # CHECK:            %[[D31:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [4], strides = [1]} :
-        # CHECK-SAME:         vector<16xf32> to vector<4xf32>
-        # CHECK:            %[[D32:.+]] = arith.addi {{.*}}, %[[C24]]
-        # CHECK:            vector.store %[[D31]], %[[D23]][%[[D32]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
-        # CHECK-SAME:         ?>>, vector<4xf32>
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D26:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [1], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D27:.+]] = arith.addi {{.*}}, %[[C1]]
+        # CHECK:            vector.store %[[D26]], %[[D23]][%[[D27]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D28:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [2], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D29:.+]] = arith.addi {{.*}}, %[[C2]]
+        # CHECK:            vector.store %[[D28]], %[[D23]][%[[D29]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D30:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [3], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D31:.+]] = arith.addi {{.*}}, %[[C3]]
+        # CHECK:            vector.store %[[D30]], %[[D23]][%[[D31]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D32:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [4], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D33:.+]] = arith.addi {{.*}}, %[[C8]]
+        # CHECK:            vector.store %[[D32]], %[[D23]][%[[D33]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D34:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [5], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D35:.+]] = arith.addi {{.*}}, %[[C9]]
+        # CHECK:            vector.store %[[D34]], %[[D23]][%[[D35]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D36:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [6], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D37:.+]] = arith.addi {{.*}}, %[[C10]]
+        # CHECK:            vector.store %[[D36]], %[[D23]][%[[D37]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D38:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [7], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D39:.+]] = arith.addi {{.*}}, %[[C11]]
+        # CHECK:            vector.store %[[D38]], %[[D23]][%[[D39]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D40:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [8], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D41:.+]] = arith.addi {{.*}}, %[[C16]]
+        # CHECK:            vector.store %[[D40]], %[[D23]][%[[D41]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D42:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [9], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D43:.+]] = arith.addi {{.*}}, %[[C17]]
+        # CHECK:            vector.store %[[D42]], %[[D23]][%[[D43]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D44:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [10], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D45:.+]] = arith.addi {{.*}}, %[[C18]]
+        # CHECK:            vector.store %[[D44]], %[[D23]][%[[D45]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D46:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [11], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D47:.+]] = arith.addi {{.*}}, %[[C19]]
+        # CHECK:            vector.store %[[D46]], %[[D23]][%[[D47]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D48:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [12], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D49:.+]] = arith.addi {{.*}}, %[[C24]]
+        # CHECK:            vector.store %[[D48]], %[[D23]][%[[D49]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D50:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [13], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D51:.+]] = arith.addi {{.*}}, %[[C25]]
+        # CHECK:            vector.store %[[D50]], %[[D23]][%[[D51]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D52:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [14], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D53:.+]] = arith.addi {{.*}}, %[[C26]]
+        # CHECK:            vector.store %[[D52]], %[[D23]][%[[D53]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
+        # CHECK:            %[[D54:.+]] = vector.extract_strided_slice %[[D21]] {offsets = [15], sizes = [1], strides = [1]} :
+        # CHECK-SAME:         vector<16xf32> to vector<1xf32>
+        # CHECK:            %[[D55:.+]] = arith.addi {{.*}}, %[[C27]]
+        # CHECK:            vector.store %[[D54]], %[[D23]][%[[D55]], {{.*}}] : memref<128x128xf32, strided<[128, 1], offset:
+        # CHECK-SAME:         ?>>, vector<1xf32>
 
 
 @run_test


### PR DESCRIPTION
There are issues with current index_seq_analysis that made our software chunked supposedly vectorizable writes into chunks of vector.store vector<1xf32>.

In order to fix this we needed:

1. Adjusted IndexSeq generated from partition_gpr_offset to modify only the dim with gpr_offset to size of gpr_size and have stride of 1(iff gpr_offset_dim is or will be fastest dim). It used to set every dimensions in simplified index to gpr_size which is incorrect.

2. Refactored codegen of _construct_gather_scatter_indices S.T our writes with mapping can handle case where fastest dimension is not necessarily the last dimension (i.e no layout change - transposed case).


On attention dispatch146(B0: 2, B1: 20, (M, K2): 1024: K1: 64) it improved performance from 6.0 ms to 5.5 ms.