### PR TITLE
[TKW] Add `arange` op

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -872,7 +872,7 @@ class Arange(CustomOp):
     """
     Return evenly spaced values
 
-    TODO: Do we need separate begin/end/step
+    TODO: Do we need separate begin/end/step?
     """
 
     size: IndexExpr

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -84,6 +84,10 @@ def register(shape: tuple[IndexExpr, ...], dtype: DataType, value: float) -> "Re
     ...
 
 
+def arange(size: IndexExpr, dtype: DataType) -> "Register":
+    ...
+
+
 def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register":
     ...
 
@@ -860,6 +864,26 @@ class SchedulingGroupBarrier(CustomOp):
 
     instructions: dict[Operation, int]
     sync_id: int
+
+
+@define_op("arange")
+@dataclass
+class Arange(CustomOp):
+    """
+    Return evenly spaced values
+
+    TODO: Do we need separate begin/end/step
+    """
+
+    size: IndexExpr
+    dtype: DataType
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        return [self.size]
+
+    def infer_type(self):
+        self.type = Register[(self.size, self.dtype)]
 
 
 @define_op("register")

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -536,7 +536,7 @@ def handle_arange(emitter: WaveEmitter, node: fx.Node):
         value = arith_d.index_cast(int_vector_type, value)
         value = arith_d.sitofp(vector_type, value)
     else:
-        assert False, f"Unsupported dtype: f{element_type}"
+        assert False, f"Unsupported dtype: {element_type}"
 
     emitter.bind_node_proxy(node, IRProxyValue(value))
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -493,7 +493,7 @@ def _inplace_invoke(vm_context, device, entry_function, inputs, outputs, dynamic
         else:
             raise ValueError(f"Unsupported input type: {type(input)}")
     for output in outputs:
-        if isinstance(input, torch.Tensor):
+        if isinstance(output, torch.Tensor):
             push_tensor_to_arg_list(output)
         else:
             raise ValueError(f"Unsupported output type: {type(output)}")

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -263,7 +263,7 @@ def test_arange_indirect(shape, request):
         num_iterators=2,
         inputs={M: i, N: k},
         outputs={M: i, N: j},
-        dynamic_val_mappings={M: i, N: j},
+        dynamic_val_mappings={N: j},
     )
 
     constraints: list[tkw.Constraint] = [

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -234,7 +234,7 @@ def test_arange(shape, request):
         run_config=config,
     ):
         test(b)
-        a = torch.arange(shape[1]).to(b.dtype)
+        a = to_default_device(torch.arange(shape[1]).to(b.dtype))
         assert_close(a, b)
 
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -240,6 +240,79 @@ def test_arange(shape, request):
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_copy"))
+def test_arange_indirect(shape, request):
+    run_bench = request.config.getoption("--runperf")
+    M = tkl.sym.M
+    N = tkl.sym.N
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Each workgroup works on single row of input data, and rows are further
+    # split into blocks of size up to 256. We have single wave per WG,
+    # and with default wave size of 64, each thread is operating on up to 4
+    # elements.
+    wave_size = 64
+    BLOCK_M = 1
+    # Tile size cannot be dynamic, so we use a fixed value here.
+    BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
+    ELEMS_PER_THREAD = BLOCK_N / wave_size
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.dynamic_val(0)
+    mapping = tkw.IndexMapping(
+        num_iterators=2,
+        inputs={M: i, N: k},
+        outputs={M: i, N: j},
+        dynamic_val_mappings={M: i, N: j},
+    )
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: BLOCK_M, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        offset = tkw.arange(N, dtype=tkl.i32)
+        res = tkw.read(
+            a,
+            mapping=mapping,
+            mapping_dynamic_vals=(offset,),
+            elements_per_thread=ELEMS_PER_THREAD,
+        )
+        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+
+    config = get_default_run_config()
+
+    a = device_randn(shape, dtype=torch.float16)
+    b = device_zeros(shape, dtype=torch.float16)
+    with tk.gen.TestLaunchContext(
+        {
+            M: shape[0],
+            N: shape[1],
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+    ):
+        test(a, b)
+        assert_close(a, b)
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_copy"))
 def test_dynamic_copy(shape, request):
     run_bench = request.config.getoption("--runperf")
     M = tkl.sym.M


### PR DESCRIPTION
`arange` allows to create evenly spaced constant across a symbolic dimension.