### PR TITLE
 [TKW] Introduce AbsOp as an op for Quantized LLM and GenAI workload. The tkw.abs op is lowered into math.absf and math.absi MLIR dialect for float and integer respectively.

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -105,6 +105,7 @@ def exp2(src: "Register") -> "Register":
 def reciprocal(src: "Register") -> "Register":
     ...
 
+
 def abs(src: "Register") -> "Register":
     ...
 

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -105,6 +105,9 @@ def exp2(src: "Register") -> "Register":
 def reciprocal(src: "Register") -> "Register":
     ...
 
+def abs(src: "Register") -> "Register":
+    ...
+
 
 def maximum(lhs: "Register", rhs: "Register") -> "Register":
     ...
@@ -642,6 +645,7 @@ class BinaryPyOp(CustomOp, ABC):
 
 @define_interface_op("exp2")
 @define_interface_op("reciprocal")
+@define_interface_op("abs")
 @define_py_op(operator.neg)
 @dataclass
 class UnaryPyOp(CustomOp, ABC):

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -56,6 +56,7 @@ from ..ops.wave_ops import (
     reduction,
     exp2,
     reciprocal,
+    abs,
     maximum,
     get_custom,
     get_result,
@@ -1133,6 +1134,17 @@ def handle_reciprocal(source: Value) -> OpResult:
             f"Found unhandled operand type for reciprocal: {element_type}"
         )
     return reciprocal
+
+@handle_unary_op(abs)
+def handle_abs(source: Value) -> OpResult:
+    element_type = get_type_or_element_type(source.type)
+    if _is_float_type(element_type):
+        abs = math_d.absf(source)
+    else:
+        raise ValidationError(
+            f"Found unhandled operand type for abs: {element_type}"
+        )
+    return abs
 
 
 ###############################################################################

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -1140,6 +1140,8 @@ def handle_abs(source: Value) -> OpResult:
     element_type = get_type_or_element_type(source.type)
     if _is_float_type(element_type):
         abs = math_d.absf(source)
+    elif _is_integer_like_type(element_type):
+        abs = math_d.absi(source)
     else:
         raise ValidationError(
             f"Found unhandled operand type for abs: {element_type}"

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -1135,6 +1135,7 @@ def handle_reciprocal(source: Value) -> OpResult:
         )
     return reciprocal
 
+
 @handle_unary_op(abs)
 def handle_abs(source: Value) -> OpResult:
     element_type = get_type_or_element_type(source.type)
@@ -1143,9 +1144,7 @@ def handle_abs(source: Value) -> OpResult:
     elif _is_integer_like_type(element_type):
         abs = math_d.absi(source)
     else:
-        raise ValidationError(
-            f"Found unhandled operand type for abs: {element_type}"
-        )
+        raise ValidationError(f"Found unhandled operand type for abs: {element_type}")
     return abs
 
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1951,8 +1951,8 @@ def test_unary_lowerings():
         # %[[RECIPROCAL:.+]] = arith.divf %[[ONES]], %[[EXP2]] : vector<4xf16>
         
         # Testing abs
-        # %[[ABS:.+]] = math.absf %[[RECIPROCAL]]
-        # %[[ABS:.+]] = math.absi
+        # %[[ABSF:.+]] = math.absf %[[RECIPROCAL]]
+        # %[[ABSI:.+]] = math.absi
 
 
 @run_test

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1926,6 +1926,7 @@ def test_unary_lowerings():
         res = -a_reg
         res = tkw.exp2(res)
         res = tkw.reciprocal(res)
+        res = tkw.abs(res)
         tkw.write(res, a, elements_per_thread=4)
 
     a = torch.randn(16, 16, dtype=torch.float16)
@@ -1941,6 +1942,9 @@ def test_unary_lowerings():
         # Testing reciprocal
         # %[[ONES:.+]] = arith.constant dense<1.000000e+00> : vector<4xf16>
         # %[[RECIPROCAL:.+]] = arith.divf %[[ONES]], %[[EXP2]] : vector<4xf16>
+        
+        # Testing abs
+        # %[[ABS:.+]] = math.absf %[[RECIPROCAL]]
 
 
 @run_test

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1949,7 +1949,7 @@ def test_unary_lowerings():
         # Testing reciprocal
         # %[[ONES:.+]] = arith.constant dense<1.000000e+00> : vector<4xf16>
         # %[[RECIPROCAL:.+]] = arith.divf %[[ONES]], %[[EXP2]] : vector<4xf16>
-        
+
         # Testing abs
         # %[[ABSF:.+]] = math.absf %[[RECIPROCAL]]
         # %[[ABSI:.+]] = math.absi


### PR DESCRIPTION
[TKW] Introduce AbsOp as an op for Quantized LLM and GenAI workload. 
The tkw.abs op is lowered into math.absf and math.absi MLIR dialect for float and integer respectively

Fixes #322 


 