### PR TITLE
[TKW] `set_symbol` and `apply_expr` ops

### DIFF
--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     Tuple,
 )
+from types import FunctionType
 
 from ..compiler.ir import Operation
 
@@ -113,6 +114,8 @@ class KernelTracer(SubgraphTracer):
         if isinstance(a, DataType):
             return a
         if isinstance(a, IndexMapping):
+            return a
+        if isinstance(a, FunctionType):
             return a
         return super().create_arg(a)
 

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -35,13 +35,12 @@ def memref_to_tensor(memrefs: list[IrType]):
 
 
 def get_dynamic_dims(bindings: list[BindingDesc], dynamic_symbols: list[IndexSymbol]):
-    return dynamic_symbols
-    # dynamic_dims: list[IndexSymbol] = []
-    # for b in bindings:
-    #     for dim in b.kernel_buffer_type.symbolic_shape:
-    #         if dim in dynamic_symbols:
-    #             dynamic_dims.append(dim)
-    # return dynamic_dims
+    dynamic_dims: list[IndexSymbol] = []
+    for b in bindings:
+        for dim in b.kernel_buffer_type.symbolic_shape:
+            if dim in dynamic_symbols:
+                dynamic_dims.append(dim)
+    return dynamic_dims
 
 
 def isolated_test_call(

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -35,12 +35,13 @@ def memref_to_tensor(memrefs: list[IrType]):
 
 
 def get_dynamic_dims(bindings: list[BindingDesc], dynamic_symbols: list[IndexSymbol]):
-    dynamic_dims: list[IndexSymbol] = []
-    for b in bindings:
-        for dim in b.kernel_buffer_type.symbolic_shape:
-            if dim in dynamic_symbols:
-                dynamic_dims.append(dim)
-    return dynamic_dims
+    return dynamic_symbols
+    # dynamic_dims: list[IndexSymbol] = []
+    # for b in bindings:
+    #     for dim in b.kernel_buffer_type.symbolic_shape:
+    #         if dim in dynamic_symbols:
+    #             dynamic_dims.append(dim)
+    # return dynamic_dims
 
 
 def isolated_test_call(

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1395,12 +1395,8 @@ class SetSymbol(CustomOp):
         return get_custom(self.register_).type
 
     @property
-    def index(self) -> Optional[dict[IndexSymbol, IndexSequence]]:
-        return get_custom(self.register_).index
-
-    @index.setter
-    def index(self, value: dict[IndexSymbol, IndexSequence]):
-        pass  # noop
+    def indexing_dims(self) -> list[IndexSymbol]:
+        return get_custom(self.register_).indexing_dims
 
 
 @define_py_op(operator.getitem)

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1390,7 +1390,7 @@ class Write(CustomOp):
 
 @define_op("apply_expr")
 @dataclass
-class AppplyExpr(CustomOp):
+class ApplyExpr(CustomOp):
     register_: fx.Proxy
     expr: Callable
 

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -98,7 +98,7 @@ def write(
     ...
 
 
-def apply_expr(value: "Register", expr: IndexExpr) -> "Register":
+def apply_expr(value: "Register", expr: Callable) -> "Register":
     ...
 
 
@@ -1392,7 +1392,7 @@ class Write(CustomOp):
 @dataclass
 class AppplyExpr(CustomOp):
     register_: fx.Proxy
-    expr: IndexExpr
+    expr: Callable
 
     @property
     def type(self) -> "Register":

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -19,7 +19,7 @@ import torch.fx as fx
 
 from ..lang.wave_types import Memory, Register, IndexMapping
 from ..lang.global_symbols import *
-from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence, index_symbol
+from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence
 from .._support.dtype import DataType
 from .._support.regions import RegionGraph
 from .base import OpDispatcher
@@ -96,9 +96,6 @@ def write(
     mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
 ):
     ...
-
-
-APPLY_EXPR_ARG = index_symbol("$APPLY_EXPR_ARG")
 
 
 def apply_expr(value: "Register", expr: IndexExpr) -> "Register":

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -19,7 +19,7 @@ import torch.fx as fx
 
 from ..lang.wave_types import Memory, Register, IndexMapping
 from ..lang.global_symbols import *
-from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence
+from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence, index_symbol
 from .._support.dtype import DataType
 from .._support.regions import RegionGraph
 from .base import OpDispatcher
@@ -95,6 +95,13 @@ def write(
     mapping: Optional[IndexMapping] = None,
     mapping_dynamic_vals: "Register" | tuple["Register", ...] = (),
 ):
+    ...
+
+
+APPLY_EXPR_ARG = index_symbol("$APPLY_EXPR_ARG")
+
+
+def apply_expr(value: "Register", expr: IndexExpr) -> "Register":
     ...
 
 
@@ -1382,6 +1389,21 @@ class Write(CustomOp):
             elements_per_thread=self.elements_per_thread,
             is_read=False,
         )
+
+
+@define_op("apply_expr")
+@dataclass
+class AppplyExpr(CustomOp):
+    register_: fx.Proxy
+    expr: IndexExpr
+
+    @property
+    def type(self) -> "Register":
+        return get_custom(self.register_).type
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        return get_custom(self.register_).indexing_dims
 
 
 @define_op("set_symbol")

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -98,6 +98,10 @@ def write(
     ...
 
 
+def set_symbol(symbol: IndexExpr, value: "Register"):
+    ...
+
+
 def exp2(src: "Register") -> "Register":
     ...
 
@@ -1378,6 +1382,25 @@ class Write(CustomOp):
             elements_per_thread=self.elements_per_thread,
             is_read=False,
         )
+
+
+@define_op("set_symbol")
+@dataclass
+class SetSymbol(CustomOp):
+    symbol: IndexExpr
+    register_: fx.Proxy
+
+    @property
+    def type(self) -> "Register":
+        return get_custom(self.register_).type
+
+    @property
+    def index(self) -> Optional[dict[IndexSymbol, IndexSequence]]:
+        return get_custom(self.register_).index
+
+    @index.setter
+    def index(self, value: dict[IndexSymbol, IndexSequence]):
+        pass  # noop
 
 
 @define_py_op(operator.getitem)

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -15,7 +15,6 @@ import torch.utils._pytree as pytree
 from collections import namedtuple
 
 from .symbolic_constraints import SymbolicAlias
-
 from ..compiler.ir import (
     Attribute,
     DenseElementsAttr,
@@ -49,7 +48,6 @@ from iree.turbine.aot.support.ir_utils import _is_float_type, _is_integer_like_t
 # TK infrastructure imports.
 from iree.turbine.kernel.lang.global_symbols import *
 from ..ops.wave_ops import (
-    APPLY_EXPR_ARG,
     CustomOp,
     abs,
     allocate,
@@ -99,7 +97,7 @@ from .constraints import (
 from .utils import subs_idxc, find_index_bounds, get_hardware_vector_map
 
 # Indexing imports.
-from .._support.indexing import IndexingContext, IndexExpr, IndexSequence
+from .._support.indexing import IndexingContext, IndexExpr, IndexSequence, index_symbol
 from .scheduling.resources import get_scheduling_mask
 
 
@@ -917,6 +915,9 @@ def handle_apply_expr(emitter: WaveEmitter, node: fx.Node):
         register, expr = node.args
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
+
+    APPLY_EXPR_ARG = index_symbol("$APPLY_EXPR_ARG")
+    expr = expr(APPLY_EXPR_ARG)
 
     register = cast_vector(emitter, register, element_type=IndexType.get())
     src_type = register.type

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -917,8 +917,8 @@ def handle_set_symbol(emitter: WaveEmitter, node: fx.Node):
 
     register = cast_vector(emitter, register, element_type=IndexType.get())
     assert (
-        register.type.rank == 1
-    ), f"Only rank 1 vectors are supported: got {register.type}"
+        register.type.rank == 1 and register.type.shape[0] == 1
+    ), f"Only size 1 vectors are supported: got {register.type}"
     register = vector_d.extract(register, static_position=[0], dynamic_position=[])
     emitter.dynamic_dims[symbol] = register
 

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -920,16 +920,10 @@ def handle_apply_expr(emitter: WaveEmitter, node: fx.Node):
     expr = expr(APPLY_EXPR_ARG)
 
     register = cast_vector(emitter, register, element_type=IndexType.get())
-    src_type = register.type
-    assert (
-        src_type.rank == 1 and src_type.shape[0] == 1
-    ), f"Only size 1 vectors are supported: got {register.type}"
-    register = vector_d.extract(register, static_position=[0], dynamic_position=[])
 
     subs = add_emitter_subs(emitter)
     subs[APPLY_EXPR_ARG] = register
     result = gen_sympy_index(subs, expr)
-    result = vector_d.splat(src_type, result)
     emitter.bind_node_proxy(node, IRProxyValue(result))
 
 

--- a/iree/turbine/kernel/wave/expansion/expansion_utils.py
+++ b/iree/turbine/kernel/wave/expansion/expansion_utils.py
@@ -87,7 +87,8 @@ def get_dim_scaling(
                 or (tile_size / wave_count) % vector_size != 0
             ):
                 raise ValueError(
-                    "Tile size must be divisible by wave count and vector size"
+                    f"Tile size must be divisible by wave count and vector size, got: "
+                    f"tile_size={tile_size}, wave_count={wave_count}, vector_size={vector_size}"
                 )
             dim_scaling[constraint.dim] = tile_size // wave_count // vector_size
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -533,7 +533,10 @@ def test_set_symbol(shape, request):
     wave_size = 64
     BLOCK_M = 1
     # Tile size cannot be dynamic, so we use a fixed value here.
-    BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
+
+    # TODO: Only ELEMS_PER_THREAD == 1
+    # BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
+    BLOCK_N = wave_size
     ELEMS_PER_THREAD = BLOCK_N / wave_size
 
     constraints: list[tkw.Constraint] = [
@@ -567,9 +570,9 @@ def test_set_symbol(shape, request):
     def test(
         a: tkl.Memory[S, N, ADDRESS_SPACE, tkl.f16],
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
-        b: tkl.Memory[S, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=1)
+        offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
         tkw.set_symbol(S, offset)
         res = tkw.read(
             a,

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -519,6 +519,90 @@ def test_offset_read_one(shape, request):
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_copy"))
+def test_set_symbol(shape, request):
+    run_bench = request.config.getoption("--runperf")
+    M = tkl.sym.M
+    N = tkl.sym.N
+    S = tkl.sym.S
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Each workgroup works on single row of input data, and rows are further
+    # split into blocks of size up to 256. We have single wave per WG,
+    # and with default wave size of 64, each thread is operating on up to 4
+    # elements.
+    wave_size = 64
+    BLOCK_M = 1
+    # Tile size cannot be dynamic, so we use a fixed value here.
+    BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
+    ELEMS_PER_THREAD = BLOCK_N / wave_size
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: BLOCK_M, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    mapping = tkw.IndexMapping(
+        num_iterators=2,
+        inputs={M: S, N: j},
+        outputs={M: i, N: j},
+        dynamic_val_mappings={M: i, N: j},
+    )
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+
+    dynamic_symbols.append(S)
+    dynamic_symbols_map[S] = 0
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
+        tkw.set_symbol(S, offset)
+        res = tkw.read(
+            a,
+            mapping=mapping,
+            elements_per_thread=ELEMS_PER_THREAD,
+        )
+        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+
+    config = get_default_run_config()
+
+    a = device_randn(shape, dtype=torch.float16)
+    off = device_randint(shape[0], shape, dtype=torch.int32)
+    out = device_zeros(shape, dtype=torch.float16)
+    with tk.gen.TestLaunchContext(
+        {
+            M: shape[0],
+            N: shape[1],
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+    ):
+        test(a, off, out)
+        out_ref = torch.take_along_dim(a, off.to(torch.long), dim=0)
+        assert_close(out, out_ref)
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_copy"))
 def test_offset_write(shape, request):
     run_bench = request.config.getoption("--runperf")
     M = tkl.sym.M

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -537,7 +537,7 @@ def test_set_symbol(shape, request):
     # TODO: Only ELEMS_PER_THREAD == 1
     # BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
     BLOCK_N = wave_size
-    ELEMS_PER_THREAD = BLOCK_N / wave_size
+    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -557,7 +557,6 @@ def test_set_symbol(shape, request):
         num_iterators=2,
         inputs={S: S, N: j},
         outputs={S: i, N: j},
-        dynamic_val_mappings={M: i, N: j},
     )
 
     dynamic_symbols = []

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -645,8 +645,6 @@ def test_apply_expr(shape, request):
         outputs={S: i, N: j},
     )
 
-    A = tkw.APPLY_EXPR_ARG
-
     dynamic_symbols = []
     dynamic_symbols_map = {}
 
@@ -660,7 +658,7 @@ def test_apply_expr(shape, request):
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
         offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
-        offset = tkw.apply_expr(offset, M - A - 1)
+        offset = tkw.apply_expr(offset, lambda a: M - a - 1)
         tkw.set_symbol(S, offset)
         res = tkw.read(
             a,

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -688,7 +688,7 @@ def test_apply_expr(shape, request):
         dynamic_symbols_map=dynamic_symbols_map,
     ):
         test(a, off, out)
-        out_ref = torch.take_along_dim(a, (shape[1] - off - 1).to(torch.long), dim=0)
+        out_ref = torch.take_along_dim(a, (shape[0] - off - 1).to(torch.long), dim=0)
         assert_close(out, out_ref)
 
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -540,7 +540,7 @@ def test_set_symbol(shape, request):
         tkw.HardwareConstraint(
             threads_per_wave=wave_size,
             waves_per_block=(1, 1, 1),
-            vector_shapes={M: BLOCK_M, N: BLOCK_N},
+            vector_shapes={M: BLOCK_M, N: BLOCK_N, S: BLOCK_M},
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
@@ -552,8 +552,8 @@ def test_set_symbol(shape, request):
     j = tkw.IndexMapping.iterator(1)
     mapping = tkw.IndexMapping(
         num_iterators=2,
-        inputs={M: S, N: j},
-        outputs={M: i, N: j},
+        inputs={S: S, N: j},
+        outputs={S: i, N: j},
         dynamic_val_mappings={M: i, N: j},
     )
 
@@ -565,11 +565,11 @@ def test_set_symbol(shape, request):
 
     @tkw.wave(constraints)
     def test(
-        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        a: tkl.Memory[S, N, ADDRESS_SPACE, tkl.f16],
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
-        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[S, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
+        offset = tkw.read(off, elements_per_thread=1)
         tkw.set_symbol(S, offset)
         res = tkw.read(
             a,


### PR DESCRIPTION
* `set_symbol` op to set specific symbol to some dynamic value (i.e. read from memory) during codegen, this is mostly a hack until we have a proper support for slices/reductions with dynamic sizes/tilesizes.
* `apply_expr` op to allow nontrivial index calculations.