### PR TITLE
Bump tested IREE version to most recent nightly.

### DIFF
--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -10,5 +10,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.1.0rc20241212
-iree-base-runtime==3.1.0rc20241212
+iree-base-compiler==3.1.0rc20241220
+iree-base-runtime==3.1.0rc20241220


### PR DESCRIPTION
We're approaching our 3.1.0 release across all IREE packages (https://github.com/iree-org/iree/issues/19192), so testing closer to HEAD.

Commit range: https://github.com/iree-org/iree/compare/iree-3.1.0rc20241212...iree-3.1.0rc20241220