### PR TITLE
Bump tested IREE version to most recent nightly.

### DIFF
--- a/.github/workflows/test_build_release.yml
+++ b/.github/workflows/test_build_release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Release Wheels
         run: |
           ./build_tools/compute_local_version.py -dev --write-json
-          ./build_tools/build_release.py --no-download
+          ./build_tools/build_release.py
 
       - name: Validate Release Build
         if: ${{ !cancelled() }}

--- a/.github/workflows/test_build_release.yml
+++ b/.github/workflows/test_build_release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Release Wheels
         run: |
           ./build_tools/compute_local_version.py -dev --write-json
-          ./build_tools/build_release.py
+          ./build_tools/build_release.py --no-download
 
       - name: Validate Release Build
         if: ${{ !cancelled() }}

--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -10,5 +10,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.1.0rc20241220
-iree-base-runtime==3.1.0rc20241220
+iree-base-compiler==3.1.0rc20250103
+iree-base-runtime==3.1.0rc20250103

--- a/iree/turbine/runtime/op_reg/impl_helper.py
+++ b/iree/turbine/runtime/op_reg/impl_helper.py
@@ -169,7 +169,7 @@ class JinjaTemplateLoader(TemplateLoader):
 def call_function(target_function: Operation, *operands: Value) -> Sequence[Value]:
     """Emits a util.call for a util.func target function operation."""
     target_symbol = FlatSymbolRefAttr.get(
-        StringAttr(target_function.attributes["sym_name"]).value_bytes
+        StringAttr(target_function.attributes["sym_name"]).value
     )
     ftype = FunctionType(TypeAttr(target_function.attributes["function_type"]).value)
     return Operation.create(


### PR DESCRIPTION
Similar to https://github.com/iree-org/iree-turbine/pull/354, we're approaching our 3.1.0 release across all IREE packages (https://github.com/iree-org/iree/issues/19192), so testing closer to HEAD.

Changes needed:

* Update `FlatSymbolRefAttr` usage, similar to https://github.com/nod-ai/shark-ai/pull/732
* Allow the "Test Build Release" workflow to skip failed experimental release downloads while IREE's macOS compiler release builds are broken (https://github.com/iree-org/iree/issues/19591)

Commit range: https://github.com/iree-org/iree/compare/iree-3.1.0rc20241220...iree-3.1.0rc20250103