### PR TITLE
Switch torch requirements back to stable channel.

### DIFF
--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,4 +1,3 @@
---pre
 --index-url https://download.pytorch.org/whl/test/cpu
 torch>=2.3.0
 torchaudio

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,4 +1,4 @@
---index-url https://download.pytorch.org/whl/test/cpu
+--index-url https://download.pytorch.org/whl/cpu
 torch>=2.3.0
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,4 +1,3 @@
---pre
 --index-url https://download.pytorch.org/whl/rocm6.2
 torch>=2.3.0
 torchaudio


### PR DESCRIPTION
We have some test failures with 2.6.0 prereleases: https://github.com/iree-org/iree-turbine/actions/runs/12399117695?pr=346. Sticking to stable versions until we can triage.