### PR TITLE
Fix missing cast in tests

### DIFF
--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -279,7 +279,7 @@ def get_paged_decode_attention_kernels(
     def phase_1(
         logits: tkl.Memory[U, S, N, B, GLOBAL_ADDRESS_SPACE, tkl.f32],
         logits_max: tkl.Memory[U, S, B, GLOBAL_ADDRESS_SPACE, tkl.f32],
-        output: tkl.Memory[S, B, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        output: tkl.Memory[S, B, N, GLOBAL_ADDRESS_SPACE, tkl.f16],
     ):
         c_reg = tkl.Register[S, B, N, tkl.f32](0.0)
         init_sum = tkl.Register[S, B, tkl.f32](0.0)
@@ -304,6 +304,7 @@ def get_paged_decode_attention_kernels(
 
         res_max, res_sum, res_mm = repeat
         res = res_mm / res_sum
+        res = tkw.cast(res, tkl.f16)
         tkw.write(
             res, output, mapping=mapping, elements_per_thread=PHASE_1_ELEMS_PER_THREAD
         )

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1121,7 +1121,7 @@ def test_paged_flash_decoding():
     v = torch.randn(v_shape, dtype=torch.float16)
     logits = torch.zeros(logits_shape, dtype=torch.float32)
     logits_max = torch.zeros(logits_max_shape, dtype=torch.float32)
-    output = torch.zeros(o_shape, dtype=torch.float32)
+    output = torch.zeros(o_shape, dtype=torch.float16)
 
     with tk.gen.TestLaunchContext(
         hyperparams_0,

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -251,7 +251,7 @@ def testPagedFlashDecoding(
         num_kv_splits, shape.num_seqs, shape.num_query_heads, dtype=torch.float32
     )
     output = device_zeros(
-        shape.num_seqs, shape.num_query_heads, shape.head_size_kv, dtype=torch.float32
+        shape.num_seqs, shape.num_query_heads, shape.head_size_kv, dtype=torch.float16
     )
     log2e = 1.44269504089
     dk_sqrt = math.sqrt(1.0 / shape.head_size)

--- a/tests/kernel/wave/runtime/cache_test.py
+++ b/tests/kernel/wave/runtime/cache_test.py
@@ -203,7 +203,7 @@ def testSameConfig(request):
         # First run/call to kernel, this should compile from scratch.
         output = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
         mb = base_attention(q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output)
-        assert_close(output, torch_ref)
+        assert_close(output, torch_ref.to(torch.float32))
         assert isinstance(
             mb, tk.compiler.builder.ModuleBuilder
         ), "Expected first call to not be cached."
@@ -216,7 +216,7 @@ def testSameConfig(request):
         cached_kernel = base_attention(
             q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output
         )
-        assert_close(output, torch_ref)
+        assert_close(output, torch_ref.to(torch.float32))
         assert (
             len(cache_manager.session_cache) == 1
         ), "Expected to keep size of cache because we reuse same kernel."
@@ -327,7 +327,7 @@ def testDifferentDynamicSameBlock(request):
             v_shape_0.permute([0, 2, 1]),
             output_shape_0,
         )
-        assert_close(output_shape_0, torch_ref_shape_0)
+        assert_close(output_shape_0, torch_ref_shape_0.to(torch.float32))
         assert isinstance(
             mb, tk.compiler.builder.ModuleBuilder
         ), "Expected first call to not be cached."
@@ -378,7 +378,7 @@ def testDifferentDynamicSameBlock(request):
             v_shape_1.permute([0, 2, 1]),
             output_shape_1,
         )
-        assert_close(output_shape_1, torch_ref_shape_1)
+        assert_close(output_shape_1, torch_ref_shape_1.to(torch.float32))
         assert (
             len(cache_manager.session_cache) == 1
         ), "Expected to keep size of cache because we reuse same kernel."
@@ -475,7 +475,7 @@ def testSameSizeDifferentBlock(request):
         mb_config_0 = base_attention(
             q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output
         )
-        assert_close(output, torch_ref)
+        assert_close(output, torch_ref.to(torch.float32))
         assert isinstance(
             mb_config_0, tk.compiler.builder.ModuleBuilder
         ), "Expected first call to not be cached."
@@ -499,7 +499,7 @@ def testSameSizeDifferentBlock(request):
         mb_config_1 = base_attention(
             q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output
         )
-        assert_close(output, torch_ref)
+        assert_close(output, torch_ref.to(torch.float32))
         assert (
             len(cache_manager.session_cache) == 2
         ), "Expected cache size to increment, because we use different block size/config."


### PR DESCRIPTION
In the flurry of PRs that went in yesterday,
a casting bug was introduced in the paged attention test. This PR fixes that by introducing an explicit cast to f16 inside the phase one kernel.