### PR TITLE
Remove permutation of KV cache

### DIFF
--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -314,6 +314,7 @@ def get_mma_dimensional_mapping(
         rhs_shape = custom.rhs_type.symbolic_shape
         acc_shape = custom.acc_type.symbolic_shape
         k = ((set(lhs_shape) & set(rhs_shape)) - set(acc_shape)).pop()
+
         if custom not in mapping:
             mapping[custom] = {}
         mapping[custom][m] = MMAOperand.M

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1098,8 +1098,8 @@ def test_paged_flash_decoding():
         kv_lens=100,
     )
     num_kv_splits = 8
-    k_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_lens, shape.head_size)
-    v_shape = (shape.num_seqs, shape.num_kv_heads, shape.head_size_kv, shape.kv_lens)
+    k_shape = (shape.num_seqs, shape.kv_lens, shape.num_kv_heads, shape.head_size)
+    v_shape = (shape.num_seqs, shape.kv_lens, shape.num_kv_heads, shape.head_size_kv)
     q_shape = (shape.num_seqs, shape.num_query_heads, shape.head_size)
     o_shape = (shape.num_seqs, shape.num_query_heads, shape.head_size_kv)
     logits_shape = (num_kv_splits, shape.num_seqs, shape.head_size_kv, shape.kv_lens)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -205,12 +205,12 @@ def testPagedFlashDecoding(
         shape.num_kv_heads = key_cache.shape[2]
         shape.head_size_kv = value_cache.shape[3]
 
-    permuted_key_cache = key_cache.view(
+    key_cache_4d = key_cache.view(
         shape.num_seqs, -1, shape.num_kv_heads, shape.head_size
-    ).permute([0, 2, 1, 3])
-    permuted_value_cache = value_cache.view(
+    )
+    value_cache_4d = value_cache.view(
         shape.num_seqs, -1, shape.num_kv_heads, shape.head_size_kv
-    ).permute([0, 2, 3, 1])
+    )
 
     # Run the wave kernel.
     (
@@ -222,8 +222,8 @@ def testPagedFlashDecoding(
         shape,
         mfma_variant,
         num_kv_splits,
-        permuted_key_cache.shape,
-        permuted_value_cache.shape,
+        key_cache_4d.shape,
+        value_cache_4d.shape,
         block_table.shape,
     )
     hyperparams_0.update(get_default_scheduling_params())
@@ -269,8 +269,8 @@ def testPagedFlashDecoding(
         # TODO: Add variant of non-transposed V attention kernel.
         mb_qk = phase_0(
             query * dk_sqrt * log2e,
-            permuted_key_cache,
-            permuted_value_cache,
+            key_cache_4d,
+            value_cache_4d,
             request_indices,
             kv_lens_tensor,
             block_table,


### PR DESCRIPTION
This PR removes the permutation of the key and
value cache prior to kernel invocation.