### PR TITLE
Expand from write nodes inside reductions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .vs/
 .vscode/
+*.code-workspace
 *.sdf
 *.opensdf
 *.VC.opendb
@@ -37,3 +38,6 @@ version_local.json
 
 # Test artifacts
 .lit_test_times.txt
+
+# Output files
+out

--- a/iree/turbine/kernel/wave/expansion/expansion.py
+++ b/iree/turbine/kernel/wave/expansion/expansion.py
@@ -656,7 +656,7 @@ def expand_graph(
 
     leaf_ops = [get_custom(node) for node in reversed(trace.walk(is_leaf_node))]
     if not leaf_ops:
-        final_op = get_custom(next(reversed(trace.get_root_graph().nodes)))
+        final_op = get_custom(trace.get_root_graph()._root.prev)
         leaf_ops.append(final_op)
         logger.warning(
             f"No leaf operations found in kernel. Using final operation {final_op}"

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -193,6 +193,84 @@ def test_read_write():
 
 
 @tkw.wave_trace_only()
+def write_in_reduction(
+    a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+    b: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+    c: tkl.Memory[M, ADDRESS_SPACE, tkl.f16],
+):
+    # TODO(#364): simplify this by removing the max once it's possible to have a
+    # loop/reduction without reducing over something.
+    init_max = tkl.Register[M, tkl.f16](-1e6)
+
+    @tkw.reduction(K, init_args=[init_max])
+    def repeat(acc: tkl.Register[M, tkl.f16]) -> tkl.Register[M, tkl.f16]:
+        a_reg = tkw.read(a, elements_per_thread=4)
+        tkw.write(a_reg, b, elements_per_thread=4)
+        return tkw.max(a_reg, acc, dim=K)
+
+    tkw.write(repeat, c, elements_per_thread=4)
+
+
+@run_test
+def test_write_in_reduction():
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K, ARGK)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2, THREAD_0 / 64)]
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 1, 1),
+            vector_shapes={M: 16, K: 16},
+        )
+    ]
+    with tk.gen.TestLaunchContext(
+        {
+            BLOCK_M: 32,
+            BLOCK_K: 32,
+        }
+    ):
+        graph = write_in_reduction()
+        IndexingContext.current().finalize()
+        initialize_iter_args(graph)
+        infer_types(graph)
+        set_node_indices(graph, constraints)
+        expand_graph(graph, constraints)
+        set_post_expansion_indices(graph, constraints)
+        print_trace(graph)
+        # Root graph:
+        # CHECK: graph()
+        # CHECK: %reduction :
+        # CHECK-SAME: args = (K,
+        # CHECK: %getresult_M:0_K:0 :
+        # CHECK-SAME: args = (%reduction, 0)
+        # CHECK: %write_M:0_K:0 :
+        # CHECK-SAME: (%getresult_M:0_K:0, %c, 4,
+
+        # Custom format:
+        # CHECK: reduction(axis=K,
+        # CHECK: get_result(value=reduction, res_idx=0)
+        # CHECK: write(register_=getresult_M:0_K:0, memory=c, elements_per_thread=4,
+
+        # Reduction subgraph:
+        # CHECK: graph():
+        # CHECK: %read_M:0_K:0 :
+        # CHECK-SAME: (args = (%a, 4,
+        # CHECK: %read_M:0_K:1 :
+        # CHECK-SAME: (args = (%a, 4,
+        # CHECK: %write_M:0_K:0 :
+        # CHECK-SAME: (%read_M:0_K:0, %b, 4,
+        # CHECK: %write_M:0_K:1 :
+        # CHECK-SAME: (%read_M:0_K:1, %b, 4,
+
+        # Custom format:
+        # CHECK: read(memory=a, elements_per_thread=4,
+        # CHECK: read(memory=a, elements_per_thread=4,
+        # CHECK: write(register_=read_M:0_K:0, memory=b, elements_per_thread=4,
+        # CHECK: write(register_=read_M:0_K:1, memory=b, elements_per_thread=4,
+        # CHECK: -----
+
+
+@tkw.wave_trace_only()
 def gemm(
     a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
     b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],


### PR DESCRIPTION
Right now, it only looks at write nodes in the root graph and misses ones in reductions. Instead we walk all the regions for `Write` nodes and `GetResult` nodes without users.

`get_leaf_node_types` also appeared to always return `[Write]` as it sets `leaf_nodes` to that and then immediately checks if it's empty, which it never will be, so I deleted it.

Also includes some .gitignore additions that I can drop if you don't like them.

Fixes https://github.com/iree-org/iree-turbine/issues/374