### PR TITLE
[TKW] Introduce ReciprocalOp for faster attention

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -102,6 +102,10 @@ def exp2(src: "Register") -> "Register":
     ...
 
 
+def reciprocal(src: "Register") -> "Register":
+    ...
+
+
 def maximum(lhs: "Register", rhs: "Register") -> "Register":
     ...
 
@@ -637,6 +641,7 @@ class BinaryPyOp(CustomOp, ABC):
 
 
 @define_interface_op("exp2")
+@define_interface_op("reciprocal")
 @define_py_op(operator.neg)
 @dataclass
 class UnaryPyOp(CustomOp, ABC):

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -55,6 +55,7 @@ from ..ops.wave_ops import (
     read,
     reduction,
     exp2,
+    reciprocal,
     maximum,
     get_custom,
     get_result,
@@ -1101,6 +1102,22 @@ def handle_exp2(source: Value) -> OpResult:
     else:
         raise ValidationError(f"Found unhandled operand type for exp2: {element_type}")
     return result
+
+
+@handle_unary_op(reciprocal)
+def handle_reciprocal(source: Value) -> OpResult:
+    element_type = get_type_or_element_type(source.type)
+    if _is_float_type(element_type):
+        splat_ones = DenseElementsAttr.get_splat(
+            source.type, get_constant_attr(1.0, element_type)
+        )
+        ones = arith_d.ConstantOp(source.type, splat_ones)
+        reciprocal = arith_d.divf(ones, source)
+    else:
+        raise ValidationError(
+            f"Found unhandled operand type for reciprocal: {element_type}"
+        )
+    return reciprocal
 
 
 ###############################################################################

--- a/iree/turbine/kernel/wave/templates/evoformer.py
+++ b/iree/turbine/kernel/wave/templates/evoformer.py
@@ -166,7 +166,8 @@ def get_evoformer_kernel(
 
         # repeat represents the results of the loop
         res_max, res_sum, res_mm = repeat
-        res = res_mm / res_sum
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
         casted = tkw.cast(res, datatype)
         tkw.write(
             casted, c, mapping=o_mapping, elements_per_thread=STORE_ELEMS_PER_THREAD

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1925,14 +1925,22 @@ def test_unary_lowerings():
         a_reg = tkw.read(a, elements_per_thread=4)
         res = -a_reg
         res = tkw.exp2(res)
+        res = tkw.reciprocal(res)
         tkw.write(res, a, elements_per_thread=4)
 
     a = torch.randn(16, 16, dtype=torch.float16)
     with codegen_test_context():
         print(test(a).module_op)
         # CHECK-LABEL: func @test
+        # Testing Negate
         # CHECK: %[[NEG:.+]] = arith.negf
-        # CHECK: math.exp2 %[[NEG]]
+
+        # Testing exp2
+        # CHECK: %[[EXP2:.+]] = math.exp2 %[[NEG]]
+
+        # Testing reciprocal
+        # %[[ONES:.+]] = arith.constant dense<1.000000e+00> : vector<4xf16>
+        # %[[RECIPROCAL:.+]] = arith.divf %[[ONES]], %[[EXP2]] : vector<4xf16>
 
 
 @run_test

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -463,7 +463,8 @@ def testAttention(
 
         # repeat represents the results of the loop
         res_max, res_sum, res_mm = repeat
-        res = res_mm / res_sum
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
         tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     hyperparams = {
@@ -657,7 +658,8 @@ def testAttentionBias(
 
         # repeat represents the results of the loop
         res_max, res_sum, res_mm = repeat
-        res = res_mm / res_sum
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
         tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     hyperparams = {
@@ -847,7 +849,8 @@ def testAttentionF8(
 
         # repeat represents the results of the loop
         res_max, res_sum, res_mm = repeat
-        res = res_mm / res_sum
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
         tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     hyperparams = {


### PR DESCRIPTION
Doing divf is very expensive on the GPU. We introduce reciprocalOp S.T we can use it to do a single divf on online attention's sum, which we can then apply to the attention output for normalization using mul.

This will allow us to only do a divf on a single f32 as opposed to the entire vector. Which will give us speed up of around 0.1 ms per dispatch on dispatch146(B0: 2, B1: 20, (M, K2): 1024: K1: 64) (after vectorized write land it drops from 5.53ms -> 5.38 ms)