### PR TITLE
Prefill Attention

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Run e2e tests on AMD GPU MI300
         if: "contains(matrix.os, 'mi300') && !cancelled()"
         run: |
-          WAVE_CACHE_ON=0 pytest -n 8 --capture=tee-sys -vv --run-e2e --gpu-distribute 8 ./tests/kernel/wave/
+          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --gpu-distribute 8 ./tests/kernel/wave/
 
       - name: Run e2e tests on AMD GPU MI250
         if: "contains(matrix.os, 'mi250') && !cancelled()"

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -376,7 +376,7 @@ class WorkgroupConstraint(Constraint):
     workgroup_dim: int
     apply_fn: Optional[Callable] = None
     primary: Optional[bool] = True
-    iters: Optional[IndexExpr] = None
+    iters: Optional[IndexExpr | int] = None
 
     def __post_init__(self):
         self.wg_dim = None

--- a/iree/turbine/kernel/wave/templates/attention_common.py
+++ b/iree/turbine/kernel/wave/templates/attention_common.py
@@ -1,0 +1,45 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from typing import Optional
+
+import iree.turbine.kernel.lang as tkl
+
+
+@dataclass
+class AttentionShape:
+    num_query_heads: int
+    num_kv_heads: int
+    head_size: int
+    head_size_kv: int
+    # -----------------------
+    # Prefill specific
+    num_seqs: Optional[int] = None
+    max_seq_len: Optional[int] = None
+    total_seq_len: Optional[int] = None
+    # -----------------------
+    # Vanilla attention
+    query_seq_len: Optional[int] = None
+    kv_seq_len: Optional[int] = None
+
+
+# Commonly-used attention symbols
+H = tkl.sym.H
+H_Q = tkl.sym.H
+H_KV = tkl.sym.H
+N_Q = tkl.sym.N_D
+N_KV = tkl.sym.N_KV
+D_Q = tkl.sym.D_Q
+D_KV = tkl.sym.D_KV
+
+BLOCK_H = tkl.sym.BLOCK_H
+BLOCK_H_Q = tkl.sym.BLOCK_H
+BLOCK_H_KV = tkl.sym.BLOCK_H
+BLOCK_N_Q = tkl.sym.BLOCK_N_D
+BLOCK_N_KV = tkl.sym.BLOCK_N_KV
+BLOCK_D_Q = tkl.sym.BLOCK_D_Q
+BLOCK_D_KV = tkl.sym.BLOCK_D_KV

--- a/iree/turbine/kernel/wave/templates/attention_common.py
+++ b/iree/turbine/kernel/wave/templates/attention_common.py
@@ -27,15 +27,16 @@ class AttentionShape:
     kv_seq_len: Optional[int] = None
 
 
-# Commonly-used attention symbols
-H = tkl.sym.H
-H_Q = tkl.sym.H
-H_KV = tkl.sym.H
-N_Q = tkl.sym.N_D
-N_KV = tkl.sym.N_KV
-D_Q = tkl.sym.D_Q
-D_KV = tkl.sym.D_KV
+# Commonly-used attention symbols.
+H = tkl.sym.H  # number of heads
+H_Q = tkl.sym.H  # number of query heads
+H_KV = tkl.sym.H  # number of key/value heads
+N_Q = tkl.sym.N_D  # query sequence length
+N_KV = tkl.sym.N_KV  # key/value sequence length
+D_Q = tkl.sym.D_Q  # query head size
+D_KV = tkl.sym.D_KV  # key/value head size
 
+# And their corresponding tile sizes.
 BLOCK_H = tkl.sym.BLOCK_H
 BLOCK_H_Q = tkl.sym.BLOCK_H
 BLOCK_H_KV = tkl.sym.BLOCK_H

--- a/iree/turbine/kernel/wave/templates/prefill_attention.py
+++ b/iree/turbine/kernel/wave/templates/prefill_attention.py
@@ -1,0 +1,182 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import iree.turbine.kernel.wave as tkw
+import iree.turbine.kernel.lang as tkl
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.utils import (
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+)
+import math
+from iree.turbine.kernel.wave.templates.attention_common import *
+
+
+def get_prefill_attention_kernel(
+    shape: AttentionShape,
+    mfma_variant: MMAType,
+    q_shape: tuple[int],
+    k_shape: tuple[int],
+    v_shape: tuple[int],
+    o_shape: tuple[int],
+):
+    S = tkl.sym.S
+    OFFSET = tkl.sym.OFFSET
+    # Workgroup tile sizes
+    BLOCK_S = tkl.sym.BLOCK_S
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD_QK = index_symbol("LOAD_ELEMS_PER_THREAD_QK")
+    LOAD_ELEMS_PER_THREAD_PV = index_symbol("LOAD_ELEMS_PER_THREAD_PV")
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    SEQ_TILE_SIZE = 64
+    M_WAVES = 4
+    N_WAVES = 1
+
+    constraints: list[tkw.Constraint] = []
+    constraints += [
+        tkw.WorkgroupConstraint(
+            N_Q, BLOCK_N_Q, 0, iters=math.ceil(shape.max_seq_len / SEQ_TILE_SIZE)
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(D_KV, BLOCK_D_KV, 1)]
+    constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 2)]
+    constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 3)]
+    constraints += [tkw.TilingConstraint(N_KV, BLOCK_N_KV)]
+    constraints += [tkw.WaveConstraint(N_Q, BLOCK_N_Q / M_WAVES)]
+    constraints += [tkw.WaveConstraint(D_KV, BLOCK_D_KV / N_WAVES)]
+
+    if mfma_variant[1] == MMAType.F32_16x16x16_F16:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant[1] == MMAType.F32_32x32x8_F16:
+        Mvec = 32
+        Nvec = 32
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(M_WAVES, N_WAVES, 1),
+            mma_type=mfma_variant[1],
+            vector_shapes={H: 0, N_Q: Mvec, D_KV: Nvec, S: 0},
+        )
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+
+    mapping = tkw.IndexMapping(
+        num_iterators=3,
+        inputs={H: i, D_KV: j, N_Q: k},
+        outputs={H: i, N_Q: k + OFFSET, D_KV: j},
+    )
+
+    q_mapping = tkw.IndexMapping(
+        num_iterators=3,
+        inputs={H: i, N_Q: j + OFFSET, D_Q: k},
+        outputs={H: i, N_Q: j, D_Q: k},
+    )
+
+    head_ratio = shape.num_query_heads // shape.num_kv_heads
+    k_mapping = tkw.IndexMapping(
+        num_iterators=3,
+        inputs={H: i // head_ratio, N_KV: j + OFFSET, D_Q: k},
+        outputs={H: i, N_KV: j, D_Q: k},
+    )
+
+    v_mapping = tkw.IndexMapping(
+        num_iterators=3,
+        inputs={H: i // head_ratio, D_KV: j, N_KV: k + OFFSET},
+        outputs={H: i, D_KV: j, N_KV: k},
+    )
+
+    q_layout = tkl.MemoryLayout(shape=q_shape)
+    k_layout = tkl.MemoryLayout(shape=k_shape)
+    v_layout = tkl.MemoryLayout(shape=v_shape)
+    o_layout = tkl.MemoryLayout(shape=o_shape)
+
+    @tkw.wave(constraints)
+    def prefill_attention(
+        q: tkl.Memory[N_Q, H, D_Q, GLOBAL_ADDRESS_SPACE, tkl.f16, q_layout],
+        k: tkl.Memory[N_KV, H, D_Q, ADDRESS_SPACE, tkl.f16, k_layout],
+        v: tkl.Memory[H, D_KV, N_KV, ADDRESS_SPACE, tkl.f16, v_layout],
+        offsets: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        sequence_lengths: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, tkl.f32, o_layout],
+    ):
+        c_reg = tkl.Register[H, D_KV, N_Q, tkl.f32](0.0)
+        init_sum = tkl.Register[H, N_Q, tkl.f32](0.0)
+        init_max = tkl.Register[H, N_Q, tkl.f32](-1e6)
+
+        start = tkw.read(offsets, elements_per_thread=1)
+        tkw.set_symbol(OFFSET, start)
+        seq_len = tkw.read(sequence_lengths, elements_per_thread=1)
+        tkw.set_symbol(N_Q, seq_len)
+        tkw.set_symbol(N_KV, seq_len)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[H, N_Q, tkl.f32],
+            partial_sum: tkl.Register[H, N_Q, tkl.f32],
+            acc: tkl.Register[H, D_KV, N_Q, tkl.f32],
+        ):
+            imm_reg = tkl.Register[H, N_KV, N_Q, tkl.f32](0.0)
+            q_reg = tkw.read(
+                q,
+                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
+                mapping=q_mapping,
+            )
+            k_reg = tkw.read(
+                k,
+                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
+                mapping=k_mapping,
+            )
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
+            x_j = tkw.permute(inner_acc, target_shape=[H, N_Q, N_KV])
+            m_j = tkw.max(x_j, partial_max, dim=N_KV)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=N_KV)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(
+                v,
+                elements_per_thread=LOAD_ELEMS_PER_THREAD_PV,
+                mapping=v_mapping,
+            )
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
+        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD_QK: get_mfma_load_elems_per_thread(mfma_variant[0]),
+        LOAD_ELEMS_PER_THREAD_PV: get_mfma_load_elems_per_thread(mfma_variant[1]),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant[1]),
+        BLOCK_H: 1,
+        BLOCK_N_Q: SEQ_TILE_SIZE,
+        BLOCK_D_KV: SEQ_TILE_SIZE,
+        BLOCK_N_KV: SEQ_TILE_SIZE,
+        BLOCK_S: 1,
+        H: shape.num_query_heads,
+        D_KV: shape.head_size_kv,
+        D_Q: shape.head_size,
+        S: shape.num_seqs,
+    }
+
+    return prefill_attention, hyperparams

--- a/iree/turbine/kernel/wave/templates/vanilla_attention.py
+++ b/iree/turbine/kernel/wave/templates/vanilla_attention.py
@@ -1,0 +1,147 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.utils import (
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+)
+from .attention_common import AttentionShape
+from dataclasses import dataclass
+
+
+def get_vanilla_attention_kernel(
+    shape: AttentionShape, mfma_variant: MMAType, dynamic_dims: bool
+):
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD_QK = index_symbol("LOAD_ELEMS_PER_THREAD_QK")
+    LOAD_ELEMS_PER_THREAD_PV = index_symbol("LOAD_ELEMS_PER_THREAD_PV")
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 1)]
+
+    if mfma_variant[1] == MMAType.F32_16x16x16_F16:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant[1] == MMAType.F32_32x32x8_F16:
+        Mvec = 32
+        Nvec = 32
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(4, 1, 1),
+            mma_type=mfma_variant[1],
+            vector_shapes={B: 0, M: Mvec, N: Nvec},
+        )
+    ]
+
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K2 > BLOCK_K2 * 4)]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    )
+
+    @tkw.wave(constraints)
+    def base_attention(
+        q: tkl.Memory[B, M, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, M, tkl.f32],
+            partial_sum: tkl.Register[B, M, tkl.f32],
+            acc: tkl.Register[B, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
+            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
+            m_j = tkw.max(x_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD_PV)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
+        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD_QK: get_mfma_load_elems_per_thread(mfma_variant[0]),
+        LOAD_ELEMS_PER_THREAD_PV: get_mfma_load_elems_per_thread(mfma_variant[1]),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant[1]),
+        BLOCK_B: 1,
+        BLOCK_M: 128,
+        BLOCK_N: 64,
+        BLOCK_K2: 64,
+        B: shape.num_query_heads,
+        M: shape.query_seq_len,
+        N: shape.head_size_kv,
+        K1: shape.head_size,
+        K2: shape.kv_seq_len,
+    }
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+    if dynamic_dims:
+        dynamic_symbols_map[M] = hyperparams[M]
+        dynamic_symbols_map[N] = hyperparams[N]
+        dynamic_symbols_map[B] = hyperparams[B]
+        dynamic_symbols_map[K2] = hyperparams[K2]
+        dynamic_symbols.append(M)
+        dynamic_symbols.append(N)
+        dynamic_symbols.append(B)
+        dynamic_symbols.append(K2)
+        del hyperparams[M]
+        del hyperparams[N]
+        del hyperparams[B]
+        del hyperparams[K2]
+
+    return base_attention, hyperparams, dynamic_symbols, dynamic_symbols_map

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1171,13 +1171,12 @@ def test_prefill_attention():
         # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-16:           vector.load
+        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-32:           vector.load
         # CHECK-COUNT-16:           amdgpu.mfma
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
-        # CHECK-COUNT-1:            vector.maskedload
-        # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-1:            vector.maskedload
-        # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-16:           vector.load
         # CHECK-COUNT-16:           amdgpu.mfma
         # CHECK-COUNT-16:      vector.maskedstore

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -18,6 +18,15 @@ from iree.turbine.kernel.wave.templates.paged_decode_attention import (
     get_paged_decode_attention_kernels,
     paged_decode_attention_shape,
 )
+from iree.turbine.kernel.wave.templates.prefill_attention import (
+    get_prefill_attention_kernel,
+)
+from iree.turbine.kernel.wave.templates.vanilla_attention import (
+    get_vanilla_attention_kernel,
+)
+from iree.turbine.kernel.wave.templates.attention_common import (
+    AttentionShape,
+)
 import torch
 import sympy
 import math
@@ -849,100 +858,18 @@ def test_dynamic_attention_32x32x8():
 
 @run_test
 def test_attention():
-    shape = (8, 128, 128, 64, 256)
-    # Expose user-constraints
-    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
-    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
-    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
-    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
-    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
-
-    mfma_variant = tkw.MMAType.F32_16x16x16_F16
-    constraints += [
-        tkw.HardwareConstraint(
-            threads_per_wave=64,
-            waves_per_block=(2, 2, 1),
-            mma_type=mfma_variant,
-            vector_shapes={B: 0, M: 16, N: 16},
-        )
-    ]
-
-    i = tkw.IndexMapping.iterator(0)
-    j = tkw.IndexMapping.iterator(1)
-    k = tkw.IndexMapping.iterator(2)
-    mapping = tkw.IndexMapping(
-        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    shape = AttentionShape(
+        num_query_heads=8,
+        num_kv_heads=8,
+        query_seq_len=128,
+        head_size_kv=128,
+        head_size=64,
+        kv_seq_len=256,
     )
-
-    @tkw.wave(constraints)
-    def base_attention(
-        q: tkl.Memory[B, M, K1, ADDRESS_SPACE, tkl.f16],
-        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
-        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
-        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
-    ):
-        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
-        init_sum = tkl.Register[B, M, tkl.f32](0.0)
-        init_max = tkl.Register[B, M, tkl.f32](-1e6)
-
-        # This microkernel encodes the fact that if the reduction
-        # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
-        def repeat(
-            partial_max: tkl.Register[B, M, tkl.f32],
-            partial_sum: tkl.Register[B, M, tkl.f32],
-            acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, N, M, tkl.f32],
-        ):
-            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
-            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-            # b_reg: tkw.Register[B, N, K, tkl.f16]
-            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-            # acc: tkw.Register[B, N, M, tkl.f32]
-            inner_acc = tkw.mma(k_reg, q_reg, imm_reg)
-            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
-            m_j = tkw.max(x_j, partial_max, dim=K2)
-            e_delta_max = tkw.exp2(partial_max - m_j)
-            e_delta = tkw.exp2(x_j - m_j)
-            e_init = partial_sum * e_delta_max
-            d_j = tkw.sum(e_delta, e_init, dim=K2)
-            imm_f16 = tkw.cast(e_delta, tkl.f16)
-            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD)
-            new_acc = acc * e_delta_max
-            acc = tkw.mma(v_reg, imm_f16, new_acc)
-            return m_j, d_j, acc
-
-        # repeat represents the results of the loop
-        res_max, res_sum, res_mm = repeat
-        res = res_mm / res_sum
-        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
-
-    hyperparams = {
-        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
-        LOAD_ELEMS_PER_THREAD: get_mfma_load_elems_per_thread(mfma_variant),
-        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant),
-        BLOCK_B: 1,
-        BLOCK_M: 64,
-        BLOCK_N: 64,
-        BLOCK_K2: 32,
-        B: shape[0],
-        M: shape[1],
-        N: shape[2],
-        K1: shape[3],
-        K2: shape[4],
-        READ_SHARED_DELAY: 1,
-        WRITE_SHARED_DELAY: 1,
-        READ_GLOBAL_DELAY: 2,
-        WRITE_GLOBAL_DELAY: 2,
-        MMA_DELAY: 1,
-        SHARED_MEMORY_UNITS: 4,
-        GLOBAL_MEMORY_UNITS: 4,
-        MMA_UNITS: 4,
-    }
+    mfma_variant = (tkw.MMAType.F32_16x16x16_F16,) * 2
+    base_attention, hyperparams, _, _ = get_vanilla_attention_kernel(
+        shape, mfma_variant, False
+    )
 
     with tk.gen.TestLaunchContext(
         hyperparams,
@@ -953,10 +880,27 @@ def test_attention():
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)
-        q = torch.randn(shape[0], shape[1], shape[3], dtype=torch.float16)
-        k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
-        v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
-        output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        q = torch.randn(
+            shape.num_query_heads,
+            shape.query_seq_len,
+            shape.head_size,
+            dtype=torch.float16,
+        )
+        k = torch.randn(
+            shape.num_kv_heads, shape.kv_seq_len, shape.head_size, dtype=torch.float16
+        )
+        v = torch.randn(
+            shape.num_kv_heads,
+            shape.kv_seq_len,
+            shape.head_size_kv,
+            dtype=torch.float16,
+        )
+        output = torch.zeros(
+            shape.num_query_heads,
+            shape.query_seq_len,
+            shape.head_size_kv,
+            dtype=torch.float32,
+        )
         print(base_attention(q, k, v, output).module_op)
 
         # CHECK-LABEL:       func.func @base_attention
@@ -1181,3 +1125,59 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-1:           arith.addf
     # CHECK-COUNT-1:      arith.divf
     # CHECK-COUNT-1:      vector.store
+
+
+@run_test
+def test_prefill_attention():
+    shape = AttentionShape(
+        num_query_heads=16,
+        num_kv_heads=4,
+        head_size=64,
+        head_size_kv=64,
+        num_seqs=2,
+        max_seq_len=12,
+        total_seq_len=20,
+    )
+    q_shape = (shape.total_seq_len, shape.num_query_heads, shape.head_size)
+    k_shape = (shape.total_seq_len, shape.num_kv_heads, shape.head_size)
+    v_shape = (shape.total_seq_len, shape.num_kv_heads, shape.head_size_kv)
+    o_shape = (shape.total_seq_len, shape.num_query_heads, shape.head_size_kv)
+    mfma_variant = (tkw.MMAType.F32_16x16x16_F16,) * 2
+    prefill_attention, hyperparams = get_prefill_attention_kernel(
+        shape, mfma_variant, q_shape, k_shape, v_shape, o_shape
+    )
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=False,
+        run_bench=False,
+        schedule=False,
+        use_scheduling_barriers=False,
+    ):
+        torch.manual_seed(0)
+        q = torch.randn(q_shape, dtype=torch.float16)
+        k = torch.randn(k_shape, dtype=torch.float16)
+        v = torch.randn(v_shape, dtype=torch.float16)
+        output = torch.zeros(o_shape, dtype=torch.float32)
+        offsets = torch.ones(shape.num_seqs, dtype=torch.int32)
+        seq_lens = torch.ones(shape.num_seqs, dtype=torch.int32)
+        print(prefill_attention(q, k, v, offsets, seq_lens, output).module_op)
+
+        # CHECK-LABEL:       func.func @prefill_attention
+        # CHECK-COUNT-4:        vector.maskedload
+        # CHECK:                scf.for
+        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-16:           vector.load
+        # CHECK-COUNT-16:           amdgpu.mfma
+        # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
+        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-16:           vector.load
+        # CHECK-COUNT-16:           amdgpu.mfma
+        # CHECK-COUNT-16:      vector.maskedstore

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -314,4 +314,4 @@ def testPagedFlashDecoding(
     else:
         ref_vllm_output = torch.load(os.path.join(artifact_directory, "output.pt"))
 
-    assert_close(output, ref_vllm_output, rtol=1e-3, atol=1e-3, check_dtype=False)
+    assert_close(output, ref_vllm_output, rtol=1e-3, atol=1e-3)

--- a/tests/kernel/wave/attention/prefill_attention_test.py
+++ b/tests/kernel/wave/attention/prefill_attention_test.py
@@ -1,0 +1,182 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import torch
+import math
+import iree.turbine.kernel as tk
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.utils import (
+    get_default_run_config,
+    get_default_scheduling_params,
+    device_arange,
+    device_full,
+    device_randn,
+    device_zeros,
+)
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.templates.prefill_attention import (
+    get_prefill_attention_kernel,
+)
+from iree.turbine.kernel.wave.templates.attention_common import (
+    AttentionShape,
+)
+import os
+from torch.testing import assert_close
+from ..common.utils import (
+    require_e2e,
+    require_cdna3,
+    enable_scheduling_barriers,
+    dump_generated_mlir,
+)
+from ..common.shapes import get_test_shapes
+from typing import List, Optional
+
+# Reference paged attention implementation from vLLM and sglang.
+# (NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, SEQ_LENS)
+shapes = [(4, 1, 64, 64, (128, 256))]
+
+
+# From: https://github.com/sgl-project/sglang/blob/main/test/srt/test_triton_attention_kernels.py
+def validate_accuracy(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    seq_lens: List[int],
+    causal: bool,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    cu_seq_lens = [0] * (len(seq_lens) + 1)
+    for i, seq_len in enumerate(seq_lens):
+        cu_seq_lens[i + 1] = cu_seq_lens[i] + seq_len
+
+    for i in range(len(seq_lens)):
+        start, end = cu_seq_lens[i], cu_seq_lens[i + 1]
+        o_torch = torch.nn.functional.scaled_dot_product_attention(
+            query[start:end].permute(1, 0, 2),
+            key[start:end].permute(1, 0, 2),
+            value[start:end].permute(1, 0, 2),
+            is_causal=causal,
+        ).permute(1, 0, 2)
+        assert_close(
+            output[start:end], o_torch, check_dtype=False, rtol=1e-3, atol=1e-3
+        )
+
+    return o_torch
+
+
+def create_inputs(
+    shape: AttentionShape,
+    seq_lens: tuple[int],
+    dtype: torch.dtype,
+):
+    query = device_randn(
+        shape.total_seq_len, shape.num_query_heads, shape.head_size, dtype=dtype
+    )
+    key = device_randn(
+        shape.total_seq_len, shape.num_kv_heads, shape.head_size, dtype=dtype
+    )
+    value = device_randn(
+        shape.total_seq_len, shape.num_kv_heads, shape.head_size, dtype=dtype
+    )
+    start_offsets = [0]
+    for seq in seq_lens[:-1]:
+        start_offsets.append(start_offsets[-1] + seq)
+    start_offsets = torch.tensor(start_offsets, device=value.device, dtype=torch.int32)
+    seq_lens = torch.tensor(seq_lens, device=value.device, dtype=torch.int32)
+    return (query, key, value, start_offsets, seq_lens)
+
+
+# TODO: Investigate errors on MI250.
+@require_e2e
+@require_cdna3
+@pytest.mark.parametrize("shape", shapes)
+@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("enable_scheduling", [False])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [(MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16)],
+)
+def testPrefillAttention(
+    shape: tuple[int],
+    dtype: torch.dtype,
+    enable_scheduling: bool,
+    mfma_variant: MMAType,
+    request,
+):
+
+    torch.manual_seed(0)
+    seq_lens = shape[4]
+    shape = AttentionShape(
+        num_query_heads=shape[0],
+        num_kv_heads=shape[1],
+        head_size=shape[2],
+        head_size_kv=shape[3],
+        num_seqs=len(seq_lens),
+        max_seq_len=max(seq_lens),
+        total_seq_len=sum(seq_lens),
+    )
+    assert shape.num_query_heads % shape.num_kv_heads == 0
+
+    (query, key, value, start_offsets, seq_lens) = create_inputs(shape, seq_lens, dtype)
+
+    output_shape = (shape.total_seq_len, shape.num_query_heads, shape.head_size_kv)
+    permuted_value = value.permute(1, 2, 0)
+    # Run the wave kernel.
+    (prefill, hyperparams) = get_prefill_attention_kernel(
+        shape,
+        mfma_variant,
+        query.shape,
+        key.shape,
+        permuted_value.shape,
+        output_shape,
+    )
+
+    hyperparams.update(get_default_scheduling_params())
+    config = get_default_run_config()
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    log2e = 1.44269504089
+    dk_sqrt = math.sqrt(1.0 / shape.head_size)
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+    ):
+        # TODO: Add scaling of QK as part of kernel.
+        # TODO: Add variant of non-transposed V attention kernel.
+        output = device_zeros(output_shape, dtype=torch.float32)
+        mb = prefill(
+            query * dk_sqrt * log2e,
+            key,
+            permuted_value,
+            start_offsets,
+            seq_lens,
+            output,
+        )
+
+        validate_accuracy(
+            query=query,
+            key=key,
+            value=value,
+            seq_lens=seq_lens,
+            causal=False,
+            output=output,
+        )

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -30,6 +30,10 @@ from ..common.utils import (
     dump_generated_mlir,
 )
 from ..common.shapes import get_test_shapes
+from iree.turbine.kernel.wave.templates.vanilla_attention import (
+    get_vanilla_attention_kernel,
+)
+from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
 
 
 @require_e2e
@@ -54,120 +58,24 @@ def testAttention(
 ):
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")
-    # Input sizes
-    B = tkl.sym.B
-    M = tkl.sym.M
-    N = tkl.sym.N
-    K1 = tkl.sym.K1
-    K2 = tkl.sym.K2
-    # Workgroup tile sizes
-    BLOCK_B = tkl.sym.BLOCK_B
-    BLOCK_M = tkl.sym.BLOCK_M
-    BLOCK_N = tkl.sym.BLOCK_N
-    BLOCK_K2 = tkl.sym.BLOCK_K2
-    # Address space (for GPU, shared(1) or global(0))
-    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
-    # Other hyperparameters
-    LOAD_ELEMS_PER_THREAD_QK = index_symbol("LOAD_ELEMS_PER_THREAD_QK")
-    LOAD_ELEMS_PER_THREAD_PV = index_symbol("LOAD_ELEMS_PER_THREAD_PV")
-    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
-
-    # Expose user-constraints
-    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
-    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
-    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
-    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
-    constraints += [tkw.WaveConstraint(N, BLOCK_N / 1)]
-
-    if mfma_variant[1] == MMAType.F32_16x16x16_F16:
-        Mvec = 16
-        Nvec = 16
-    if mfma_variant[1] == MMAType.F32_32x32x8_F16:
-        Mvec = 32
-        Nvec = 32
-
-    constraints += [
-        tkw.HardwareConstraint(
-            threads_per_wave=64,
-            waves_per_block=(4, 1, 1),
-            mma_type=mfma_variant[1],
-            vector_shapes={B: 0, M: Mvec, N: Nvec},
-        )
-    ]
-
-    if dynamic_dims:
-        constraints += [tkw.Assumption(K2 > BLOCK_K2 * 4)]
-
-    i = tkw.IndexMapping.iterator(0)
-    j = tkw.IndexMapping.iterator(1)
-    k = tkw.IndexMapping.iterator(2)
-    mapping = tkw.IndexMapping(
-        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    shape = AttentionShape(
+        num_query_heads=shape[0],
+        num_kv_heads=shape[0],
+        query_seq_len=shape[1],
+        head_size_kv=shape[2],
+        head_size=shape[3],
+        kv_seq_len=shape[4],
     )
-
-    @tkw.wave(constraints)
-    def base_attention(
-        q: tkl.Memory[B, M, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
-        k: tkl.Memory[B, K2, K1, ADDRESS_SPACE, tkl.f16],
-        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
-        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
-    ):
-        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
-        init_sum = tkl.Register[B, M, tkl.f32](0.0)
-        init_max = tkl.Register[B, M, tkl.f32](-1e6)
-
-        # This microkernel encodes the fact that if the reduction
-        # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
-        def repeat(
-            partial_max: tkl.Register[B, M, tkl.f32],
-            partial_sum: tkl.Register[B, M, tkl.f32],
-            acc: tkl.Register[B, N, M, tkl.f32],
-        ) -> (
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, M, tkl.f32],
-            tkl.Register[B, N, M, tkl.f32],
-        ):
-            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
-            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
-            # b_reg: tkw.Register[B, N, K, tkl.f16]
-            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
-            # acc: tkw.Register[B, N, M, tkl.f32]
-            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
-            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
-            m_j = tkw.max(x_j, partial_max, dim=K2)
-            e_delta_max = tkw.exp2(partial_max - m_j)
-            e_delta = tkw.exp2(x_j - m_j)
-            e_init = partial_sum * e_delta_max
-            d_j = tkw.sum(e_delta, e_init, dim=K2)
-            imm_f16 = tkw.cast(e_delta, tkl.f16)
-            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD_PV)
-            new_acc = acc * e_delta_max
-            acc = tkw.mma(v_reg, imm_f16, new_acc)
-            return m_j, d_j, acc
-
-        # repeat represents the results of the loop
-        res_max, res_sum, res_mm = repeat
-        reciprocal_sum = tkw.reciprocal(res_sum)
-        res = res_mm * reciprocal_sum
-        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
-
-    hyperparams = {
-        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
-        LOAD_ELEMS_PER_THREAD_QK: get_mfma_load_elems_per_thread(mfma_variant[0]),
-        LOAD_ELEMS_PER_THREAD_PV: get_mfma_load_elems_per_thread(mfma_variant[1]),
-        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant[1]),
-        BLOCK_B: 1,
-        BLOCK_M: 128,
-        BLOCK_N: 64,
-        BLOCK_K2: 64,
-        B: shape[0],
-        M: shape[1],
-        N: shape[2],
-        K1: shape[3],
-        K2: shape[4],
-    }
+    (
+        base_attention,
+        hyperparams,
+        dynamic_symbols,
+        dynamic_symbols_map,
+    ) = get_vanilla_attention_kernel(shape, mfma_variant, dynamic_dims)
+    q_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size)
+    k_shape = (shape.num_kv_heads, shape.kv_seq_len, shape.head_size)
+    v_shape = (shape.num_kv_heads, shape.kv_seq_len, shape.head_size_kv)
+    o_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
     hyperparams.update(get_default_scheduling_params())
     config = get_default_run_config()
     if run_bench:
@@ -179,23 +87,6 @@ def testAttention(
             dump_perf, "tk_" + perf_filename
         )
     compile_config = {"waves_per_eu": 2, "denorm_fp_math_f32": "preserve-sign"}
-
-    dynamic_symbols = []
-    dynamic_symbols_map = {}
-    if dynamic_dims:
-        dynamic_symbols_map[M] = hyperparams[M]
-        dynamic_symbols_map[N] = hyperparams[N]
-        dynamic_symbols_map[B] = hyperparams[B]
-        dynamic_symbols_map[K2] = hyperparams[K2]
-        dynamic_symbols.append(M)
-        dynamic_symbols.append(N)
-        dynamic_symbols.append(B)
-        dynamic_symbols.append(K2)
-        del hyperparams[M]
-        del hyperparams[N]
-        del hyperparams[B]
-        del hyperparams[K2]
-
     with tk.gen.TestLaunchContext(
         hyperparams,
         canonicalize=True,
@@ -209,12 +100,12 @@ def testAttention(
         dynamic_symbols_map=dynamic_symbols_map,
     ):
         torch.manual_seed(0)
-        q = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
-        k = device_randn(shape[0], shape[4], shape[3], dtype=torch.float16)
-        v = device_randn(shape[0], shape[4], shape[2], dtype=torch.float16)
-        output = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+        q = device_randn(q_shape, dtype=torch.float16)
+        k = device_randn(k_shape, dtype=torch.float16)
+        v = device_randn(v_shape, dtype=torch.float16)
+        output = device_zeros(o_shape, dtype=torch.float32)
         log2e = 1.44269504089
-        dk_sqrt = math.sqrt(1.0 / shape[3])
+        dk_sqrt = math.sqrt(1.0 / shape.head_size)
         # TODO: Add scaling of QK as part of kernel.
         # TODO: Add variant of non-transposed V attention kernel.
         mb = base_attention(q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output)


### PR DESCRIPTION
This PR adds an implementation of prefill attention. In prefill attention, we have variable length sequences and so we need to pass in the start offsets as well as the lengths of the sequences. The setting of the offsets and variable sequence lengths is accomplished using set_symbol.

Also, this PR adds the ability to specify the total count for a work group constraint and adds attention cleanups.