### PR TITLE
[TKW] Implement pipeline to enable llvm_func_attrs and denormal_math

### DIFF
--- a/iree/turbine/kernel/compiler/dispatch_codegen.py
+++ b/iree/turbine/kernel/compiler/dispatch_codegen.py
@@ -171,7 +171,7 @@ class StreamExecutable:
                         iree_codegen_d.DispatchLoweringPassPipeline.None_
                     )
                     translation_config = None
-                    if len(llvm_configs) > 0:
+                    if llvm_configs:
                         # Add llvm_func_attrs to translation config if any is specified.
                         llvm_func_attrs = DictAttr.get(
                             {k: StringAttr.get(str(v)) for k, v in llvm_configs.items()}

--- a/iree/turbine/kernel/compiler/dispatch_codegen.py
+++ b/iree/turbine/kernel/compiler/dispatch_codegen.py
@@ -21,6 +21,7 @@ from .builder import (
 from .ir import (
     Attribute,
     Block,
+    DictAttr,
     FunctionType,
     IndexType,
     InsertionPoint,
@@ -99,6 +100,7 @@ class StreamExecutable:
         workgroup_size: list[int] = None,
         subgroup_size: int = None,
         dynamic_symbols: list[IndexSymbol] = [],
+        llvm_configs: dict[str, str] = {},
     ) -> "DispatchEntrypoint":
         """Defines a dispatch function with a signature like:
 
@@ -168,10 +170,23 @@ class StreamExecutable:
                     pipeline_attr = iree_codegen_d.DispatchLoweringPassPipelineAttr.get(
                         iree_codegen_d.DispatchLoweringPassPipeline.None_
                     )
+                    translation_config = None
+                    if len(llvm_configs) > 0:
+                        # Add llvm_func_attrs to translation config if any is specified.
+                        llvm_func_attrs = DictAttr.get(
+                            {k: StringAttr.get(str(v)) for k, v in llvm_configs.items()}
+                        )
+                        translation_config = DictAttr.get(
+                            {"llvm_func_attrs": llvm_func_attrs}
+                        )
                     def_func_op.attributes[
                         "translation_info"
                     ] = iree_codegen_d.TranslationInfoAttr.get(
-                        pipeline_attr, None, workgroup_size, subgroup_size
+                        pipeline_attr,
+                        None,
+                        workgroup_size,
+                        subgroup_size,
+                        configuration=translation_config,
                     )
 
             # Define the export.

--- a/iree/turbine/kernel/compiler/ir.py
+++ b/iree/turbine/kernel/compiler/ir.py
@@ -10,6 +10,7 @@ from iree.compiler.ir import (
     ArrayAttr,
     Block,
     Context,
+    DictAttr,
     DenseElementsAttr,
     F16Type,
     F32Type,

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -558,9 +558,6 @@ def compile_and_invoke(
         "--iree-vm-target-truncate-unsupported-floats",
     ]
 
-    if config.get("waves_per_eu", None) is not None:
-        flags.append(f"--iree-hip-waves-per-eu={config['waves_per_eu']}")
-
     # TODO: More targets/backends support.
     if backend == "rocm":
         target = config["target"]

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -330,6 +330,14 @@ class LaunchableWave(Launchable):
         exe = dispatch_codegen.StreamExecutable(mb, name=entrypoint_name)
         workgroup_size = self.hardware_constraints[0].threads_per_block
         subgroup_size = self.hardware_constraints[0].threads_per_wave
+        run_config = kwargs.get("run_config", {})
+
+        # Setup LLVM func compilation configs.
+        llvm_func_config = {}
+        denorm_fp_math_f32 = run_config.get("denorm_fp_math_f32", None)
+        if denorm_fp_math_f32 is not None:
+            llvm_func_config["denorm_fp_math_f32"] = denorm_fp_math_f32
+
         dispatch_entrypoint = exe.define_entrypoint(
             entrypoint_name,
             kernel_sig,
@@ -337,6 +345,7 @@ class LaunchableWave(Launchable):
             workgroup_size,
             subgroup_size,
             dynamic_symbols,
+            llvm_func_config,
         )
 
         emitter = WaveEmitter(

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -330,13 +330,17 @@ class LaunchableWave(Launchable):
         exe = dispatch_codegen.StreamExecutable(mb, name=entrypoint_name)
         workgroup_size = self.hardware_constraints[0].threads_per_block
         subgroup_size = self.hardware_constraints[0].threads_per_wave
-        run_config = kwargs.get("run_config", {})
 
         # Setup LLVM func compilation configs.
+        compile_config = kwargs.get("compile_config", {})
         llvm_func_config = {}
-        denorm_fp_math_f32 = run_config.get("denorm_fp_math_f32", None)
-        if denorm_fp_math_f32 is not None:
-            llvm_func_config["denorm_fp_math_f32"] = denorm_fp_math_f32
+        denorm_fp_math_f32 = compile_config.get("denorm_fp_math_f32", None)
+        if denorm_fp_math_f32 != None:
+            llvm_func_config["denormal-fp-math-f32"] = denorm_fp_math_f32
+
+        waves_per_eu = compile_config.get("waves_per_eu", None)
+        if waves_per_eu != None:
+            llvm_func_config["amdgpu-waves-per-eu"] = waves_per_eu
 
         dispatch_entrypoint = exe.define_entrypoint(
             entrypoint_name,

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -563,11 +563,13 @@ def test_attention_32x32x8():
         MMA_UNITS: 4,
     }
 
+    config = {"denorm_fp_math_f32": "preserve-sign"}
     with tk.gen.TestLaunchContext(
         hyperparams,
         canonicalize=True,
         run=False,
         run_bench=False,
+        run_config=config,
         schedule=False,
         use_scheduling_barriers=False,
     ):
@@ -578,6 +580,8 @@ def test_attention_32x32x8():
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
         print(base_attention_32x32x8(q, k, v, output).module_op)
 
+        # CHECK-DAG:        #iree_codegen.translation_info
+        # CHECK-SAME:       {llvm_func_attrs = {denorm_fp_math_f32 = "preserve-sign"}
         # CHECK-LABEL:      func.func @base_attention_32x32x8
         # CHECK:                {{.*}} = scf.for
         # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -563,13 +563,13 @@ def test_attention_32x32x8():
         MMA_UNITS: 4,
     }
 
-    config = {"denorm_fp_math_f32": "preserve-sign"}
+    compile_config = {"waves_per_eu": 2, "denorm_fp_math_f32": "preserve-sign"}
     with tk.gen.TestLaunchContext(
         hyperparams,
         canonicalize=True,
         run=False,
         run_bench=False,
-        run_config=config,
+        compile_config=compile_config,
         schedule=False,
         use_scheduling_barriers=False,
     ):
@@ -581,7 +581,7 @@ def test_attention_32x32x8():
         print(base_attention_32x32x8(q, k, v, output).module_op)
 
         # CHECK-DAG:        #iree_codegen.translation_info
-        # CHECK-SAME:       {llvm_func_attrs = {denorm_fp_math_f32 = "preserve-sign"}
+        # CHECK-SAME:       {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign"}
         # CHECK-LABEL:      func.func @base_attention_32x32x8
         # CHECK:                {{.*}} = scf.for
         # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -482,6 +482,7 @@ def testAttention(
     }
     hyperparams.update(get_default_scheduling_params())
     config = get_default_run_config()
+    config["denorm_fp_math_f32"] = "preserve-sign"
     if run_bench:
         config["benchmark_batch_size"] = 10
         config["benchmark_repetitions"] = 3

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -482,7 +482,6 @@ def testAttention(
     }
     hyperparams.update(get_default_scheduling_params())
     config = get_default_run_config()
-    config["denorm_fp_math_f32"] = "preserve-sign"
     if run_bench:
         config["benchmark_batch_size"] = 10
         config["benchmark_repetitions"] = 3
@@ -491,6 +490,7 @@ def testAttention(
         config["benchmark_results_file"] = os.path.join(
             dump_perf, "tk_" + perf_filename
         )
+    compile_config = {"waves_per_eu": 2, "denorm_fp_math_f32": "preserve-sign"}
 
     dynamic_symbols = []
     dynamic_symbols_map = {}
@@ -514,6 +514,7 @@ def testAttention(
         run=True,
         run_bench=run_bench,
         run_config=config,
+        compile_config=compile_config,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
         dynamic_symbols=dynamic_symbols,

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -98,6 +98,7 @@ def testEvoformerAttentionForward(
 
     config = get_default_run_config()
     config["waves_per_eu"] = 2
+    config["denorm_fp_math_f32"] = "preserve-sign"
     if run_bench:
         config["benchmark_batch_size"] = 1000
         config["benchmark_repetitions"] = 3

--- a/tests/kernel/wave/wave_evoformer_test.py
+++ b/tests/kernel/wave/wave_evoformer_test.py
@@ -97,8 +97,6 @@ def testEvoformerAttentionForward(
     symbols.update(get_default_scheduling_params())
 
     config = get_default_run_config()
-    config["waves_per_eu"] = 2
-    config["denorm_fp_math_f32"] = "preserve-sign"
     if run_bench:
         config["benchmark_batch_size"] = 1000
         config["benchmark_repetitions"] = 3
@@ -107,6 +105,7 @@ def testEvoformerAttentionForward(
         config["benchmark_results_file"] = os.path.join(
             dump_perf, "tk_" + perf_filename
         )
+    compile_config = {"waves_per_eu": 2, "denorm_fp_math_f32": "preserve-sign"}
 
     with tk.gen.TestLaunchContext(
         symbols,
@@ -114,6 +113,7 @@ def testEvoformerAttentionForward(
         run=True,
         run_bench=run_bench,
         run_config=config,
+        compile_config=compile_config,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):


### PR DESCRIPTION
For flash attention, denormal-fp-math-f32" = "preserve-sign" is very important optimization. With this flag, we are able to drop latency from 5.38ms to 4.75ms on dispatch146(B0: 2, B1: 20, (M, K2): 1024: K1: 64).

Added compile_config S.T we can use it as a parameter for kernel cacher as well.