### PR TITLE
Introduce update_iree_version_pins.py.

### DIFF
--- a/build_tools/update_iree_version_pins.py
+++ b/build_tools/update_iree_version_pins.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Updates the pinned IREE package versions in this repository.
+
+Usage:
+  update_iree_version_pins.py
+"""
+
+from pathlib import Path
+import re
+import subprocess
+import sys
+import textwrap
+
+REPO_ROOT = Path(__file__).parent.parent
+REQUIREMENTS_IREE_PINNED_PATH = REPO_ROOT / "requirements-iree-pinned.txt"
+
+
+def get_latest_package_version(package_name, extra_pip_args=[]):
+    print("\n-------------------------------------------------------------------------")
+    print(f"Finding latest available package version for package '{package_name}'\n")
+
+    # This queries the pip index to get the latest version.
+    #
+    # Note: the `index` subcommand is experimental. Other possible approaches:
+    #   * Install (into a venv) then check what was installed with --report or 'pip freeze'
+    #   * Download then check what was downloaded
+    #   * Scrape the package index and/or release page (https://iree.dev/pip-release-links.html)
+    subprocess_args = [
+        sys.executable,
+        "-m",
+        "pip",
+        "index",
+        "versions",
+        package_name,
+        "--disable-pip-version-check",
+    ]
+    subprocess_args.extend(extra_pip_args)
+    subprocess_cmdline = subprocess.list2cmdline(subprocess_args)
+
+    print(f"Running command:\n  {subprocess_cmdline}\n")
+    result = subprocess.run(subprocess_cmdline, stdout=subprocess.PIPE)
+    output = result.stdout.decode("utf-8")
+    print(f"Command output:\n{textwrap.indent(output, '  ')}")
+
+    # Search for text like `iree-base-compiler (3.2.0rc20250109)` within the
+    # multiple lines of output from the command.
+    # WARNING: The output from `pip index` is UNSTABLE and UNSTRUCTURED, but
+    # this seems to work using Python 3.11.2 and pip 22.3.1.
+    version_search_regex = re.compile(f"{package_name}\s\((.*)\)")
+    matches = version_search_regex.match(output)
+    if not matches:
+        raise RuntimeError("Failed to find a package version using regex")
+    version = matches.groups()[0]
+    print(
+        f"Found package version for '{package_name}' in output using regex: '{version}'"
+    )
+    return version
+
+
+def main():
+    print("Updating IREE version pins!")
+
+    iree_nightly_pip_args = [
+        "--pre",
+        "--find-links",
+        "https://iree.dev/pip-release-links.html",
+    ]
+    iree_base_compiler_version = get_latest_package_version(
+        "iree-base-compiler", iree_nightly_pip_args
+    )
+    iree_base_runtime_version = get_latest_package_version(
+        "iree-base-runtime", iree_nightly_pip_args
+    )
+
+    print("\n-------------------------------------------------------------------------")
+    print(f"Editing version pins in '{REQUIREMENTS_IREE_PINNED_PATH}'")
+    with open(REQUIREMENTS_IREE_PINNED_PATH, "r") as f:
+        text = f.read()
+        print(f"Original text:\n{textwrap.indent(text, '  ')}\n")
+        text = re.sub(
+            "iree-base-compiler==.*",
+            f"iree-base-compiler=={iree_base_compiler_version}",
+            text,
+        )
+        text = re.sub(
+            "iree-base-runtime==.*",
+            f"iree-base-runtime=={iree_base_runtime_version}",
+            text,
+        )
+        print(f"New text:\n{textwrap.indent(text, '  ')}\n")
+    with open(REQUIREMENTS_IREE_PINNED_PATH, "w") as f:
+        f.write(text)
+
+    print("-------------------------------------------------------------------------")
+    print("Edits complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Depends on https://github.com/iree-org/iree-turbine/pull/372 (which renames the requirements file).

This updates the pinned IREE versions in a requirements file. We can run this as part of an automated job that sends dependency update pull requests.

I also looked into using Dependabot but found that it struggles with `--find-links`, `--index-url`, and with there being mulitple `requirements.txt` files in a repository. While I would love to not need to reinvent this wheel, I do like keeping full control over the process.

## Sample output

```
D:\dev\projects\iree-turbine (version-update-script)
λ .\build_tools\update_iree_version_pins.py
Updating IREE version pins!

-------------------------------------------------------------------------
Finding latest available package version for package 'iree-base-compiler'

Running command:
  "C:\Program Files\Python311\python.exe" -m pip index versions iree-base-compiler --disable-pip-version-check --pre --find-links https://iree.dev/pip-release-links.html

WARNING: pip index is currently an experimental command. It may be removed/changed in a future release without prior warning.
Command output:
  iree-base-compiler (3.2.0rc20250109)
  Available versions: 3.2.0rc20250109, 3.1.0, 3.1.0rc20250108, 3.1.0rc20250107, 3.1.0rc20250106, 3.1.0rc20250105, 3.1.0rc20250104, 3.1.0rc20250103, 3.1.0rc20250102, 3.1.0rc20250101, 3.1.0rc20241231, 3.1.0rc20241230, 3.1.0rc20241229, 3.1.0rc20241228, 3.1.0rc20241226, 3.1.0rc20241225, 3.1.0rc20241224, 3.1.0rc20241223, 3.1.0rc20241222, 3.1.0rc20241221, 3.1.0rc20241220, 3.1.0rc20241219, 3.1.0rc20241218, 3.1.0rc20241217, 3.1.0rc20241215, 3.1.0rc20241214, 3.1.0rc20241213, 3.1.0rc20241212, 3.1.0rc20241211, 3.1.0rc20241210, 3.1.0rc20241208, 3.1.0rc20241207, 3.1.0rc20241206, 3.1.0rc20241205, 3.1.0rc20241204, 3.1.0rc20241203, 3.1.0rc20241202, 3.1.0rc20241201, 3.1.0rc20241129, 3.1.0rc20241128, 3.1.0rc20241127, 3.1.0rc20241126, 3.1.0rc20241125, 3.1.0rc20241124, 3.1.0rc20241123, 3.1.0rc20241122, 3.1.0rc20241121, 3.1.0rc20241120, 3.1.0rc20241119, 3.0.0, 3.0.0rc20241118, 3.0.0rc20241117, 3.0.0rc20241116, 3.0.0rc20241115, 3.0.0rc20241114, 3.0.0rc20241113, 3.0.0rc20241112, 2.9.1rc20241111, 2.9.1rc20241110, 2.9.1rc20241109, 2.9.0, 2.9.0rc20241108, 2.9.0rc20241107

Found package version for 'iree-base-compiler' in output using regex: '3.2.0rc20250109'

-------------------------------------------------------------------------
Finding latest available package version for package 'iree-base-runtime'

Running command:
  "C:\Program Files\Python311\python.exe" -m pip index versions iree-base-runtime --disable-pip-version-check --pre --find-links https://iree.dev/pip-release-links.html

WARNING: pip index is currently an experimental command. It may be removed/changed in a future release without prior warning.
Command output:
  iree-base-runtime (3.2.0rc20250109)
  Available versions: 3.2.0rc20250109, 3.1.0, 3.1.0rc20250108, 3.1.0rc20250107, 3.1.0rc20250106, 3.1.0rc20250105, 3.1.0rc20250104, 3.1.0rc20250103, 3.1.0rc20250102, 3.1.0rc20250101, 3.1.0rc20241231, 3.1.0rc20241230, 3.1.0rc20241229, 3.1.0rc20241228, 3.1.0rc20241227, 3.1.0rc20241226, 3.1.0rc20241225, 3.1.0rc20241224, 3.1.0rc20241223, 3.1.0rc20241222, 3.1.0rc20241221, 3.1.0rc20241220, 3.1.0rc20241219, 3.1.0rc20241218, 3.1.0rc20241217, 3.1.0rc20241215, 3.1.0rc20241214, 3.1.0rc20241213, 3.1.0rc20241212, 3.1.0rc20241211, 3.1.0rc20241210, 3.1.0rc20241209, 3.1.0rc20241208, 3.1.0rc20241207, 3.1.0rc20241206, 3.1.0rc20241205, 3.1.0rc20241204, 3.1.0rc20241203, 3.1.0rc20241202, 3.1.0rc20241201, 3.1.0rc20241130, 3.1.0rc20241129, 3.1.0rc20241128, 3.1.0rc20241127, 3.1.0rc20241126, 3.1.0rc20241125, 3.1.0rc20241124, 3.1.0rc20241123, 3.1.0rc20241122, 3.1.0rc20241121, 3.1.0rc20241120, 3.1.0rc20241119, 3.0.0, 3.0.0rc20241118, 3.0.0rc20241117, 3.0.0rc20241116, 3.0.0rc20241115, 3.0.0rc20241114, 3.0.0rc20241113, 3.0.0rc20241112, 2.9.1rc20241111, 2.9.1rc20241110, 2.9.1rc20241109, 2.9.0, 2.9.0rc20241108, 2.9.0rc20241107

Found package version for 'iree-base-runtime' in output using regex: '3.2.0rc20250109'

-------------------------------------------------------------------------
Editing version pins in 'D:\dev\projects\iree-turbine\requirements-iree-pinned.txt'
Original text:
  # Pinned versions of IREE dependencies.

  # Allow downloading prerelease versions from nightly IREE releases.
  --find-links https://iree.dev/pip-release-links.html
  --pre

  # Uncomment to skip versions from PyPI (so _only_ nightly versions).
  # --no-index

  iree-base-compiler==3.1.0rc20250107
  iree-base-runtime==3.1.0rc20250107


New text:
  # Pinned versions of IREE dependencies.

  # Allow downloading prerelease versions from nightly IREE releases.
  --find-links https://iree.dev/pip-release-links.html
  --pre

  # Uncomment to skip versions from PyPI (so _only_ nightly versions).
  # --no-index

  iree-base-compiler==3.2.0rc20250109
  iree-base-runtime==3.2.0rc20250109


-------------------------------------------------------------------------
Edits complete
```