### PR TITLE
[TKW] Update iree-requirements and integrate rocdl_d

### DIFF
--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -10,5 +10,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.1.0rc20241127
-iree-base-runtime==3.1.0rc20241127
+iree-base-compiler==3.1.0rc20241212
+iree-base-runtime==3.1.0rc20241212

--- a/iree/turbine/kernel/compiler/ir.py
+++ b/iree/turbine/kernel/compiler/ir.py
@@ -46,6 +46,7 @@ from iree.compiler.dialects import (
     llvm as llvm_d,
     math as math_d,
     memref as memref_d,
+    rocdl as rocld_d,
     stream as stream_d,
     scf as scf_d,
     transform as transform_d,


### PR DESCRIPTION
ROCDL dialect is required to do use setprio for performant scheduling