### PR TITLE
Cleanup requirements and packaging files.

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -55,7 +55,7 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-cache-dir -r iree-requirements-ci.txt --upgrade
+          pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
 
       - name: Run unit tests

--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -46,7 +46,7 @@ jobs:
         id: cache-pip
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
+          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements*.txt') }}
 
       - name: Install pip deps
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-cache-dir -r iree-requirements-ci.txt
+          pip install --no-cache-dir -r requirements-iree-pinned.txt
           pip install -r requirements.txt -e .
 
       - name: Run unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         id: cache-pip
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
+          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements*.txt') }}
 
       - name: Install pip deps
         run: |

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -57,7 +57,7 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-rocm-requirements.txt
-          pip install --no-cache-dir -r iree-requirements-ci.txt --upgrade
+          pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
 
       - name: Run e2e tests on MI300

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -48,7 +48,7 @@ jobs:
         id: cache-pip
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
+          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements*.txt') }}
 
       - name: Install pip deps
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include README.md
-include requirements.txt
-include pytorch-cpu-requirements.txt
-include version_info.json
-include iree/turbine/ops/templates/*.mlir

--- a/build_tools/build_release.py
+++ b/build_tools/build_release.py
@@ -108,12 +108,9 @@ def _download_iree_binaries_for_platform_args(
             ]
             args.extend(platform_args)
             args += [
-                # Uncomment to allow nightly releases (if not pinned in the file)
-                # "-f",
-                # "https://iree.dev/pip-release-links.html",
                 "-f",
                 WHEEL_DIR,
-                # Note: could also drop `-ci` here, if coordinating a release
+                # Note: could also switch to unpinned if coordinating a release
                 # across projects and new stable versions of the IREE packages
                 # haven't yet been pushed.
                 "-r",

--- a/build_tools/build_release.py
+++ b/build_tools/build_release.py
@@ -117,7 +117,7 @@ def _download_iree_binaries_for_platform_args(
                 # across projects and new stable versions of the IREE packages
                 # haven't yet been pushed.
                 "-r",
-                REPO_ROOT / "iree-requirements-ci.txt",
+                REPO_ROOT / "requirements-iree-pinned.txt",
             ]
             exec(args)
         except:

--- a/iree-requirements.txt
+++ b/iree-requirements.txt
@@ -1,2 +1,0 @@
-iree-base-compiler
-iree-base-runtime

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,3 +1,0 @@
-# Typing packages needed for full mypy execution at the project level.
-mypy==1.8.0
-types-requests

--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -1,9 +1,6 @@
-# Requirements for CI jobs.
-#
-# Developer may want to install from iree-requirements.txt where we are more
-# forgiving on the exact version.
+# Pinned versions of IREE dependencies.
 
-# Uncomment to select a nightly version.
+# Allow downloading prerelease versions from nightly IREE releases.
 --find-links https://iree.dev/pip-release-links.html
 --pre
 

--- a/requirements-iree-unpinned.txt
+++ b/requirements-iree-unpinned.txt
@@ -1,0 +1,11 @@
+# Unpinned versions of IREE dependencies.
+
+# Allow downloading prerelease versions from nightly IREE releases.
+--find-links https://iree.dev/pip-release-links.html
+--pre
+
+# Uncomment to skip versions from PyPI (so _only_ nightly versions).
+# --no-index
+
+iree-base-compiler
+iree-base-runtime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # Build/test requirements.
 Jinja2==3.1.3
 filecheck==1.0.0
+lit==18.1.7
+ml_dtypes==0.5.0
+mypy==1.8.0
 numpy
 parameterized==0.9.0
-pytest==8.0.0
 pytest-xdist==3.5.0
-lit==18.1.7
-mypy==1.8.0
-ml_dtypes==0.5.0
+pytest==8.0.0
 setuptools
 typing_extensions
 wheel


### PR DESCRIPTION
This is preparation for adding automation to handle updating dependency versions.

* Renamed `iree-requirements.txt` and `iree-requirements-ci.txt` to `requirements-iree-[un]pinned.txt` so they sort next to other `requirements-*.txt` files and match the names used downstream in https://github.com/nod-ai/shark-ai.
* Deleted `MANIFEST.in` that was unused since `package_data` in `setup.py` does what those `include` lines used to: https://github.com/iree-org/iree-turbine/blob/e4550f37dcd8b9b691db93c30b478c1d67eee83b/setup.py#L97-L100
* Sorted dependencies in `requirements.txt`.
* Deleted unused `mypy-requirements.txt`.