### PR TITLE
Remove 'torch' from deps and warn instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Discord server).
     pip install torch --index-url https://download.pytorch.org/whl/test/cpu
     ```
 
+    Then install iree-turbine:
+
     ```bash
     # Stable releases
     pip install iree-turbine

--- a/README.md
+++ b/README.md
@@ -32,21 +32,20 @@ Discord server).
 
 1. Install from PyPI:
 
+    Install a torch version that fulfills your needs:
+
+    ```bash
+    # Fast installation of torch with just CPU support.
+    # See other options at https://pytorch.org/get-started/locally/
+    pip install torch --index-url https://download.pytorch.org/whl/test/cpu
+    ```
+
     ```bash
     # Stable releases
     pip install iree-turbine
 
     # Nightly releases
     pip install --find-links https://iree.dev/pip-release-links.html --upgrade --pre iree-turbine
-    ```
-
-    The above does install some CUDA/cuDNN packages which are unnecessary for most
-    usage. To avoid this you can
-    [install just pytorch-cpu](https://pytorch.org/get-started/locally/) via:
-
-    ```bash
-    pip install -r pytorch-cpu-requirements.txt
-    pip install iree-turbine
     ```
 
     (or follow the "Developers" instructions below)
@@ -84,9 +83,8 @@ source .venv/bin/activate
 
 ### Install PyTorch for your system
 
-If no explicit action is taken, the default PyTorch version will be installed.
-On Linux this may give you a current CUDA-based version. Install a different
-variant by doing so explicitly first, either by following the
+You need to explicit install a PyTorch version that fulfills your needs.
+On Linux, install a variant by either following the
 [official instructions](https://pytorch.org/get-started/locally/) or by using
 one of our `requirements.txt` files:
 

--- a/iree/turbine/__init__.py
+++ b/iree/turbine/__init__.py
@@ -8,3 +8,13 @@ learning models to cloud and edge devices.
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import importlib.util
+
+msg = """No module named 'torch'. Follow https://pytorch.org/get-started/locally/#start-locally to install 'torch'.
+For example, on Linux to install with CPU support run:
+  pip3 install torch --index-url https://download.pytorch.org/whl/cpu
+"""
+
+if spec := importlib.util.find_spec("torch") is None:
+    raise ModuleNotFoundError(msg)

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ setup(
         f"numpy{get_version_spec('numpy')}",
         f"iree-base-compiler{get_version_spec('iree-base-compiler')}",
         f"iree-base-runtime{get_version_spec('iree-base-runtime')}",
-        "torch>=2.3.0",
         f"Jinja2{get_version_spec('Jinja2')}",
         f"ml_dtypes{get_version_spec('ml_dtypes')}",
         f"typing_extensions{get_version_spec('typing_extensions')}",


### PR DESCRIPTION
Instead of enforcing the installation for 'torch' as a dependency, error if 'torch' cannot be imported and point the user to how to install.