### PR TITLE
Update grid size for PDA

### DIFF
--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -376,6 +376,7 @@ class WorkgroupConstraint(Constraint):
     workgroup_dim: int
     apply_fn: Optional[Callable] = None
     primary: Optional[bool] = True
+    iters: Optional[IndexExpr] = None
 
     def __post_init__(self):
         self.wg_dim = None
@@ -392,6 +393,8 @@ class WorkgroupConstraint(Constraint):
         """
         Returns an expression for the total number of workgroups for the specific workgroup_dim.
         """
+        if self.iters:
+            return self.iters
         return ceiling(self.dim / self.tile_size)
 
     def apply(self) -> IndexSequence:

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -15,6 +15,7 @@ from iree.turbine.kernel.wave.utils import (
 import sympy
 from enum import Enum
 from collections import namedtuple
+import math
 
 paged_decode_attention_shape = namedtuple(
     "paged_decode_attention_shape",
@@ -65,11 +66,13 @@ def get_paged_decode_attention_kernels(
         PHASE_0 = (0,)
         PHASE_1 = (1,)
 
-    B_WAVES = 1
     THREADS_PER_WAVE = 64
     PHASE_1_BLOCK_B = 64
     PHASE_1_ELEMS_PER_THREAD = PHASE_1_BLOCK_B // THREADS_PER_WAVE
     PHASE_1_BLOCK_N = 1
+    HEAD_BLOCK_SIZE = 16
+    head_ratio = shape.num_query_heads // shape.num_kv_heads
+    B_WAVES = 1
 
     def phase_0_constraints():
         # K1, K2 are reduction dimensions that are fixed (not distributed) so
@@ -88,20 +91,19 @@ def get_paged_decode_attention_kernels(
         )
         wg_func = lambda wg: wg * sympy.floor(T / U) + sympy.Min(wg, sympy.Mod(T, U))
         constraints += [
-            tkw.WorkgroupConstraint(
-                T, BLOCK_T, 0, apply_fn=lambda wg: wg_func(wg), primary=False
-            )
+            tkw.WorkgroupConstraint(T, BLOCK_T, 0, apply_fn=wg_func, primary=False)
         ]
         constraints += [tkw.TilingConstraint(T, 1, iters=count)]
 
         # BH is the kv-head index and is distributed across workgroups.
         # B is the query index and is distributed like BH but with a different
         # workgroup and wave tile size.
-        # TODO: We will want to add a function to the workgroup constraint to
-        # allow for using WG / ceil(kv_group_num, BLOCK_B) instead of just WG.
-        # This can be done by adding an optional additional argument to the WorkgroupConstraint.
 
-        constraints += [tkw.WorkgroupConstraint(BH, BLOCK_BH, 1)]
+        wg_func_2 = lambda wg: wg // math.ceil(head_ratio / HEAD_BLOCK_SIZE)
+        count = shape.num_query_heads // min(HEAD_BLOCK_SIZE, head_ratio)
+        constraints += [
+            tkw.WorkgroupConstraint(BH, BLOCK_BH, 1, apply_fn=wg_func_2, iters=count)
+        ]
         constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 1, primary=False)]
         constraints += [tkw.WaveConstraint(B, BLOCK_B / B_WAVES)]
 
@@ -279,7 +281,7 @@ def get_paged_decode_attention_kernels(
     def phase_1(
         logits: tkl.Memory[U, S, N, B, GLOBAL_ADDRESS_SPACE, tkl.f32],
         logits_max: tkl.Memory[U, S, B, GLOBAL_ADDRESS_SPACE, tkl.f32],
-        output: tkl.Memory[S, B, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        output: tkl.Memory[S, B, N, GLOBAL_ADDRESS_SPACE, tkl.f16],
     ):
         c_reg = tkl.Register[S, B, N, tkl.f32](0.0)
         init_sum = tkl.Register[S, B, tkl.f32](0.0)
@@ -304,35 +306,29 @@ def get_paged_decode_attention_kernels(
 
         res_max, res_sum, res_mm = repeat
         res = res_mm / res_sum
+        res_f16 = tkw.cast(res, tkl.f16)
         tkw.write(
-            res, output, mapping=mapping, elements_per_thread=PHASE_1_ELEMS_PER_THREAD
+            res_f16,
+            output,
+            mapping=mapping,
+            elements_per_thread=PHASE_1_ELEMS_PER_THREAD,
         )
-
-    (
-        num_query_heads,
-        num_kv_heads,
-        head_size,
-        head_size_kv,
-        block_size,
-        num_seqs,
-        kv_lens,
-    ) = shape
 
     symbols_0 = {
         ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
         LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
         STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
         BLOCK_BH: 1,
-        BLOCK_B: num_query_heads // num_kv_heads,
+        BLOCK_B: HEAD_BLOCK_SIZE,
         BLOCK_S: 1,
         BLOCK_U: 1,
-        B: num_query_heads,
+        B: shape.num_query_heads,
         M: 1,
-        N: head_size_kv,
-        K1: head_size,
-        K2: block_size,
-        BH: num_kv_heads,
-        S: num_seqs,
+        N: shape.head_size_kv,
+        K1: shape.head_size,
+        K2: shape.block_size,
+        BH: shape.num_kv_heads,
+        S: shape.num_seqs,
         U: num_kv_splits,
     }
     symbols_1 = dict(symbols_0)

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1121,7 +1121,7 @@ def test_paged_flash_decoding():
     v = torch.randn(v_shape, dtype=torch.float16)
     logits = torch.zeros(logits_shape, dtype=torch.float32)
     logits_max = torch.zeros(logits_max_shape, dtype=torch.float32)
-    output = torch.zeros(o_shape, dtype=torch.float32)
+    output = torch.zeros(o_shape, dtype=torch.float16)
 
     with tk.gen.TestLaunchContext(
         hyperparams_0,
@@ -1139,21 +1139,21 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-3:                vector.maskedload
     # CHECK-COUNT-8:                vector.store
     # CHECK-COUNT-8:                vector.load
-    # CHECK-COUNT-16:               amdgpu.mfma
-    # CHECK-COUNT-4:                gpu.shuffle
-    # CHECK-COUNT-2:                arith.subf
-    # CHECK-COUNT-2:                math.exp2
-    # CHECK-COUNT-8:                arith.subf
-    # CHECK-COUNT-8:                math.exp2
-    # CHECK-COUNT-4:                gpu.shuffle
+    # CHECK-COUNT-8:               amdgpu.mfma
+    # CHECK-COUNT-2:                gpu.shuffle
+    # CHECK-COUNT-1:                arith.subf
+    # CHECK-COUNT-1:                math.exp2
+    # CHECK-COUNT-4:                arith.subf
+    # CHECK-COUNT-4:                math.exp2
+    # CHECK-COUNT-2:                gpu.shuffle
     # TODO: Remove gathers for performance
     # CHECK-COUNT-2:                vector.gather
     # CHECK-COUNT-8:                vector.store
     # CHECK-COUNT-8:                vector.load
-    # CHECK-COUNT-16:                amdgpu.mfma
-    # CHECK-COUNT-2:          arith.divf
-    # CHECK-COUNT-2:          math.log2
-    # CHECK-COUNT-18:         vector.store
+    # CHECK-COUNT-8:                amdgpu.mfma
+    # CHECK-COUNT-1:          arith.divf
+    # CHECK-COUNT-1:          math.log2
+    # CHECK-COUNT-9:         vector.store
 
     with tk.gen.TestLaunchContext(
         hyperparams_1,

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -251,7 +251,7 @@ def testPagedFlashDecoding(
         num_kv_splits, shape.num_seqs, shape.num_query_heads, dtype=torch.float32
     )
     output = device_zeros(
-        shape.num_seqs, shape.num_query_heads, shape.head_size_kv, dtype=torch.float32
+        shape.num_seqs, shape.num_query_heads, shape.head_size_kv, dtype=torch.float16
     )
     log2e = 1.44269504089
     dk_sqrt = math.sqrt(1.0 / shape.head_size)


### PR DESCRIPTION
This PR updates the grid distribution for paged decode attention. Previously, we were launching only as many workgroups as there were kv heads. However, if instead we can exploit much more parallelism if instead we launch ```shape.num_query_heads // min(HEAD_BLOCK_SIZE, head_ratio)``` workgroups and do some arithmetic on the workgroup index to recover the kv head index.