### PR TITLE
[TKW] Add layout to maximize shared reads

### DIFF
--- a/iree/turbine/kernel/wave/decompose_vmma_ops.py
+++ b/iree/turbine/kernel/wave/decompose_vmma_ops.py
@@ -1,0 +1,166 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ..wave.constraints import (
+    Constraint,
+    HardwareConstraint,
+    MMAType,
+    MMAOperand,
+)
+from iree.turbine.kernel.wave.utils import get_mfma_load_elems_per_thread
+from .._support.tracing import CapturedTrace
+from .._support.indexing import IndexSequence, IndexSymbol, IndexExpr
+from ..ops.wave_ops import (
+    get_custom,
+    MMA,
+    Reshape,
+)
+from ..lang.global_symbols import *
+
+import copy
+import sympy
+
+
+VMMA_TO_NATIVE_MAP = {
+    MMAType.F32_16x16x32_K8_F16: MMAType.F32_16x16x16_F16,
+    MMAType.F32_32x32x16_K8_F16: MMAType.F32_32x32x8_F16,
+}
+
+
+def get_m_dim(mma_op):
+    m_dims = set(mma_op.lhs_type.symbolic_shape).difference(
+        mma_op.rhs_type.symbolic_shape
+    )
+    assert len(m_dims) == 1, "Expect to have single M-dim."
+    return m_dims.pop()
+
+
+def get_n_dim(mma_op):
+    n_dims = set(mma_op.rhs_type.symbolic_shape).difference(
+        mma_op.lhs_type.symbolic_shape
+    )
+    assert len(n_dims) == 1, "Expect to have single N-dim."
+    return n_dims.pop()
+
+
+def get_k_dim(mma_op):
+    k_dims = set(mma_op.lhs_type.symbolic_shape).intersection(
+        mma_op.rhs_type.symbolic_shape
+    )
+    k_dims = k_dims.difference(mma_op.acc_type.symbolic_shape)
+    assert len(k_dims) == 1, "Expect to have single K-dim."
+    return k_dims.pop()
+
+
+def replace_subexpr(
+    main_expr: sympy.Expr, src_subexpr: sympy.Expr, dst_subexpr: sympy.Expr
+):
+    assert (
+        len(main_expr.find(src_subexpr)) > 0
+    ), "Expected src subexpression to be found in main expression."
+    # Early exit if src and dst is already the same.
+    if src_subexpr == dst_subexpr:
+        return
+    main_expr = main_expr.subs(src_subexpr, dst_subexpr)
+
+
+def decompose_vmma_ops(
+    trace: CapturedTrace,
+    constraints: list[Constraint],
+):
+    """
+    The decomposition for VMMA is done in five steps:
+      1. Collect all MMA ops and only process the ones with virtual intrinsics.
+      2. For each VirtualMMAOp, we generate check it's unroll factor
+      3. Generate slices of lhs and rhs from coaleseced reads based on native and virtual MMA sizes
+      4. Generate native MMA ops based on unroll factor that takes in slices of coaleseced lhs and rhs
+      5. Modify index expression of new mma op by replacing the expression based on virtual layout
+         with it's equivalent native layout expression.
+    """
+    # Get MMA nodes.
+    mma_nodes = trace.walk(lambda node: isinstance(get_custom(node), MMA))
+    if not mma_nodes:
+        return
+    hardware_constraint = next(
+        c for c in constraints if isinstance(c, HardwareConstraint)
+    )
+    for node in mma_nodes:
+        mma_op = get_custom(node)
+        mma_type = mma_op.mma_type
+        if mma_type == None:
+            mma_type = hardware_constraint.mma_type
+        # Only process VirtualMMAOps.
+        if mma_type not in VMMA_TO_NATIVE_MAP:
+            continue
+        native_mma_type = VMMA_TO_NATIVE_MAP[mma_type]
+        virtual_vector_shapes = mma_op.vector_shapes
+        native_vector_shapes = {
+            k: v
+            for k, v in zip(
+                virtual_vector_shapes,
+                hardware_constraint.mma_matrix_shapes(native_mma_type),
+            )
+        }
+
+        innermost_lhs_dim = mma_op.lhs.type.symbolic_shape[-1]
+        innermost_rhs_dim = mma_op.rhs.type.symbolic_shape[-1]
+        assert (
+            innermost_lhs_dim == innermost_rhs_dim
+        ), "Only support lhs and rhs have same innermost dim."
+        innermost_dim = innermost_lhs_dim
+
+        unrollKFactor = (
+            virtual_vector_shapes[innermost_dim] // native_vector_shapes[innermost_dim]
+        )
+        assert unrollKFactor > 1, "Expected Unroll K factor to be > 1"
+
+        mma_acc = mma_op.acc
+        for i in range(unrollKFactor):
+            # Emitting ReshapeOp for slicing
+            with mma_op.graph.inserting_before(mma_op.fx_node):
+                slice_lhs = Reshape([mma_op.lhs], virtual_vector_shapes).add_to_graph(
+                    mma_op.graph
+                )
+                slice_rhs = Reshape([mma_op.rhs], virtual_vector_shapes).add_to_graph(
+                    mma_op.graph
+                )
+
+            # Setting vector_shapes for num_paritions
+            slice_lhs.vector_shapes = native_vector_shapes
+            slice_rhs.vector_shapes = native_vector_shapes
+
+            # Setting offset
+            slice_lhs.expanded_dims = {innermost_dim: i}
+            slice_rhs.expanded_dims = {innermost_dim: i}
+
+            # Generate new MMA
+            vmma_expr = hardware_constraint.mma_index_offset(mma_type)
+            mma_expr = hardware_constraint.mma_index_offset(native_mma_type)
+            with mma_op.graph.inserting_before(mma_op.fx_node):
+                mma_acc = MMA(
+                    slice_lhs, slice_rhs, mma_acc, native_mma_type
+                ).add_to_graph(mma_op.graph)
+                mma_acc.index = copy.deepcopy(mma_op.index)
+                m_dim = get_m_dim(mma_op)
+                n_dim = get_n_dim(mma_op)
+                k_dim = get_k_dim(mma_op)
+                # Replace expression based on virtual with it's equivalence in the native layout.
+                replace_subexpr(
+                    mma_acc.index[m_dim].start,
+                    vmma_expr[MMAOperand.M.value],
+                    mma_expr[MMAOperand.M.value],
+                )
+                replace_subexpr(
+                    mma_acc.index[n_dim].start,
+                    vmma_expr[MMAOperand.N.value],
+                    mma_expr[MMAOperand.N.value],
+                )
+                replace_subexpr(
+                    mma_acc.index[k_dim].start,
+                    vmma_expr[MMAOperand.K.value],
+                    mma_expr[MMAOperand.K.value],
+                )
+        mma_op.replace_all_uses_with(mma_acc)

--- a/iree/turbine/kernel/wave/decompose_vmma_ops.py
+++ b/iree/turbine/kernel/wave/decompose_vmma_ops.py
@@ -89,9 +89,7 @@ def decompose_vmma_ops(
     )
     for node in mma_nodes:
         mma_op = get_custom(node)
-        mma_type = mma_op.mma_type
-        if mma_type == None:
-            mma_type = hardware_constraint.mma_type
+        mma_type = mma_op.mma_type or hardware_constraint.mma_type
         # Only process VirtualMMAOps.
         if mma_type not in VMMA_TO_NATIVE_MAP:
             continue
@@ -105,12 +103,7 @@ def decompose_vmma_ops(
             )
         }
 
-        innermost_lhs_dim = mma_op.lhs.type.symbolic_shape[-1]
-        innermost_rhs_dim = mma_op.rhs.type.symbolic_shape[-1]
-        assert (
-            innermost_lhs_dim == innermost_rhs_dim
-        ), "Only support lhs and rhs have same innermost dim."
-        innermost_dim = innermost_lhs_dim
+        innermost_dim = mma_op.reduction_dim
 
         unrollKFactor = (
             virtual_vector_shapes[innermost_dim] // native_vector_shapes[innermost_dim]
@@ -128,7 +121,7 @@ def decompose_vmma_ops(
                     mma_op.graph
                 )
 
-            # Setting vector_shapes for num_paritions
+            # Setting vector_shapes for num_partitions
             slice_lhs.vector_shapes = native_vector_shapes
             slice_rhs.vector_shapes = native_vector_shapes
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1022,12 +1022,14 @@ def get_mfma_load_elems_per_thread(mfma_variant: MMAType) -> int:
             return 4
         case (
             MMAType.F32_16x16x32_F8
+            | MMAType.F32_16x16x32_K8_F16
             | MMAType.F32_16x16x32_K4_F8
             | MMAType.I32_16x16x32_I8
         ):
             return 8
         case (
             MMAType.F32_32x32x16_F8
+            | MMAType.F32_32x32x16_K8_F16
             | MMAType.F32_32x32x16_K4_F8
             | MMAType.I32_32x32x16_I8
         ):
@@ -1042,12 +1044,14 @@ def get_mfma_store_elems_per_thread(mfma_variant: MMAType) -> int:
             return 16
         case (
             MMAType.F32_16x16x32_F8
+            | MMAType.F32_16x16x32_K8_F16
             | MMAType.F32_16x16x32_K4_F8
             | MMAType.I32_16x16x32_I8
         ):
             return 4
         case (
             MMAType.F32_32x32x16_F8
+            | MMAType.F32_32x32x16_K8_F16
             | MMAType.F32_32x32x16_K4_F8
             | MMAType.I32_32x32x16_I8
         ):

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -39,6 +39,7 @@ from .utils import (
 )
 from .minimize_global_loads import minimize_global_loads
 from .decompose_reduce_ops import decompose_reduce_ops
+from .decompose_vmma_ops import decompose_vmma_ops
 from .barriers import add_shared_memory_barriers
 from ..lang import Grid, IndexMapping
 from ..lang.global_symbols import *
@@ -348,6 +349,7 @@ class LaunchableWave(Launchable):
         remove_chained_getresult(graph)
 
         # Optimizations.
+        decompose_vmma_ops(graph, self.constraints)
         hoist_loop_invariant_ops(graph, self.constraints)
         minimize_global_loads(graph, self.constraints)
 

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -218,6 +218,153 @@ def testGemm(
 
 
 @require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
+@pytest.mark.parametrize("enable_scheduling", [False, True])
+@pytest.mark.parametrize("dynamic_dims", [False, True])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_32x32x16_K8_F16,
+        MMAType.F32_16x16x32_K8_F16,
+    ],
+)
+def testVMFMAGemm(
+    shape: tuple[int],
+    enable_scheduling: bool,
+    dynamic_dims: bool,
+    mfma_variant: MMAType,
+    request,
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(2, 2, 1), mma_type=mfma_variant
+        )
+    ]
+
+    # With dynamic dimensions, we need to add an assumption on how big
+    # the reduction dimension is to determine whether we can schedule or not.
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K > BLOCK_K * 4)]
+
+    # Wave-level micro-kernel.
+    # Since warps are not directly addressable, there is no
+    # explicit notion of a warp id (like a workgroup or thread id).
+    # This kernel uses the input sizes M, N, K throughout, as the tiling
+    # and data movement strategy is determined during the compilation process.
+    # These can be influenced by introducing constraints.
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            # a_reg: tkw.Register[M, K, tkl.f16]
+            a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # b_reg: tkw.Register[N, K, tkl.f16]
+            b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+            # acc: tkw.Register[M, N, tkl.f32]
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K: 32,
+        M: shape[0],
+        N: shape[1],
+        K: shape[2],
+    }
+    hyperparams.update(get_default_scheduling_params())
+    config = get_default_run_config()
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+    if dynamic_dims:
+        dynamic_symbols_map[M] = hyperparams[M]
+        dynamic_symbols_map[N] = hyperparams[N]
+        dynamic_symbols_map[K] = hyperparams[K]
+        dynamic_symbols.append(M)
+        dynamic_symbols.append(N)
+        dynamic_symbols.append(K)
+        del hyperparams[M]
+        del hyperparams[N]
+        del hyperparams[K]
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+    ):
+        a = device_randn(shape[0], shape[2], dtype=torch.float16)
+        b = device_randn(shape[1], shape[2], dtype=torch.float16)
+        c = device_zeros(shape[0], shape[1], dtype=torch.float32)
+        mb = gemm(a, b, c)
+
+        if test_dump_generated_mlir:
+            filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
+            with open(filename, "w") as f:
+                f.write(mb.module_op.get_asm())
+
+        if run_bench:
+            if dump_perf is not None:
+                config["benchmark_results_file"] = os.path.join(
+                    dump_perf, "iree_" + perf_filename
+                )
+        iree_ref = torch.zeros(shape[0], shape[1], dtype=torch.float32)
+        generate_iree_ref("mmt", [a, b], [iree_ref], config, run_bench=run_bench)
+        assert_close(c, iree_ref, atol=2e-4, rtol=3e-4, check_device=False)
+
+
+@require_e2e
 @require_cdna2
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize("enable_scheduling", [False, True])


### PR DESCRIPTION
To improve performance on attention, we add virtual MMA layout to maximize read/loads from shared memory to register. We also add decomposition for these virtual MMA layout that converts virtual MMA + coalesced reads -> unrolled MMA + unrolled broken apart reads.  The decomposition for VMMA is done in three steps:

      1. Collect all MMA ops and only process the ones with virtual intrinsics.
      2. For each VirtualMMAOp, we generate check it's unroll factor
      3. Generate slices of lhs and rhs from coaleseced reads based on native and virtual MMA sizes
      4. Generate native MMA ops based on unroll factor that takes in slices of coaleseced lhs and rhs
      5. Modify index expression of new mma op by replacing the expression based on virtual layout
         with it's equivalent native layout expression.


 