### PR TITLE
Add flash decode v2

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -102,6 +102,10 @@ def exp2(src: "Register") -> "Register":
     ...
 
 
+def log2(src: "Register") -> "Register":
+    ...
+
+
 def reciprocal(src: "Register") -> "Register":
     ...
 
@@ -653,6 +657,7 @@ class BinaryPyOp(CustomOp, ABC):
         self.type = broadcasted_type
 
 
+@define_interface_op("log2")
 @define_interface_op("exp2")
 @define_interface_op("reciprocal")
 @define_interface_op("abs")

--- a/iree/turbine/kernel/wave/symbolic_constraints.py
+++ b/iree/turbine/kernel/wave/symbolic_constraints.py
@@ -1,0 +1,27 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from iree.turbine.kernel._support.indexing import IndexExpr, IndexSymbol
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class SymbolicAlias:
+    """
+    A constraint of the form `tkw.SymbolicConstraint(K, SYMBOLIC_K)` specifies
+    that the relationship between the source and target symbols is given by
+    source = source_to_target(target).
+
+    SymbolicAliases are modeled in the compiler as additional workgroup, wave,
+    and tiling constraints that are derived from the source. They are ignored
+    during expansion and utilize the same workgroup and wave ids as the
+    target symbol.
+    """
+
+    source: IndexSymbol | IndexExpr
+    target: IndexSymbol | IndexExpr
+    source_to_target: Callable[[IndexSymbol | IndexExpr], IndexSymbol | IndexExpr]

--- a/iree/turbine/kernel/wave/templates/decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/decode_attention.py
@@ -65,12 +65,7 @@ def get_decode_attention_kernels(
         constraints += [
             SymbolicAlias(U, K2, lambda x: sympy.ceiling(x / (BLOCK_K2 / K_WAVES)))
         ]
-        if mfma_variant == MMAType.F32_16x16x16_F16:
-            vector_shapes = {B: 0, M: 16, N: 16}
-        elif mfma_variant == MMAType.F32_32x32x8_F16:
-            vector_shapes = {B: 0, M: 32, N: 32}
-        else:
-            raise NotImplementedError(f"Unsupported mfma_variant: {mfma_variant}")
+        vector_shapes = {B: 0}
         waves_per_block = (M_WAVES, N_WAVES, K_WAVES)
         constraints += [
             tkw.HardwareConstraint(
@@ -147,8 +142,8 @@ def get_decode_attention_kernels(
         acc = tkw.mma(v_reg, imm_f16, new_acc)
         res = acc / d_j
         dm_j = m_j + tkw.log2(d_j)
-        tkw.write(res, output, elements_per_thread=STORE_ELEMS_PER_THREAD)
         tkw.write(dm_j, output_max, elements_per_thread=1)
+        tkw.write(res, output, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     @tkw.wave(get_constraints(Phase.PHASE_1))
     def phase_1(

--- a/iree/turbine/kernel/wave/templates/decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/decode_attention.py
@@ -1,0 +1,201 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel._support.dtype import DataType
+from iree.turbine.kernel.wave.utils import (
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+)
+from ..symbolic_constraints import SymbolicAlias
+import sympy
+from enum import Enum
+import math
+
+
+def get_decode_attention_kernels(
+    shape: tuple[int],
+    mfma_variant: MMAType,
+):
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+    U = tkl.sym.U
+    BLOCK_U = tkl.sym.BLOCK_U
+
+    class Phase(Enum):
+        PHASE_0 = (0,)
+        PHASE_1 = (1,)
+
+    M_WAVES = 2
+    N_WAVES = 2
+    K_WAVES = 2
+    THREADS_PER_WAVE = 64
+    PHASE_1_BLOCK_M = 128
+    PHASE_1_ELEMS_PER_THREAD = PHASE_1_BLOCK_M // THREADS_PER_WAVE
+    PHASE_1_BLOCK_N = 1
+
+    def phase_0_constraints():
+        constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+        constraints += [tkw.WaveConstraint(M, BLOCK_M / M_WAVES)]
+        constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+        constraints += [tkw.WaveConstraint(N, BLOCK_N / N_WAVES)]
+        constraints += [tkw.WorkgroupConstraint(K2, BLOCK_K2, 2)]
+        constraints += [tkw.WaveConstraint(K2, BLOCK_K2 / K_WAVES)]
+        constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 3)]
+        constraints += [
+            SymbolicAlias(U, K2, lambda x: sympy.ceiling(x / (BLOCK_K2 / K_WAVES)))
+        ]
+        vector_shapes = {B: 0, M: 16, N: 16, K2: 16}
+        waves_per_block = (M_WAVES, N_WAVES, K_WAVES)
+        constraints += [
+            tkw.HardwareConstraint(
+                threads_per_wave=THREADS_PER_WAVE,
+                waves_per_block=waves_per_block,
+                mma_type=mfma_variant,
+                vector_shapes=vector_shapes,
+            )
+        ]
+        return constraints
+
+    def phase_1_constraints() -> list[tkw.Constraint]:
+        constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+        constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+        constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+        constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+        constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+        constraints += [tkw.TilingConstraint(U, BLOCK_U)]
+        vector_shapes = {
+            B: 0,
+            M: BLOCK_M,
+            N: BLOCK_N,
+            U: 1,
+        }
+        waves_per_block = (1, 1, 1)
+        constraints += [
+            tkw.HardwareConstraint(
+                threads_per_wave=THREADS_PER_WAVE,
+                waves_per_block=waves_per_block,
+                mma_type=mfma_variant,
+                vector_shapes=vector_shapes,
+            )
+        ]
+        return constraints
+
+    def get_constraints(phase: Phase) -> list[tkw.Constraint]:
+        if phase == Phase.PHASE_0:
+            return phase_0_constraints()
+        else:
+            return phase_1_constraints()
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3,
+        inputs={B: i, N: j, M: k},
+        outputs={B: i, N: j, M: k},
+    )
+
+    @tkw.wave(get_constraints(Phase.PHASE_0))
+    def phase_0(
+        q: tkl.Memory[B, M, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        output: tkl.Memory[U, B, N, M, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        output_max: tkl.Memory[U, B, M, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        new_acc = tkl.Register[B, N, M, tkl.f32](0.0)
+        q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        acc = tkw.mma(k_reg, q_reg, c_reg)
+        x_j = tkw.permute(acc, target_shape=[B, M, K2])
+        m_j = tkw.max(x_j, init_max, dim=K2)
+        e_delta_max = tkw.exp2(init_max - m_j)
+        e_delta = tkw.exp2(x_j - m_j)
+        e_init = init_sum * e_delta_max
+        d_j = tkw.sum(e_delta, e_init, dim=K2)
+        imm_f16 = tkw.cast(e_delta, tkl.f16)
+        v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        acc = tkw.mma(v_reg, imm_f16, new_acc)
+        res = acc / d_j
+        dm_j = m_j + tkw.log2(d_j)
+        tkw.write(res, output, elements_per_thread=STORE_ELEMS_PER_THREAD)
+        tkw.write(dm_j, output_max, elements_per_thread=1)
+
+    @tkw.wave(get_constraints(Phase.PHASE_1))
+    def phase_1(
+        logits: tkl.Memory[U, B, N, M, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        logits_max: tkl.Memory[U, B, M, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        output: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+
+        @tkw.reduction(U, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, M, tkl.f32],
+            partial_sum: tkl.Register[B, M, tkl.f32],
+            acc: tkl.Register[B, N, M, tkl.f32],
+        ):
+            x_j = tkw.read(logits, elements_per_thread=PHASE_1_ELEMS_PER_THREAD)
+            xm_j = tkw.read(logits_max, elements_per_thread=PHASE_1_ELEMS_PER_THREAD)
+            m_j = tkw.maximum(xm_j, partial_max)
+            old_scale = tkw.exp2(partial_max - m_j)
+            new_scale = tkw.exp2(xm_j - m_j)
+            d_j = partial_sum * old_scale + new_scale
+            new_acc = acc * old_scale
+            term = new_scale * x_j
+            new_acc = new_acc + term
+            return m_j, d_j, new_acc
+
+        res_max, res_sum, res_mm = repeat
+        res = res_mm / res_sum
+        tkw.write(
+            res, output, mapping=mapping, elements_per_thread=PHASE_1_ELEMS_PER_THREAD
+        )
+
+    symbols_0 = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        BLOCK_B: 1,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K2: 32,
+        BLOCK_U: 1,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K1: shape[3],
+        K2: shape[4],
+    }
+    symbols_0[U] = math.ceil(symbols_0[K2] / (symbols_0[BLOCK_K2] / K_WAVES))
+    symbols_1 = dict(symbols_0)
+    symbols_1[BLOCK_M] = PHASE_1_BLOCK_M
+    symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
+
+    return phase_0, phase_1, symbols_0, symbols_1

--- a/iree/turbine/kernel/wave/templates/decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/decode_attention.py
@@ -65,7 +65,12 @@ def get_decode_attention_kernels(
         constraints += [
             SymbolicAlias(U, K2, lambda x: sympy.ceiling(x / (BLOCK_K2 / K_WAVES)))
         ]
-        vector_shapes = {B: 0, M: 16, N: 16, K2: 16}
+        if mfma_variant == MMAType.F32_16x16x16_F16:
+            vector_shapes = {B: 0, M: 16, N: 16}
+        elif mfma_variant == MMAType.F32_32x32x8_F16:
+            vector_shapes = {B: 0, M: 32, N: 32}
+        else:
+            raise NotImplementedError(f"Unsupported mfma_variant: {mfma_variant}")
         waves_per_block = (M_WAVES, N_WAVES, K_WAVES)
         constraints += [
             tkw.HardwareConstraint(

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -871,7 +871,8 @@ def bfs(
 
 
 def capture_forward_slice(
-    node: fx.Node, filter_fn: Callable[[fx.node], bool] = lambda x: True
+    node: fx.Node,
+    filter_fn: Callable[[fx.node], bool] = lambda x: True,
 ) -> set[fx.Node]:
     """
     Run BFS on the graph to capture the forward slice of a node.

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -8,6 +8,8 @@ from typing import Any, Callable, Optional
 import torch.fx as fx
 import inspect
 
+from .symbolic_constraints import SymbolicAlias
+
 from ..compiler import builder, dispatch_codegen, kernel_codegen, host_codegen
 from ..compiler.ir import Context, Operation
 from .codegen import WaveEmitter
@@ -212,13 +214,43 @@ class LaunchableWave(Launchable):
                 if tiling_constraint.dim == get_custom(reduction).axis:
                     reduction.count = subs_idxc(tiling_constraint.count)
 
+    def get_workgroup_dims(self) -> list[int]:
+        """
+        Returns the workgroup dimensions that are not aliased.
+        """
+        # Ignore aliased variables. They will be handled separately.
+        aliased_dims = [
+            x.source for x in self.constraints if isinstance(x, SymbolicAlias)
+        ]
+        workgroup_dims = {
+            x.workgroup_dim: x
+            for x in self.workgroup_constraints
+            if x.dim not in aliased_dims
+        }
+        return workgroup_dims
+
+    def update_aliased_workgroup_constraints(
+        self, workgroup_dims: dict[int, int]
+    ) -> None:
+        """
+        This function updates the wg_dim for aliased workgroup constraints.
+        """
+        aliased_dims = [
+            x.source for x in self.constraints if isinstance(x, SymbolicAlias)
+        ]
+        # Update the workgroup constraints for aliases sources.
+        for constraint in self.workgroup_constraints:
+            if constraint.dim in aliased_dims:
+                constraint.wg_dim = workgroup_dims[constraint.workgroup_dim].wg_dim
+
     def initialize_workgroup_constraints(self, trace: CapturedTrace) -> None:
         """
         For kernels that distribute more than three dimensions among workgroups,
         we need to update the workgroup constraints for dimensions >= 2
         with the appropriate workgroup index.
         """
-        workgroup_dims = {x.workgroup_dim: x for x in self.workgroup_constraints}
+
+        workgroup_dims = self.get_workgroup_dims()
         if all(x <= 2 for x in workgroup_dims.keys()):
             return
         shape = [
@@ -228,6 +260,89 @@ class LaunchableWave(Launchable):
         new_workgroup_dims = delinearize_index(WORKGROUP_2, shape)
         for i in range(2, max(workgroup_dims.keys()) + 1):
             workgroup_dims[i].wg_dim = new_workgroup_dims[i - 2]
+        self.update_aliased_workgroup_constraints(workgroup_dims)
+
+    def create_new_constraints(
+        self,
+        symbolic_constraints: list[SymbolicAlias],
+        constraints: list[Constraint],
+    ) -> list[Constraint]:
+        """
+        Creates new constraints for the given constraints with the appropriate
+        substitution of the indexing context.
+
+        """
+        new_constraints = []
+        if not constraints:
+            return new_constraints
+        match constraints[0]:
+            case WorkgroupConstraint():
+                build_constraint = lambda x, y, z: WorkgroupConstraint(x, y, z)
+                id_fn = lambda x: x.workgroup_dim
+            case WaveConstraint():
+                build_constraint = lambda x, y, z: WaveConstraint(x, y, z)
+                id_fn = lambda x: x.wave_id
+            case TilingConstraint():
+                build_constraint = lambda x, y, z: TilingConstraint(x, y, z)
+                id_fn = lambda x: x.induction_var
+        for symbolic_constraint in symbolic_constraints:
+            for constraint in constraints:
+                if symbolic_constraint.target == constraint.dim:
+                    tile_size = subs_idxc(
+                        symbolic_constraint.source_to_target(constraint.tile_size)
+                    )
+                    if tile_size.is_number and tile_size == 0:
+                        continue
+                    new_constraints.append(
+                        build_constraint(
+                            symbolic_constraint.source,
+                            symbolic_constraint.source_to_target(constraint.tile_size),
+                            id_fn(constraint),
+                        )
+                    )
+        return new_constraints
+
+    def initialize_symbolic_constraints(self, trace: CapturedTrace) -> None:
+        """
+        For each symbolic constraint, create new constraints for the
+        related symbolic values with appropriate substitutions.
+        """
+        symbolic_constraints = [
+            x for x in self.constraints if isinstance(x, SymbolicAlias)
+        ]
+        new_wg_constraints, new_wave_constraints, new_tiling_constraints = [], [], []
+        new_wg_constraints += self.create_new_constraints(
+            symbolic_constraints, self.workgroup_constraints
+        )
+        new_wave_constraints += self.create_new_constraints(
+            symbolic_constraints, self.wave_constraints
+        )
+        new_tiling_constraints += self.create_new_constraints(
+            symbolic_constraints, self.tiling_constraints
+        )
+        # Remove wave constraints with same tile size as workgroup constraints
+        for wave_constraint in new_wave_constraints:
+            for workgroup_constraint in new_wg_constraints:
+                if (
+                    wave_constraint.dim == workgroup_constraint.dim
+                    and wave_constraint.tile_size == workgroup_constraint.tile_size
+                ):
+                    new_wave_constraints.remove(wave_constraint)
+        self.constraints += (
+            new_wg_constraints + new_wave_constraints + new_tiling_constraints
+        )
+        idxc = IndexingContext.current()
+        vector_shapes = self.hardware_constraints[0].vector_shapes
+        for constraint in symbolic_constraints:
+            if subs_idxc(constraint.target).is_number:
+                idxc._bind_symbol(
+                    constraint.source,
+                    subs_idxc(constraint.source_to_target(constraint.target)),
+                )
+            if constraint.target in vector_shapes:
+                vector_shapes[constraint.source] = subs_idxc(
+                    constraint.source_to_target(vector_shapes[constraint.target])
+                )
 
     def _trace_and_get_kernel_signature(
         self,
@@ -242,6 +357,7 @@ class LaunchableWave(Launchable):
         self.create_induction_vars(graph)
         self.initialize_wave_constraints(graph)
         self.initialize_reductions(graph)
+        self.initialize_symbolic_constraints(graph)
         self.initialize_workgroup_constraints(graph)
 
         idxc = IndexingContext.current()
@@ -307,7 +423,10 @@ class LaunchableWave(Launchable):
         # Determine grid shape.
         self.grid_type.dims = [1, 1, 1]
         max_workgroup_dim = 2
+        aliases = [x.source for x in self.constraints if isinstance(x, SymbolicAlias)]
         for constraint in self.workgroup_constraints:
+            if constraint.dim in aliases:
+                continue
             dim = (
                 constraint.workgroup_dim
                 if constraint.workgroup_dim < max_workgroup_dim

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -6,13 +6,18 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.symbolic_constraints import SymbolicAlias
 from iree.turbine.kernel.wave.utils import (
     run_test,
     get_mfma_load_elems_per_thread,
     get_mfma_store_elems_per_thread,
 )
+from iree.turbine.kernel.wave.templates.decode_attention import (
+    get_decode_attention_kernels,
+)
 import torch
-from enum import Enum
+import sympy
+import math
 
 # Input sizes
 B = tkl.sym.B
@@ -479,174 +484,70 @@ def test_attention_pipelined():
 def test_flash_decoding():
     shape = (8, 128, 128, 64, 256)
     mfma_variant = tkw.MMAType.F32_16x16x16_F16
-
-    class Phase(Enum):
-        QK = (0,)
-        SOFTMAX_V = (1,)
-
-    def get_constraints(phase: Phase) -> list[tkw.Constraint]:
-        constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
-        constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
-        constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
-        if phase == Phase.QK:
-            constraints += [tkw.WorkgroupConstraint(K2, BLOCK_K2, 1)]
-            constraints += [tkw.WaveConstraint(K2, BLOCK_K2 / 2)]
-            vector_shapes = {B: 0, M: 16, K2: 16}
-        else:
-            constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-            constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
-            constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
-            vector_shapes = {B: 0, M: 16, N: 16}
-        constraints += [
-            tkw.HardwareConstraint(
-                threads_per_wave=64,
-                waves_per_block=(2, 2, 1),
-                mma_type=mfma_variant,
-                vector_shapes=vector_shapes,
-            )
-        ]
-        return constraints
-
-    # The first kernel computes Q @ K.T.
-    @tkw.wave(get_constraints(Phase.QK))
-    def qk_kernel(
-        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
-        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
-        c: tkl.Memory[B, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f32],
-    ):
-        c_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
-        q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-        k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-        acc = tkw.mma(k_reg, q_reg, c_reg)
-        x_j = tkw.permute(acc, target_shape=[B, M, K2])
-        tkw.write(x_j, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
-
-    # The second kernel computes the softmax and V @ softmax(Q @ K.T).
-    i = tkw.IndexMapping.iterator(0)
-    j = tkw.IndexMapping.iterator(1)
-    k = tkw.IndexMapping.iterator(2)
-    mapping = tkw.IndexMapping(
-        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    phase_0, phase_1, hyperparams_0, hyperparams_1 = get_decode_attention_kernels(
+        shape, mfma_variant
     )
-
-    @tkw.wave(get_constraints(Phase.SOFTMAX_V))
-    def softmax_v_kernel(
-        qk: tkl.Memory[B, M, K2, ADDRESS_SPACE, tkl.f32],
-        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
-        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
-    ):
-        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
-        init_sum = tkl.Register[B, M, tkl.f32](0.0)
-        init_max = tkl.Register[B, M, tkl.f32](-1e6)
-
-        # This microkernel encodes the fact that if the reduction
-        # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
-        def repeat(
-            partial_max: tkl.Register[B, M, tkl.f32],
-            partial_sum: tkl.Register[B, M, tkl.f32],
-            acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, N, M, tkl.f32],
-        ):
-            x_j = tkw.read(qk, elements_per_thread=STORE_ELEMS_PER_THREAD)
-            m_j = tkw.max(x_j, partial_max, dim=K2)
-            e_delta_max = tkw.exp2(partial_max - m_j)
-            e_delta = tkw.exp2(x_j - m_j)
-            e_init = partial_sum * e_delta_max
-            d_j = tkw.sum(e_delta, e_init, dim=K2)
-            imm_f16 = tkw.cast(e_delta, tkl.f16)
-            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-            new_acc = acc * e_delta_max
-            acc = tkw.mma(v_reg, imm_f16, new_acc)
-            return m_j, d_j, acc
-
-        # repeat represents the results of the loop
-        res_max, res_sum, res_mm = repeat
-        res = res_mm / res_sum
-        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
-
-    hyperparams = {
-        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
-        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
-        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
-        BLOCK_B: 1,
-        BLOCK_M: 64,
-        BLOCK_N: 64,
-        BLOCK_K2: 32,
-        B: shape[0],
-        M: shape[1],
-        N: shape[2],
-        K1: shape[3],
-        K2: shape[4],
-        READ_SHARED_DELAY: 1,
-        WRITE_SHARED_DELAY: 1,
-        READ_GLOBAL_DELAY: 2,
-        WRITE_GLOBAL_DELAY: 2,
-        MMA_DELAY: 1,
-        VALU_DELAY: 1,
-        SHUFFLE_DELAY: 1,
-        SHARED_MEMORY_UNITS: 4,
-        GLOBAL_MEMORY_UNITS: 4,
-        MMA_UNITS: 4,
-        VALU_UNITS: 2,
-        SHUFFLE_UNITS: 2,
-    }
 
     torch.manual_seed(0)
     q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
     k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
     v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
-    qkt = torch.zeros(shape[0], shape[1], shape[4], dtype=torch.float32)
+    logits = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+    logits_max = torch.zeros(shape[0], shape[1], dtype=torch.float32)
     output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
 
     with tk.gen.TestLaunchContext(
-        hyperparams,
+        hyperparams_0,
         canonicalize=True,
         run=False,
         run_bench=False,
         schedule=False,
         use_scheduling_barriers=False,
     ):
-        print(qk_kernel(q, k, qkt).module_op)
+        print(phase_0(q, k, v, logits, logits_max).module_op)
 
-        # CHECK:            func.func @qk_kernel
-        # CHECK-NOT:               {{.*}} = scf.for
-        # CHECK-COUNT-1:           {{.*}} = vector.load
-        # CHECK-COUNT-1:           vector.store
-        # CHECK-COUNT-1:           {{.*}} = vector.load
-        # CHECK-COUNT-1:           vector.store
-        # CHECK-COUNT-8:           {{.*}} = vector.load
-        # CHECK-COUNT-1:           {{.*}} = vector.load
-        # CHECK-COUNT-1:           vector.store
-        # CHECK-COUNT-4:           {{.*}} = vector.load
-        # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma
-        # CHECK-COUNT-2:           vector.store
+    # CHECK:            func.func @phase_0
+    # CHECK-NOT:               {{.*}} = scf.for
+    # CHECK-COUNT-9:           {{.*}} = vector.load
+    # CHECK-COUNT-1:           vector.store
+    # CHECK-COUNT-4:           {{.*}} = vector.load
+    # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma
+    # CHECK-COUNT-4:           {{.*}} = gpu.shuffle
+    # CHECK-COUNT-2:           {{.*}} = arith.subf
+    # CHECK-COUNT-2:           {{.*}} = math.exp2
+    # CHECK-COUNT-2:           {{.*}} = arith.subf
+    # CHECK-COUNT-2:           {{.*}} = math.exp2
+    # CHECK-COUNT-4:           {{.*}} = gpu.shuffle
+    # CHECK-COUNT-2:           {{.*}} = amdgpu.mfma
+    # CHECK-COUNT-2:           {{.*}} = arith.divf
+    # CHECK-COUNT-2:           {{.*}} = math.log2
+    # CHECK-COUNT-18:          vector.store
 
     with tk.gen.TestLaunchContext(
-        hyperparams,
+        hyperparams_1,
         canonicalize=True,
         run=False,
         run_bench=False,
         schedule=False,
         use_scheduling_barriers=False,
     ):
-        print(softmax_v_kernel(qkt, v, output).module_op)
+        print(phase_1(logits, logits_max, output).module_op)
 
-        # CHECK:            func.func @softmax_v_kernel
-        # CHECK:               {{.*}} = scf.for
-        # CHECK-COUNT-1:           {{.*}} = vector.load
-        # CHECK-COUNT-1:           vector.store
-        # CHECK-COUNT-1:           {{.*}} = vector.load
-        # CHECK-COUNT-1:           vector.store
-        # CHECK-COUNT-4:           {{.*}} = vector.load
-        # CHECK-COUNT-4:           {{.*}} = gpu.shuffle
-        # CHECK-COUNT-4:           {{.*}} = arith.subf
-        # CHECK-COUNT-4:           {{.*}} = math.exp2
-        # CHECK-COUNT-4:           {{.*}} = gpu.shuffle
-        # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma
+    # CHECK:            func.func @phase_1
+    # CHECK:               {{.*}} = scf.for
+    # CHECK-COUNT-2:           {{.*}} = vector.load
+    # CHECK-COUNT-1:           {{.*}} = arith.maximumf
+    # CHECK-COUNT-1:           {{.*}} = arith.subf
+    # CHECK-COUNT-1:           {{.*}} = math.exp2
+    # CHECK-COUNT-1:           {{.*}} = arith.subf
+    # CHECK-COUNT-1:           {{.*}} = math.exp2
+    # CHECK-COUNT-1:           {{.*}} = arith.mulf
+    # CHECK-COUNT-1:           {{.*}} = arith.addf
+    # CHECK-COUNT-2:           {{.*}} = arith.mulf
+    # CHECK-COUNT-1:           {{.*}} = arith.addf
+    # CHECK-COUNT-1:      {{.*}} = arith.divf
+    # TODO: Remove vector.scatter when optimizing for performance
+    # CHECK-COUNT-1:      vector.scatter
 
 
 @run_test

--- a/tests/kernel/wave/wave_attention_test.py
+++ b/tests/kernel/wave/wave_attention_test.py
@@ -25,6 +25,9 @@ from iree.turbine.kernel.wave.utils import (
     device_zeros,
 )
 from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.templates.decode_attention import (
+    get_decode_attention_kernels,
+)
 import os
 import json
 from torch.testing import assert_close, assert_allclose
@@ -930,136 +933,11 @@ def testFlashDecoding(
 ):
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")
-    # Input sizes
-    B = tkl.sym.B
-    M = tkl.sym.M
-    N = tkl.sym.N
-    K1 = tkl.sym.K1
-    K2 = tkl.sym.K2
-    # Workgroup tile sizes
-    BLOCK_B = tkl.sym.BLOCK_B
-    BLOCK_M = tkl.sym.BLOCK_M
-    BLOCK_N = tkl.sym.BLOCK_N
-    BLOCK_K2 = tkl.sym.BLOCK_K2
-    # Address space (for GPU, shared(1) or global(0))
-    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
-    # Other hyperparameters
-    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
-    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
-
-    class Phase(Enum):
-        QK = (0,)
-        SOFTMAX_V = (1,)
-
-    def get_constraints(phase: Phase) -> list[tkw.Constraint]:
-        if mfma_variant == MMAType.F32_16x16x16_F16:
-            Mvec = 16
-            Nvec = 16
-        if mfma_variant == MMAType.F32_32x32x8_F16:
-            Mvec = 32
-            Nvec = 32
-        ratio_m = 2
-        ratio_n = 2
-        constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
-        constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
-        constraints += [tkw.WaveConstraint(M, BLOCK_M / ratio_m)]
-        if phase == Phase.QK:
-            constraints += [tkw.WorkgroupConstraint(K2, BLOCK_K2, 1)]
-            constraints += [tkw.WaveConstraint(K2, BLOCK_K2 / ratio_n)]
-            vector_shapes = {B: 0, M: Mvec, K2: Nvec}
-        else:
-            constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-            constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
-            constraints += [tkw.WaveConstraint(N, BLOCK_N / ratio_n)]
-            vector_shapes = {B: 0, M: Mvec, N: Nvec}
-        constraints += [
-            tkw.HardwareConstraint(
-                threads_per_wave=64,
-                waves_per_block=(ratio_m, ratio_n, 1),
-                mma_type=mfma_variant,
-                vector_shapes=vector_shapes,
-            )
-        ]
-        if dynamic_dims:
-            constraints += [tkw.Assumption(K2 > BLOCK_K2 * 4)]
-        return constraints
-
-    i = tkw.IndexMapping.iterator(0)
-    j = tkw.IndexMapping.iterator(1)
-    k = tkw.IndexMapping.iterator(2)
-    mapping = tkw.IndexMapping(
-        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    phase_0, phase_1, hyperparams_0, hyperparams_1 = get_decode_attention_kernels(
+        shape, mfma_variant
     )
-
-    # The first kernel computes K @ Q.T.
-    @tkw.wave(get_constraints(Phase.QK))
-    def qk_kernel(
-        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
-        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
-        c: tkl.Memory[B, M, K2, GLOBAL_ADDRESS_SPACE, tkl.f32],
-    ):
-        c_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
-        q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-        k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-        acc = tkw.mma(k_reg, q_reg, c_reg)
-        x_j = tkw.permute(acc, target_shape=[B, M, K2])
-        tkw.write(x_j, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
-
-    # The second kernel computes the softmax and V @ softmax(K @ Q.T).
-    @tkw.wave(get_constraints(Phase.SOFTMAX_V))
-    def softmax_v_kernel(
-        qk: tkl.Memory[B, M, K2, ADDRESS_SPACE, tkl.f32],
-        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
-        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
-    ):
-        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
-        init_sum = tkl.Register[B, M, tkl.f32](0.0)
-        init_max = tkl.Register[B, M, tkl.f32](-1e6)
-
-        # This microkernel encodes the fact that if the reduction
-        # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
-        def repeat(
-            partial_max: tkl.Register[B, M, tkl.f32],
-            partial_sum: tkl.Register[B, M, tkl.f32],
-            acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, N, M, tkl.f32],
-        ):
-            x_j = tkw.read(qk, elements_per_thread=STORE_ELEMS_PER_THREAD)
-            m_j = tkw.max(x_j, partial_max, dim=K2)
-            e_delta_max = tkw.exp2(partial_max - m_j)
-            e_delta = tkw.exp2(x_j - m_j)
-            e_init = partial_sum * e_delta_max
-            d_j = tkw.sum(e_delta, e_init, dim=K2)
-            imm_f16 = tkw.cast(e_delta, tkl.f16)
-            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-            new_acc = acc * e_delta_max
-            acc = tkw.mma(v_reg, imm_f16, new_acc)
-            return m_j, d_j, acc
-
-        # repeat represents the results of the loop
-        res_max, res_sum, res_mm = repeat
-        res = res_mm / res_sum
-        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
-
-    hyperparams = {
-        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
-        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
-        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
-        BLOCK_B: 1,
-        BLOCK_M: 64,
-        BLOCK_N: 64,
-        BLOCK_K2: 64,
-        B: shape[0],
-        M: shape[1],
-        N: shape[2],
-        K1: shape[3],
-        K2: shape[4],
-    }
-    hyperparams.update(get_default_scheduling_params())
+    hyperparams_0.update(get_default_scheduling_params())
+    hyperparams_1.update(get_default_scheduling_params())
     config = get_default_run_config()
     if run_bench:
         config["benchmark_batch_size"] = 10
@@ -1070,68 +948,57 @@ def testFlashDecoding(
             dump_perf, "tk_" + perf_filename
         )
 
-    dynamic_symbols = []
-    dynamic_symbols_map = {}
-    if dynamic_dims:
-        dynamic_symbols_map[M] = hyperparams[M]
-        dynamic_symbols_map[N] = hyperparams[N]
-        dynamic_symbols_map[B] = hyperparams[B]
-        dynamic_symbols_map[K2] = hyperparams[K2]
-        dynamic_symbols.append(M)
-        dynamic_symbols.append(N)
-        dynamic_symbols.append(B)
-        dynamic_symbols.append(K2)
-        del hyperparams[M]
-        del hyperparams[N]
-        del hyperparams[B]
-        del hyperparams[K2]
-
     torch.manual_seed(0)
-    q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
-    k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
-    qk = device_zeros(shape[0], shape[1], shape[4], dtype=torch.float32)
-    v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)
-    output = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+    B, M, N, K1, K2 = shape
+    U = hyperparams_0[index_symbol("U")]
+    q = device_randn(B, M, K1, dtype=torch.float16)
+    k = device_randn(B, K2, K1, dtype=torch.float16)
+    v = device_randn(B, K2, N, dtype=torch.float16)
+    phase_0_output = device_zeros(U, B, N, M, dtype=torch.float32)
+    phase_0_output_max = device_zeros(U, B, M, dtype=torch.float32)
+    output = device_zeros(B, M, N, dtype=torch.float32)
     log2e = 1.44269504089
-    dk_sqrt = math.sqrt(1.0 / shape[3])
+    dk_sqrt = math.sqrt(1.0 / K1)
 
     with tk.gen.TestLaunchContext(
-        hyperparams,
+        hyperparams_0,
         canonicalize=True,
         run=True,
         run_bench=run_bench,
         run_config=config,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
-        dynamic_symbols=dynamic_symbols,
-        dynamic_symbols_map=dynamic_symbols_map,
     ):
         # TODO: Add scaling of QK as part of kernel.
-        mb_qk = qk_kernel(q * dk_sqrt * log2e, k, qk)
+        mb_qk = phase_0(
+            q * dk_sqrt * log2e,
+            k,
+            v.permute([0, 2, 1]),
+            phase_0_output,
+            phase_0_output_max,
+        )
 
     with tk.gen.TestLaunchContext(
-        hyperparams,
+        hyperparams_1,
         canonicalize=True,
         run=True,
         run_bench=run_bench,
         run_config=config,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
-        dynamic_symbols=dynamic_symbols,
-        dynamic_symbols_map=dynamic_symbols_map,
     ):
         # TODO: Add variant of non-transposed V attention kernel.
-        mb_sv = softmax_v_kernel(qk, v.permute([0, 2, 1]), output)
+        mb_sv = phase_1(phase_0_output, phase_0_output_max, output)
 
     torch_ref = torch.nn.functional.scaled_dot_product_attention(
         q, k, v, attn_mask=None
     )
 
     if test_dump_generated_mlir:
-        filename = f"wave_qk_kernel_{'x'.join(map(str, shape))}.mlir"
+        filename = f"wave_phase_0_kernel_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
             f.write(mb_qk.module_op.get_asm())
-        filename = f"wave_softmax_v_kernel_{'x'.join(map(str, shape))}.mlir"
+        filename = f"wave_phase_1_kernel_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
             f.write(mb_sv.module_op.get_asm())
 


### PR DESCRIPTION
This PR at support for a new variant of flash decoding. In this version we use a split – K approach, where the first kernel compute the attention parallelizing over the sequence length, and the second kernel sums up all the results. In order to make this work, we had to add support for the following
- SymbolicAliases - these are language constructs that allow us to say that one symbol is associated with another symbol with a specific relationship. This is implemented as constructing additional work group constraints telling constraints and wave constraints. They are ignored during expansion.
- Added a template for flash decoding that is used in both the lit test as well as the end to end tests