### PR TITLE
Bump tested IREE versions to the latest release candidate.

### DIFF
--- a/iree-requirements-ci.txt
+++ b/iree-requirements-ci.txt
@@ -10,5 +10,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.1.0rc20250103
-iree-base-runtime==3.1.0rc20250103
+iree-base-compiler==3.1.0rc20250107
+iree-base-runtime==3.1.0rc20250107


### PR DESCRIPTION
We have a release candidate for https://github.com/iree-org/iree/issues/19192. Switching to test it.

Commit range: https://github.com/iree-org/iree/compare/iree-3.1.0rc20250103...iree-3.1.0rc20250107