### PR TITLE
[TKW] Add MinimumOp as an op for Quantized LLM and GenAI workload

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -136,6 +136,10 @@ def maximum(lhs: "Register", rhs: "Register") -> "Register":
     ...
 
 
+def minimum(lhs: "Register", rhs: "Register") -> "Register":
+    ...
+
+
 def broadcast(
     arg: "Register", target_shape: Optional[Sequence[IndexExpr | int]] = None
 ) -> "Register":
@@ -681,6 +685,7 @@ class CustomOp(ABC):
 @define_py_op(operator.mul)
 @define_py_op(operator.truediv)
 @define_interface_op("maximum")
+@define_interface_op("minimum")
 @dataclass
 class BinaryPyOp(CustomOp, ABC):
     """

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -65,6 +65,7 @@ from ..ops.wave_ops import (
     get_result,
     log2,
     maximum,
+    minimum,
     mma,
     permute,
     read,
@@ -1218,6 +1219,24 @@ def handle_maximum(lhs: Value, rhs: Value) -> OpResult:
     else:
         raise ValidationError(
             f"Found unhandled operand type for maximum: {element_type}"
+        )
+    return result
+
+
+@handle_binary_op(minimum)
+def handle_minimum(lhs: Value, rhs: Value) -> OpResult:
+    element_type = get_type_or_element_type(lhs.type)
+    if _is_float_type(element_type):
+        result = arith_d.minimumf(lhs, rhs)
+    elif _is_integer_like_type(element_type) and (
+        element_type.is_signed() or element_type.is_signless()
+    ):
+        result = arith_d.minsi(lhs, rhs)
+    elif _is_integer_like_type(element_type) and element_type.is_unsigned():
+        result = arith_d.minui(lhs, rhs)
+    else:
+        raise ValidationError(
+            f"Found unhandled operand type for minimum: {element_type}"
         )
     return result
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1616,6 +1616,7 @@ def test_binary_lowerings():
         res = a_reg - b_reg
         res = res * a_reg
         res = res / b_reg
+        res = tkw.minimum(a_reg, b_reg)
         tkw.write(res, a, elements_per_thread=4)
 
     a = torch.randn(16, 16, dtype=torch.float16)
@@ -1626,6 +1627,7 @@ def test_binary_lowerings():
         # CHECK: %[[SUB:.+]] = arith.subf
         # CHECK: %[[MUL:.+]] = arith.mulf %[[SUB]]
         # CHECK: %[[DIV:.+]] = arith.divf %[[MUL]]
+        # CHECK: %[[MINIMUM:.+]] = arith.minimumf
 
 
 # TODO: Something is broken in codegen and we are getting int in place of fx.Node


### PR DESCRIPTION
The tkw.minimum(elementwise) is lowered into arith::MinimumFOp, arith::MinisIOp, and arith::MiniuIOp for floats, signed and unsigned integers respectively

Fixes: #339 