### PR TITLE
[TKW] Fix chained dynamic vals

### DIFF
--- a/iree/turbine/kernel/_support/indexing.py
+++ b/iree/turbine/kernel/_support/indexing.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Optional, Type, TypeVar, Union
+from typing import Any, ClassVar, Optional, Type, TypeVar, Union, Self
 
 from abc import ABC
 from dataclasses import dataclass
@@ -410,24 +410,29 @@ class IndexSequence:
     size: IndexExpr | int
     stride: Optional[IndexExpr | int] = 1
 
+    @staticmethod
     def _subs(
-        self, value: int | IndexExpr, map: dict[IndexExpr, IndexExpr]
+        value: int | IndexExpr, map: dict[IndexExpr, IndexExpr]
     ) -> int | IndexExpr:
         if isinstance(value, (sympy.Basic, IndexSequence)):
             return value.subs(map)
         return value
 
-    def subs(self, map: dict[IndexExpr, IndexExpr]):
+    def subs(self, map: dict[IndexExpr, IndexExpr]) -> Self:
         start = self._subs(self.start, map)
         size = self._subs(self.size, map)
         stride = self._subs(self.stride, map)
         return IndexSequence(start, size, stride)
 
-    def apply_expr(self, symbol: IndexExpr, expr: IndexExpr):
-        start = self._subs(expr, {symbol: self.start})
-        size = self._subs(expr, {symbol: self.size})
-        stride = self._subs(expr, {symbol: self.stride})
+    @staticmethod
+    def from_expr(expr: IndexExpr, subs: dict[IndexExpr, Self]) -> Self:
+        start_subs = {k: v.start for k, v in subs.items()}
+        size_subs = {k: v.size for k, v in subs.items()}
+        stride_subs = {k: v.stride for k, v in subs.items()}
+        start = IndexSequence._subs(expr, start_subs)
+        size = IndexSequence._subs(expr, size_subs)
+        stride = IndexSequence._subs(expr, stride_subs)
         return IndexSequence(start, size, stride)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.start} : {self.size} : {self.stride}"

--- a/iree/turbine/kernel/_support/indexing.py
+++ b/iree/turbine/kernel/_support/indexing.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Optional, Type, TypeVar, Union, Self
+from typing import Any, ClassVar, Optional, Type, TypeVar, Union
 
 from abc import ABC
 from dataclasses import dataclass
@@ -418,14 +418,14 @@ class IndexSequence:
             return value.subs(map)
         return value
 
-    def subs(self, map: dict[IndexExpr, IndexExpr]) -> Self:
+    def subs(self, map: dict[IndexExpr, IndexExpr]):
         start = self._subs(self.start, map)
         size = self._subs(self.size, map)
         stride = self._subs(self.stride, map)
         return IndexSequence(start, size, stride)
 
     @staticmethod
-    def from_expr(expr: IndexExpr, subs: dict[IndexExpr, Self]) -> Self:
+    def from_expr(expr: IndexExpr, subs: dict[IndexExpr, Any]):
         start_subs = {k: v.start for k, v in subs.items()}
         size_subs = {k: v.size for k, v in subs.items()}
         stride_subs = {k: v.stride for k, v in subs.items()}

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1013,7 +1013,10 @@ class Read(CustomOp):
             iters = self.mapping.iters
             mapping = self.mapping.dynamic_val_mappings[i]
             subs = {v: k for k, v in zip(iters, mapping.keys())}
-            return {k: v.apply_expr(subs[k], mapping[k]) for k, v in index.items()}
+            return {
+                k: v.apply_expr(subs[k2], mapping[k2])
+                for k, (k2, v) in zip(arg.type.symbolic_shape, index.items())
+            }
 
         return index
 
@@ -1021,8 +1024,11 @@ class Read(CustomOp):
         self,
     ) -> list[tuple[dict[IndexSymbol, IndexSequence], fx.Node]]:
         def transform_idx(arg):
-            new_index = self.transform_index_backwards(self.index, arg)
-            return {k: v for k, v in zip(arg.type.symbolic_shape, new_index.values())}
+            return {
+                k: v
+                for k, v in self.transform_index_backwards(self.index, arg).items()
+                if v.start != 0
+            }
 
         return [(arg, transform_idx(arg)) for arg in self.mapping_dynamic_vals]
 
@@ -1253,7 +1259,10 @@ class Write(CustomOp):
             iters = self.mapping.iters
             mapping = self.mapping.dynamic_val_mappings[i]
             subs = {v: k for k, v in zip(iters, mapping.keys())}
-            return {k: v.apply_expr(subs[k], mapping[k]) for k, v in index.items()}
+            return {
+                k: v.apply_expr(subs[k2], mapping[k2])
+                for k, (k2, v) in zip(arg.type.symbolic_shape, index.items())
+            }
 
         return index
 
@@ -1261,8 +1270,11 @@ class Write(CustomOp):
         self,
     ) -> list[tuple[dict[IndexSymbol, IndexSequence], fx.Node]]:
         def transform_idx(arg):
-            new_index = self.transform_index_backwards(self.index, arg)
-            return {k: v for k, v in zip(arg.type.symbolic_shape, new_index.values())}
+            return {
+                k: v
+                for k, v in self.transform_index_backwards(self.index, arg).items()
+                if v.start != 0
+            }
 
         return [(arg, transform_idx(arg)) for arg in self.mapping_dynamic_vals]
 

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1014,8 +1014,8 @@ class Read(CustomOp):
             mapping = self.mapping.dynamic_val_mappings[i]
             subs = {v: k for k, v in zip(iters, mapping.keys())}
             return {
-                k: v.apply_expr(subs[k2], mapping[k2])
-                for k, (k2, v) in zip(arg.type.symbolic_shape, index.items())
+                k: v.apply_expr(subs[k], mapping[k])
+                for k, v in zip(arg.type.symbolic_shape, index.values())
             }
 
         return index
@@ -1260,8 +1260,8 @@ class Write(CustomOp):
             mapping = self.mapping.dynamic_val_mappings[i]
             subs = {v: k for k, v in zip(iters, mapping.keys())}
             return {
-                k: v.apply_expr(subs[k2], mapping[k2])
-                for k, (k2, v) in zip(arg.type.symbolic_shape, index.items())
+                k: v.apply_expr(subs[k], mapping[k])
+                for k, v in zip(arg.type.symbolic_shape, index.values())
             }
 
         return index

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -281,7 +281,9 @@ def combine_derived_index(
 
     new_index = copy(src_index)
     for dim, new_idx in dst_index.items():
-        assert dim in src_index, f"Dim {dim} not in index {src_index}"
+        if dim not in src_index:
+            continue
+
         old_idx = src_index[dim]
         if old_idx == new_idx:
             continue
@@ -306,7 +308,8 @@ def set_derived_index(trace):
         custom = get_custom(current)
         custom.index = combine_derived_index(custom.index, index)
         for inp in get_inputs(current)[0]:
-            worklist.append((inp, index))
+            new_index = custom.transform_index_backwards(custom.index, inp)
+            worklist.append((inp, new_index))
 
 
 def set_node_indices(trace: CapturedTrace, constraints: list[Constraint]):

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -482,7 +482,7 @@ def test_read_write_dynamic_mapping_broadcast():
         num_iterators=2,
         inputs={M: i, N: k + j % 16},
         outputs={M: i, N: j},
-        dynamic_val_mappings={M: i, N: j // 16},
+        dynamic_val_mappings={M: i, ONE: j // 16},
     )
 
     @tkw.wave(constraints)
@@ -537,13 +537,13 @@ def test_read_write_dynamic_mapping_chain():
         num_iterators=2,
         inputs={M: i, SIZE2: k},
         outputs={M: i, SIZE2: j},
-        dynamic_val_mappings={M: i, SIZE2: j // 2},
+        dynamic_val_mappings={M: i, SIZE1: j // 2},
     )
     mapping2 = tkw.IndexMapping(
         num_iterators=2,
         inputs={M: i, N: k + j % 4},
         outputs={M: i, N: j},
-        dynamic_val_mappings={M: i, N: j // 4},
+        dynamic_val_mappings={M: i, SIZE2: j // 4},
     )
 
     @tkw.wave(constraints)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -475,7 +475,7 @@ def test_offset_read_one(shape, request):
         num_iterators=2,
         inputs={M: k, N: j},
         outputs={M: i, N: j},
-        dynamic_val_mappings={M: i, N: j // ELEMS_PER_THREAD},
+        dynamic_val_mappings={M: i, N1: j // ELEMS_PER_THREAD},
     )
 
     @tkw.wave(constraints)
@@ -640,7 +640,7 @@ def test_offset_write_one(shape, request):
         num_iterators=2,
         inputs={M: i, N: j},
         outputs={M: i, N: k + j % ELEMS_PER_THREAD},
-        dynamic_val_mappings={M: i, N: j // ELEMS_PER_THREAD},
+        dynamic_val_mappings={M: i, N1: j // ELEMS_PER_THREAD},
     )
 
     @tkw.wave(constraints)


### PR DESCRIPTION
* Properly propagate index through chained read.write ops using `transform_index_backwards`
* Use proper symbols for dynamic vals
* Do not propagate 0 index