### PR TITLE
Remove permutation of KV cache 

### DIFF
--- a/iree/turbine/kernel/compiler/kernel_codegen.py
+++ b/iree/turbine/kernel/compiler/kernel_codegen.py
@@ -31,7 +31,6 @@ from ..lang.kernel_buffer import (
     KernelBuffer,
     KernelBufferUsage,
     is_kernel_buffer_meta_derived,
-    NotSetType,
 )
 from ..lang.wave_types import Memory
 from ..lang.grid import Grid
@@ -132,10 +131,7 @@ class BindingDesc:
                 spec_asm = element_type_asm
             ref_type = self.reference[1].type
             # If a physical layout is present, use it to determine the shape and strides.
-            if (
-                not isinstance(ref_type.physical_layout, NotSetType)
-                and ref_type.physical_layout
-            ):
+            if ref_type.physical_layout:
                 shape_asm = "x".join(
                     sym_to_dim_asm(s) for s in ref_type.physical_layout.shape
                 )

--- a/iree/turbine/kernel/lang/kernel_buffer.py
+++ b/iree/turbine/kernel/lang/kernel_buffer.py
@@ -23,13 +23,6 @@ __all__ = [
 SubtypeT = TypeVar("SubtypeT")
 
 
-class NotSetType:
-    ...
-
-
-NotSet = NotSetType()
-
-
 class AddressSpace(Enum):
     REGISTER = 0
     SHARED_MEMORY = 1
@@ -72,20 +65,20 @@ class KernelBufferMeta(ShapedDataType):
     def new_subtype(
         cls: Type[SubtypeT],
         *,
-        name: str | NotSetType = NotSet,
-        address_space: AddressSpace | NotSetType = NotSet,
-        symbolic_shape: tuple[IndexExpr, ...] | NotSetType = NotSet,
-        dtype: DataType | NotSetType = NotSet,
-        physical_layout: MemoryLayout | NotSetType = NotSet,
-        usage: KernelBufferUsage | NotSetType = NotSet,
+        name: str | None = None,
+        address_space: AddressSpace | None = None,
+        symbolic_shape: tuple[IndexExpr, ...] | None = None,
+        dtype: DataType | None = None,
+        physical_layout: MemoryLayout | None = None,
+        usage: KernelBufferUsage | None = None,
     ) -> Type[SubtypeT]:
         init_address_space = (
             address_space if address_space else AddressSpace.GLOBAL_MEMORY
         )
-        init_symbolic_shape = symbolic_shape if symbolic_shape is not NotSet else cls.symbolic_shape  # type: ignore
-        init_dtype = dtype if dtype is not NotSet else cls.dtype  # type: ignore
+        init_symbolic_shape = symbolic_shape if symbolic_shape is not None else cls.symbolic_shape  # type: ignore
+        init_dtype = dtype if dtype is not None else cls.dtype  # type: ignore
         init_physical_layout = physical_layout if physical_layout else None  # type: ignore
-        init_usage = usage if usage is not NotSet else cls.usage  # type: ignore
+        init_usage = usage if usage is not None else cls.usage  # type: ignore
 
         class SubType(cls):
             address_space = init_address_space
@@ -95,7 +88,7 @@ class KernelBufferMeta(ShapedDataType):
             physical_layout = init_physical_layout
             usage = init_usage
 
-        if name is not NotSet:
+        if name is not None:
             SubType.__name__ = name
         else:
             SubType.__name__ = KernelBufferUsage._type_name(init_usage)

--- a/iree/turbine/kernel/lang/kernel_buffer.py
+++ b/iree/turbine/kernel/lang/kernel_buffer.py
@@ -1,6 +1,7 @@
 from typing import Type, TypeVar, cast, ClassVar
 
 from enum import Enum
+from dataclasses import dataclass
 
 import torch
 
@@ -13,6 +14,7 @@ __all__ = [
     "AddressSpace",
     "KernelBuffer",
     "InputBuffer",
+    "MemoryLayout",
     "OutputBuffer",
     "TemporaryBuffer",
     "is_kernel_buffer_meta_derived",
@@ -54,6 +56,16 @@ class KernelBufferUsage(Enum):
             raise AssertionError(f"uncovered KernelBufferUsage enum ({v})")
 
 
+@dataclass
+class MemoryLayout:
+    """
+    Specifies the physical layout of a memory buffer in terms of
+    its physical shape.
+    """
+
+    shape: tuple[int | IndexExpr]
+
+
 class KernelBufferMeta(ShapedDataType):
     usage: KernelBufferUsage = KernelBufferUsage.NONE
 
@@ -64,6 +76,7 @@ class KernelBufferMeta(ShapedDataType):
         address_space: AddressSpace | NotSetType = NotSet,
         symbolic_shape: tuple[IndexExpr, ...] | NotSetType = NotSet,
         dtype: DataType | NotSetType = NotSet,
+        physical_layout: MemoryLayout | NotSetType = NotSet,
         usage: KernelBufferUsage | NotSetType = NotSet,
     ) -> Type[SubtypeT]:
         init_address_space = (
@@ -71,6 +84,7 @@ class KernelBufferMeta(ShapedDataType):
         )
         init_symbolic_shape = symbolic_shape if symbolic_shape is not NotSet else cls.symbolic_shape  # type: ignore
         init_dtype = dtype if dtype is not NotSet else cls.dtype  # type: ignore
+        init_physical_layout = physical_layout if physical_layout else None  # type: ignore
         init_usage = usage if usage is not NotSet else cls.usage  # type: ignore
 
         class SubType(cls):
@@ -78,6 +92,7 @@ class KernelBufferMeta(ShapedDataType):
             symbolic_shape = init_symbolic_shape
             rank = len(init_symbolic_shape)  # type: ignore
             dtype = init_dtype
+            physical_layout = init_physical_layout
             usage = init_usage
 
         if name is not NotSet:

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -14,10 +14,24 @@ from iree.turbine.kernel.wave.utils import (
 )
 import sympy
 from enum import Enum
+from collections import namedtuple
+
+paged_decode_attention_shape = namedtuple(
+    "paged_decode_attention_shape",
+    [
+        "num_query_heads",
+        "num_kv_heads",
+        "head_size",
+        "head_size_kv",
+        "block_size",
+        "num_seqs",
+        "kv_lens",
+    ],
+)
 
 
 def get_paged_decode_attention_kernels(
-    shape: tuple[int],
+    shape: paged_decode_attention_shape,
     mfma_variant: MMAType,
     num_kv_splits: int,
     k_shape: tuple[int],
@@ -37,9 +51,7 @@ def get_paged_decode_attention_kernels(
     # Workgroup tile sizes
     BLOCK_B = tkl.sym.BLOCK_B
     BLOCK_BH = tkl.sym.BLOCK_BH
-    BLOCK_M = tkl.sym.BLOCK_M
     BLOCK_N = tkl.sym.BLOCK_N
-    BLOCK_K2 = tkl.sym.BLOCK_K2
     BLOCK_U = tkl.sym.BLOCK_U
     BLOCK_T = tkl.sym.BLOCK_T
     BLOCK_S = tkl.sym.BLOCK_S
@@ -326,18 +338,9 @@ def get_paged_decode_attention_kernels(
     symbols_1[BLOCK_B] = PHASE_1_BLOCK_B
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
 
-    dynamic_symbols_0 = []
-    dynamic_symbols_1 = []
-    dynamic_symbols_map_0 = {}
-    dynamic_symbols_map_1 = {}
-
     return (
         phase_0,
         phase_1,
         symbols_0,
         symbols_1,
-        dynamic_symbols_0,
-        dynamic_symbols_map_0,
-        dynamic_symbols_1,
-        dynamic_symbols_map_1,
     )

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1098,6 +1098,10 @@ def device_arange(*args, **kwargs):
     return to_default_device(torch.arange(*args, **kwargs))
 
 
+def device_full(*args, **kwargs):
+    return to_default_device(torch.full(*args, **kwargs))
+
+
 def device_randn(*args, **kwargs):
     return to_default_device(torch.randn(*args, **kwargs))
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -314,6 +314,7 @@ def get_mma_dimensional_mapping(
         rhs_shape = custom.rhs_type.symbolic_shape
         acc_shape = custom.acc_type.symbolic_shape
         k = ((set(lhs_shape) & set(rhs_shape)) - set(acc_shape)).pop()
+
         if custom not in mapping:
             mapping[custom] = {}
         mapping[custom][m] = MMAOperand.M

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1098,8 +1098,8 @@ def test_paged_flash_decoding():
         kv_lens=100,
     )
     num_kv_splits = 8
-    k_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_lens, shape.head_size)
-    v_shape = (shape.num_seqs, shape.num_kv_heads, shape.head_size_kv, shape.kv_lens)
+    k_shape = (shape.num_seqs, shape.kv_lens, shape.num_kv_heads, shape.head_size)
+    v_shape = (shape.num_seqs, shape.kv_lens, shape.num_kv_heads, shape.head_size_kv)
     q_shape = (shape.num_seqs, shape.num_query_heads, shape.head_size)
     o_shape = (shape.num_seqs, shape.num_query_heads, shape.head_size_kv)
     logits_shape = (num_kv_splits, shape.num_seqs, shape.head_size_kv, shape.kv_lens)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -13,8 +13,8 @@ from iree.turbine.kernel.wave.utils import (
     get_default_run_config,
     get_default_scheduling_params,
     device_arange,
+    device_full,
     device_randn,
-    device_randint,
     device_zeros,
 )
 from iree.turbine.kernel.wave.constraints import MMAType
@@ -33,86 +33,10 @@ from ..common.shapes import get_test_shapes
 from typing import List, Optional
 
 # Reference paged attention implementation from vLLM and sglang.
-# From: https://github.com/vllm-project/vllm/blob/main/tests/kernels/test_flash_attn.py
-NUM_HEADS = [(128, 4)]
-HEAD_SIZES = [64]
-BLOCK_SIZES = [64]
-DTYPES = [torch.float16]
-NUM_BLOCKS = [128]
-# First item is query length, second item is key/value length.
-# In decode, query length is always one.
-SEQ_LENS = [[(1, 19), (1, 34), (1, 27)]]
-
-
-# From: https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/torch_native_backend.py
-def _run_sdpa_forward_decode(
-    query: torch.Tensor,
-    output: torch.Tensor,
-    k_cache: torch.Tensor,
-    v_cache: torch.Tensor,
-    req_to_token: torch.Tensor,
-    req_pool_indices: torch.Tensor,
-    seq_lens: torch.Tensor,
-    scaling=None,
-    enable_gqa=False,
-    causal=False,
-):
-    """Run the decode forward by using torch native sdpa op.
-
-    Args:
-        query: [num_tokens, num_heads, head_size]
-        output: [num_tokens, num_heads, head_size]
-        k_cache: [max_total_num_tokens, num_heads, head_size]
-        v_cache: [max_total_num_tokens, num_heads, head_size]
-        req_to_token: [max_num_reqs, max_context_len]
-        req_pool_indices: [num_seqs]
-        seq_lens: [num_seqs]
-        scaling: float or None
-        enable_gqa: bool
-        causal: bool
-
-    Returns:
-        output: [num_tokens, num_heads, head_size]
-    """
-
-    # [num_tokens, num_heads, head_size] -> [num_heads, num_tokens, head_size]
-    query = query.movedim(0, query.dim() - 2)
-
-    start_q, start_kv = 0, 0
-    for seq_idx in range(seq_lens.shape[0]):
-        # TODO: this loop process a sequence per iter, this is inefficient.
-        # Need optimize the performance later.
-
-        seq_len_q = 1
-        seq_len_kv = seq_lens[seq_idx]
-        end_q = start_q + seq_len_q
-        end_kv = start_kv + seq_len_kv
-
-        per_req_query = query[:, start_q:end_q, :]
-
-        # get key and value from cache. per_req_tokens contains the kv cache
-        # index for each token in the sequence.
-        req_pool_idx = req_pool_indices[seq_idx]
-        per_req_tokens = req_to_token[req_pool_idx, :seq_len_kv]
-        per_req_key = k_cache[per_req_tokens].movedim(0, query.dim() - 2)
-        per_req_value = v_cache[per_req_tokens].movedim(0, query.dim() - 2)
-
-        per_req_out = (
-            torch.nn.functional.scaled_dot_product_attention(
-                per_req_query.unsqueeze(0),
-                per_req_key.unsqueeze(0),
-                per_req_value.unsqueeze(0),
-                enable_gqa=enable_gqa,
-                scale=scaling,
-                is_causal=causal,
-            )
-            .squeeze(0)
-            .movedim(query.dim() - 2, 0)
-        )
-        output[start_q:end_q, :, :] = per_req_out
-        start_q, start_kv = end_q, end_kv
-
-    return output
+# (NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, BLOCK_SIZE, NUM_SEQS, SEQ_LEN)
+shapes = [(16, 1, 64, 64, 32, 2, 100)]
+shapes += [(64, 1, 80, 80, 32, 2, 128)]
+shapes += [(128, 2, 80, 80, 32, 2, 500)]
 
 
 def ref_paged_attn(
@@ -129,7 +53,7 @@ def ref_paged_attn(
 ) -> torch.Tensor:
     num_seqs = len(query_lens)
     block_tables = block_tables.cpu().numpy()
-    _, block_size, num_kv_heads, head_size = key_cache.shape
+    _, num_kv_heads, head_size = key_cache.shape
 
     outputs: List[torch.Tensor] = []
     start_idx = 0
@@ -172,18 +96,53 @@ def ref_paged_attn(
     return torch.cat(outputs, dim=0)
 
 
+def create_inputs(
+    num_seqs: int,
+    kv_lens: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    head_size_kv: int,
+    dtype: torch.dtype,
+):
+    query = device_randn(num_seqs, num_query_heads, head_size, dtype=dtype)
+    key_cache = device_randn(num_seqs * kv_lens, num_kv_heads, head_size, dtype=dtype)
+
+    value_cache = device_randn(
+        num_seqs * kv_lens, num_kv_heads, head_size_kv, dtype=dtype
+    )
+    block_table = device_arange(num_seqs * kv_lens, dtype=torch.int32).reshape(
+        num_seqs, kv_lens
+    )
+    request_indices = device_arange(num_seqs, dtype=torch.int32)
+    kv_lens_tensor = device_full((num_seqs,), kv_lens, dtype=torch.int32)
+    return (
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        request_indices,
+        kv_lens_tensor,
+    )
+
+
+def load_inputs(directory):
+    query = torch.load(os.path.join(directory, "query.pt"))
+    key_cache = torch.load(os.path.join(directory, "key_cache.pt"))
+    value_cache = torch.load(os.path.join(directory, "value_cache.pt"))
+    block_table = torch.load(os.path.join(directory, "block_table.pt"))
+    request_indices = torch.load(os.path.join(directory, "request_indices.pt"))
+    kv_lens = torch.load(os.path.join(directory, "kv_lens.pt"))
+    return query, key_cache, value_cache, block_table, request_indices, kv_lens
+
+
 # TODO: Investigate errors on MI250.
 @require_e2e
 @require_cdna3
-@pytest.mark.parametrize("seq_lens", SEQ_LENS)
-@pytest.mark.parametrize("num_heads", NUM_HEADS)
-@pytest.mark.parametrize("head_size", HEAD_SIZES)
-@pytest.mark.parametrize("block_size", BLOCK_SIZES)
-@pytest.mark.parametrize("sliding_window", [None])
-@pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("soft_cap", [None])
-@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+@pytest.mark.parametrize("shape", shapes)
+@pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("enable_scheduling", [False])
+@pytest.mark.parametrize("num_kv_splits", [8])
 @pytest.mark.parametrize(
     "mfma_variant",
     [
@@ -191,58 +150,68 @@ def ref_paged_attn(
     ],
 )
 def testPagedFlashDecoding(
-    seq_lens: List[tuple[int, int]],
-    num_heads: tuple[int, int],
-    head_size: int,
-    block_size: int,
-    sliding_window: Optional[int],
+    shape: tuple[int],
     dtype: torch.dtype,
-    soft_cap: Optional[float],
-    num_blocks: int,
     enable_scheduling: bool,
+    num_kv_splits: int,
     mfma_variant: MMAType,
     request,
 ):
 
     torch.manual_seed(0)
-    num_seqs = len(seq_lens)
-    query_lens = [x[0] for x in seq_lens]
-    kv_lens = [x[1] for x in seq_lens]
-    num_query_heads = num_heads[0]
-    num_kv_heads = num_heads[1]
+    (
+        num_query_heads,
+        num_kv_heads,
+        head_size,
+        head_size_kv,
+        block_size,
+        num_seqs,
+        kv_lens,
+    ) = shape
     assert num_query_heads % num_kv_heads == 0
-    max_query_len = max(query_lens)
-    max_kv_len = max(kv_lens)
-    window_size = (sliding_window - 1, 0) if sliding_window is not None else (-1, -1)
     scale = head_size**-0.5
 
-    query = device_randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
-    key_cache = device_randn(
-        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    artifact_directory = None
+    if not artifact_directory:
+        (
+            query,
+            key_cache,
+            value_cache,
+            block_table,
+            request_indices,
+            kv_lens_tensor,
+        ) = create_inputs(
+            num_seqs,
+            kv_lens,
+            num_query_heads,
+            num_kv_heads,
+            head_size,
+            head_size_kv,
+            dtype,
+        )
+    else:
+        (
+            query,
+            key_cache,
+            value_cache,
+            block_table,
+            request_indices,
+            kv_lens_tensor,
+        ) = load_inputs(artifact_directory)
+        num_seqs = query.shape[0]
+        num_query_heads = query.shape[1]
+        head_size = query.shape[2]
+        num_kv_heads = key_cache.shape[2]
+        head_size_kv = value_cache.shape[3]
+
+    permuted_key_cache = key_cache.view(num_seqs, -1, num_kv_heads, head_size).permute(
+        [0, 2, 1, 3]
     )
-    value_cache = torch.randn_like(key_cache)
-    # TODO: The block table entries should be able to be a random number
-    # in the range [0, num_blocks * block_size), but that fails for now.
-    # As a workaround, the maximum value is set to num_seqs - 1.
-    block_table = device_randint(
-        0, num_blocks, (num_seqs, num_blocks), dtype=torch.int32
-    )
-    request_indices = device_arange(num_seqs, dtype=torch.int32)
-    kv_lens_tensor = device_zeros(num_seqs, dtype=torch.int32)
-    for i in range(len(kv_lens)):
-        kv_lens_tensor[i] = kv_lens[i]
+    permuted_value_cache = value_cache.view(
+        num_seqs, -1, num_kv_heads, head_size_kv
+    ).permute([0, 2, 3, 1])
 
     # Run the wave kernel.
-    # TODO: Currently all but K1 is set to dynamic. This may not be the case.
-    S = num_seqs
-    B = num_query_heads
-    K1 = head_size
-    K2 = block_size
-    M = 1
-    N = head_size
-    BH = num_kv_heads
-    shape = (B, M, N, K1, K2, BH, S, num_blocks)
-    num_kv_splits = 8
     (
         phase_0,
         phase_1,
@@ -253,7 +222,12 @@ def testPagedFlashDecoding(
         dynamic_symbols_1,
         dynamic_symbols_map_1,
     ) = get_paged_decode_attention_kernels(
-        shape, num_blocks * block_size, mfma_variant, num_kv_splits
+        shape,
+        mfma_variant,
+        num_kv_splits,
+        permuted_key_cache.shape,
+        permuted_value_cache.shape,
+        block_table.shape,
     )
     hyperparams_0.update(get_default_scheduling_params())
     hyperparams_1.update(get_default_scheduling_params())
@@ -269,16 +243,15 @@ def testPagedFlashDecoding(
             dump_perf, "tk_" + perf_filename
         )
 
-    sym_U = index_symbol("U")
-    if sym_U in hyperparams_0:
-        U = hyperparams_0[sym_U]
-    else:
-        U = dynamic_symbols_map_0[sym_U]
-    phase_0_output = device_zeros(U, S, N, B, dtype=torch.float32)
-    phase_0_output_max = device_zeros(U, S, B, dtype=torch.float32)
-    output = device_zeros(S, B, N, dtype=torch.float32)
+    phase_0_output = device_zeros(
+        num_kv_splits, num_seqs, head_size_kv, num_query_heads, dtype=torch.float32
+    )
+    phase_0_output_max = device_zeros(
+        num_kv_splits, num_seqs, num_query_heads, dtype=torch.float32
+    )
+    output = device_zeros(num_seqs, num_query_heads, head_size_kv, dtype=torch.float32)
     log2e = 1.44269504089
-    dk_sqrt = math.sqrt(1.0 / K1)
+    dk_sqrt = math.sqrt(1.0 / head_size)
 
     with tk.gen.TestLaunchContext(
         hyperparams_0,
@@ -292,10 +265,11 @@ def testPagedFlashDecoding(
         dynamic_symbols_map=dynamic_symbols_map_0,
     ):
         # TODO: Add scaling of QK as part of kernel.
+        # TODO: Add variant of non-transposed V attention kernel.
         mb_qk = phase_0(
             query * dk_sqrt * log2e,
-            key_cache.permute([0, 2, 1, 3]),
-            value_cache.permute([0, 2, 3, 1]),
+            permuted_key_cache,
+            permuted_value_cache,
             request_indices,
             kv_lens_tensor,
             block_table,
@@ -314,7 +288,6 @@ def testPagedFlashDecoding(
         dynamic_symbols=dynamic_symbols_1,
         dynamic_symbols_map=dynamic_symbols_map_1,
     ):
-        # TODO: Add variant of non-transposed V attention kernel.
         mb_sv = phase_1(phase_0_output, phase_0_output_max, output)
 
     if dump_generated_mlir:
@@ -325,37 +298,21 @@ def testPagedFlashDecoding(
         with open(filename, "w") as f:
             f.write(mb_sv.module_op.get_asm())
 
-    # Run the reference implementation (vllm or sglang).
-    ref_vllm_output = ref_paged_attn(
-        query=query,
-        key_cache=key_cache,
-        value_cache=value_cache,
-        query_lens=query_lens,
-        kv_lens=kv_lens,
-        block_tables=block_table,
-        scale=scale,
-        causal=False,
-        sliding_window=sliding_window,
-        soft_cap=soft_cap,
-    )
-
-    compare_sglang = False
-    if compare_sglang:
-        # Since the query gets scaled in the first call, we don't
-        # scale it again below.
-        ref_sglang_output = _run_sdpa_forward_decode(
+    if not artifact_directory:
+        # Run the reference implementation.
+        ref_vllm_output = ref_paged_attn(
             query=query,
-            output=torch.zeros_like(query),
-            k_cache=key_cache,
-            v_cache=value_cache,
-            req_to_token=block_table,
-            req_pool_indices=torch.arange(num_seqs),
-            seq_lens=torch.tensor(kv_lens, dtype=torch.int32),
-            scaling=1,
-            enable_gqa=True,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            query_lens=torch.ones(num_seqs, dtype=torch.int32),
+            kv_lens=kv_lens_tensor,
+            block_tables=block_table,
+            scale=scale,
             causal=False,
+            sliding_window=None,
+            soft_cap=None,
         )
-
-        assert_allclose(ref_vllm_output, ref_sglang_output, rtol=1e-3, atol=1e-3)
+    else:
+        ref_vllm_output = torch.load(os.path.join(artifact_directory, "output.pt"))
 
     assert_allclose(output, ref_vllm_output, rtol=1e-3, atol=1e-3)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -205,12 +205,12 @@ def testPagedFlashDecoding(
         shape.num_kv_heads = key_cache.shape[2]
         shape.head_size_kv = value_cache.shape[3]
 
-    permuted_key_cache = key_cache.view(
+    key_cache_4d = key_cache.view(
         shape.num_seqs, -1, shape.num_kv_heads, shape.head_size
-    ).permute([0, 2, 1, 3])
-    permuted_value_cache = value_cache.view(
+    )
+    value_cache_4d = value_cache.view(
         shape.num_seqs, -1, shape.num_kv_heads, shape.head_size_kv
-    ).permute([0, 2, 3, 1])
+    )
 
     # Run the wave kernel.
     (
@@ -222,8 +222,8 @@ def testPagedFlashDecoding(
         shape,
         mfma_variant,
         num_kv_splits,
-        permuted_key_cache.shape,
-        permuted_value_cache.shape,
+        key_cache_4d.shape,
+        value_cache_4d.shape,
         block_table.shape,
     )
     hyperparams_0.update(get_default_scheduling_params())
@@ -269,8 +269,8 @@ def testPagedFlashDecoding(
         # TODO: Add variant of non-transposed V attention kernel.
         mb_qk = phase_0(
             query * dk_sqrt * log2e,
-            permuted_key_cache,
-            permuted_value_cache,
+            key_cache_4d,
+            value_cache_4d,
             request_indices,
             kv_lens_tensor,
             block_table,


### PR DESCRIPTION
This PR removes the permutation of the key and
value cache prior to kernel invocation. In order to accomplish this, we add an additional attribute to the MMA operator that specifies which dimensions map to the M, N, K dimensions of the matrix multiplication.