### PR TITLE
[TKW] Fixes for `@conditional` and paged attention

### DIFF
--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -24,6 +24,7 @@ from .indexing import (
     IndexSymbol,
     IndexingContext,
 )
+import sympy
 
 from ..lang.kernel_buffer import KernelBuffer
 from ..lang.grid import Grid
@@ -108,7 +109,7 @@ class KernelTracer(SubgraphTracer):
 
     def create_arg(self, a):
         # Let IndexExpr persist as arguments.
-        if isinstance(a, IndexExpr):
+        if isinstance(a, sympy.Basic):
             return a
         # Let DataType persist as arguments.
         if isinstance(a, DataType):

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -856,10 +856,7 @@ class Placeholder(CustomOp):
             if custom.get_captured_fx_node(subgraph, var):
                 live_captures.append(var)
 
-        if len(live_captures) != len(custom.implicit_captures):
-            print("live_captures", custom.implicit_captures, live_captures)
         custom.update_arg("implicit_captures", live_captures)
-        print(get_custom(parent).implicit_captures)
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1182,6 +1182,16 @@ class NestedRegionOp(CustomOp):
                 captured_vars.append(nested_node)
         return captured_vars
 
+    def get_captured_fx_node(
+        self, graph: fx.Graph, outer_node: fx.Node
+    ) -> Optional[fx.Node]:
+        for var in self.captured_vars(graph):
+            custom = get_custom(var)
+            if custom.get_captured_fx_node() == outer_node:
+                return var
+
+        return None
+
 
 @define_op("conditional")
 @dataclass

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -74,7 +74,9 @@ def read(
     ...
 
 
-def conditional(condition: "Register") -> Callable[[Callable[[], None]], None]:
+def conditional(
+    condition: "Register" | IndexExpr,
+) -> Callable[[Callable[[], None]], None]:
     ...
 
 
@@ -1228,7 +1230,7 @@ class NestedRegionOp(CustomOp):
 @define_op("conditional")
 @dataclass
 class Conditional(NestedRegionOp):
-    condition: fx.Proxy
+    condition: fx.Proxy | IndexExpr
     subgraph_name: str
     implicit_captures: Sequence[fx.Proxy]
 
@@ -1254,7 +1256,10 @@ class Conditional(NestedRegionOp):
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:
-        return get_custom(self.condition).indexing_dims
+        if isinstance(self.condition, fx.Node):
+            return get_custom(self.condition).indexing_dims
+
+        return []
 
 
 @define_op("reduction")

--- a/iree/turbine/kernel/wave/codegen.py
+++ b/iree/turbine/kernel/wave/codegen.py
@@ -1326,8 +1326,11 @@ def handle_conditional(emitter: WaveEmitter, node: fx.Node):
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
 
-    condition = cast_vector(emitter, condition)
-    condition = _to_scalar(condition)
+    if isinstance(condition, sympy.Basic):
+        condition = gen_sympy_index(add_emitter_subs(emitter), condition)
+    else:
+        condition = cast_vector(emitter, condition)
+        condition = _to_scalar(condition)
 
     cond_type = condition.type
     assert IntegerType.isinstance(

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -630,7 +630,6 @@ def should_update_index(
     source_vector_shapes: dict[IndexSymbol, int],
     symbolic_constraints: list[SymbolicAlias],
 ):
-    # print("should_update_index", source)
     # Get symbolic shape without any aliased variables.
     aliased_dims = [x.source for x in symbolic_constraints]
     symbolic_shape = set(source.type.symbolic_shape).difference(aliased_dims)
@@ -638,7 +637,6 @@ def should_update_index(
     # If all the source indexing dimensions are not present in source vector shapes,
     # we should not update the index.
     if not set(symbolic_shape).issubset(set(source_vector_shapes.keys())):
-        print("fail 1")
         return False
 
     # Determine if we should update the idx based on the source.
@@ -649,12 +647,10 @@ def should_update_index(
     # If the source index is smaller than the non-batch dims, check if the
     # source index is a subset of the non-batch dims.
     if len(source_index.keys()) < len(non_batch_dims):
-        print("fail 2", set(source_index.keys()).issubset(set(non_batch_dims)))
         return set(source_index.keys()).issubset(set(non_batch_dims))
 
     # Otherwise, check if the non-batch dims are a subset of the source index.
     if not set(non_batch_dims).issubset(set(source_index.keys())):
-        print("fail 3")
         return False
 
     return True
@@ -707,8 +703,6 @@ def propagate_index(
             source_index = source.transform_index(source_index)
             source.index = combine_indices(source.index, source_index)
             source.vector_shapes = source_vector_shapes
-            # print("  source.index",source.index)
-            # print("  source.vector_shapes", source.vector_shapes)
             append_aliased_shapes(source, symbolic_constraints)
         visited.add(source)
         for func in [get_inputs, get_users]:

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -630,6 +630,7 @@ def should_update_index(
     source_vector_shapes: dict[IndexSymbol, int],
     symbolic_constraints: list[SymbolicAlias],
 ):
+    # print("should_update_index", source)
     # Get symbolic shape without any aliased variables.
     aliased_dims = [x.source for x in symbolic_constraints]
     symbolic_shape = set(source.type.symbolic_shape).difference(aliased_dims)
@@ -637,6 +638,7 @@ def should_update_index(
     # If all the source indexing dimensions are not present in source vector shapes,
     # we should not update the index.
     if not set(symbolic_shape).issubset(set(source_vector_shapes.keys())):
+        print("fail 1")
         return False
 
     # Determine if we should update the idx based on the source.
@@ -647,10 +649,12 @@ def should_update_index(
     # If the source index is smaller than the non-batch dims, check if the
     # source index is a subset of the non-batch dims.
     if len(source_index.keys()) < len(non_batch_dims):
+        print("fail 2", set(source_index.keys()).issubset(set(non_batch_dims)))
         return set(source_index.keys()).issubset(set(non_batch_dims))
 
     # Otherwise, check if the non-batch dims are a subset of the source index.
     if not set(non_batch_dims).issubset(set(source_index.keys())):
+        print("fail 3")
         return False
 
     return True
@@ -703,6 +707,8 @@ def propagate_index(
             source_index = source.transform_index(source_index)
             source.index = combine_indices(source.index, source_index)
             source.vector_shapes = source_vector_shapes
+            # print("  source.index",source.index)
+            # print("  source.vector_shapes", source.vector_shapes)
             append_aliased_shapes(source, symbolic_constraints)
         visited.add(source)
         for func in [get_inputs, get_users]:

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -278,12 +278,13 @@ def get_paged_decode_attention_kernels(
             return m_j, d_j, acc
 
         res_max, res_sum, res_mm = loop
-        reciprocal_sum = tkw.reciprocal(res_sum)
-        res = res_mm * reciprocal_sum
-        res_max_log_sum = res_max + tkw.log2(res_sum)
 
         @tkw.conditional(iter_count > 0)
         def then():
+            reciprocal_sum = tkw.reciprocal(res_sum)
+            res = res_mm * reciprocal_sum
+            res_max_log_sum = res_max + tkw.log2(res_sum)
+
             tkw.write(res_max_log_sum, output_max, elements_per_thread=1)
             tkw.write(res, output, elements_per_thread=STORE_ELEMS_PER_THREAD)
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -206,6 +206,7 @@ def DCE(trace: CapturedTrace):
 
     def is_removable_operator(node: fx.Node) -> bool:
         custom = get_custom(node)
+
         if (
             custom.users
             or isinstance(custom, (Output, SetSymbol, ApplyExpr))
@@ -220,7 +221,7 @@ def DCE(trace: CapturedTrace):
 
     while removable_nodes := trace.walk(is_removable_operator):
         for node in removable_nodes:
-            get_custom(node).graph.erase_node(node)
+            get_custom(node).erase()
 
 
 def remove_chained_getresult(trace: CapturedTrace):

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -852,7 +852,8 @@ def get_users(
                 subgraph = custom.graph.subgraphs[custom.subgraph_name]
                 var = custom.get_captured_fx_node(subgraph, node)
                 assert var is not None, "Invalid captured var"
-                users.append(var)
+                for u in var.users:
+                    users.append(u)
 
             continue
 

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -17,19 +17,22 @@ from .._support.tracing import CapturedTrace
 from .._support.indexing import IndexExpr, IndexingContext, IndexSymbol, IndexSequence
 from ..lang.global_symbols import *
 from ..ops.wave_ops import (
-    get_custom,
-    Output,
-    Write,
-    MMA,
-    CustomOp,
-    Reduction,
-    GetResult,
-    ExtractSlice,
-    IterArg,
-    Reshape,
-    Read,
-    SetSymbol,
     ApplyExpr,
+    Conditional,
+    CustomOp,
+    ExtractSlice,
+    GetResult,
+    IterArg,
+    MMA,
+    NestedRegionOp,
+    Output,
+    Placeholder,
+    Read,
+    Reduction,
+    Reshape,
+    SetSymbol,
+    Write,
+    get_custom,
 )
 from ..lang.wave_types import IndexMapping
 from .constraints import (
@@ -182,20 +185,38 @@ def DCE(trace: CapturedTrace):
     Repeats this process till no more operators can be removed.
     """
 
-    def is_removable_operator(node: fx.Node) -> bool:
+    def is_global_write(node: fx.Node) -> bool:
         custom = get_custom(node)
-        idxc = IndexingContext.current()
-        is_global_write = isinstance(custom, Write) and (
-            custom.type.address_space.subs(idxc.subs) == GLOBAL_ADDRESS_SPACE
-            or custom.type.address_space.subs(idxc.subs)
-            == tkl.AddressSpace.GLOBAL_MEMORY.value
+        return isinstance(custom, Write) and (
+            subs_idxc(custom.type.address_space)
+            in [GLOBAL_ADDRESS_SPACE, tkl.AddressSpace.GLOBAL_MEMORY.value]
         )
 
-        return (
-            not custom.users
-            and not isinstance(custom, (Output, SetSymbol, ApplyExpr))
-            and not is_global_write
-        )
+    def has_nested_writes(node: fx.Node) -> bool:
+        custom = get_custom(node)
+        if not isinstance(custom, NestedRegionOp):
+            return False
+
+        subgraph = custom.graph.subgraphs[custom.subgraph_name]
+        for node in subgraph.nodes:
+            if is_global_write(node) or has_nested_writes(node):
+                return True
+
+        return False
+
+    def is_removable_operator(node: fx.Node) -> bool:
+        custom = get_custom(node)
+        if (
+            custom.users
+            or isinstance(custom, (Output, SetSymbol, ApplyExpr))
+            or is_global_write(node)
+        ):
+            return False
+
+        if has_nested_writes(node):
+            return False
+
+        return True
 
     while removable_nodes := trace.walk(is_removable_operator):
         for node in removable_nodes:
@@ -824,6 +845,17 @@ def get_users(
                 if output_idx in get_results:
                     users.append(get_results[output_idx])
             continue
+        if isinstance(custom, Conditional):
+            if node == custom.condition:
+                users.append(user)
+            else:
+                subgraph = custom.graph.subgraphs[custom.subgraph_name]
+                var = custom.get_captured_fx_node(subgraph, node)
+                assert var is not None, "Invalid captured var"
+                users.append(var)
+
+            continue
+
         users.append(user)
     return users, reduction
 
@@ -863,6 +895,17 @@ def get_inputs(
         # Default handling for other ops.
         for input in node.all_input_nodes:
             inputs.append(input)
+
+    def propagate(n):
+        c = get_custom(n)
+        if isinstance(c, Placeholder):
+            p = c.get_captured_fx_node()
+            if p is not None:
+                return p
+
+        return n
+
+    inputs = [propagate(i) for i in inputs]
     return inputs, reduction
 
 

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1154,11 +1154,11 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-8:                vector.store
     # CHECK-COUNT-8:                vector.load
     # CHECK-COUNT-8:                amdgpu.mfma
-    # CHECK-COUNT-1:          arith.divf
-    # CHECK-COUNT-1:          math.log2
     # CHECK:                  %[[C1:.*]] = arith.cmpi sgt, %[[COUNT]], %[[C0]] : index
     # CHECK:                  %[[C2:.*]] = arith.cmpi ne, %[[C1]], %[[FALSE]] : i1
     # CHECK:                  scf.if %[[C2]] {
+    # CHECK-COUNT-1:          arith.divf
+    # CHECK-COUNT-1:          math.log2
     # CHECK-COUNT-9:         vector.store
 
     with tk.gen.TestLaunchContext(

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1134,8 +1134,11 @@ def test_paged_flash_decoding():
         print(phase_0(q, k, v, logits, logits_max).module_op)
 
     # CHECK:                func.func @phase_0
+    # CHECK-DAG:               %[[C0:.*]] = arith.constant 0 : index
+    # CHECK-DAG:               %[[C1:.*]] = arith.constant 1 : index
+    # CHECK-DAG:               %[[FALSE:.*]] = arith.constant false
     # CHECK-COUNT-4:           vector.load
-    # CHECK:                   scf.for
+    # CHECK:                   scf.for %{{.*}} = %[[C0]] to %[[COUNT:.*]] step %[[C1]]
     # CHECK-COUNT-3:                vector.maskedload
     # CHECK-COUNT-8:                vector.store
     # CHECK-COUNT-8:                vector.load
@@ -1153,6 +1156,9 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-8:                amdgpu.mfma
     # CHECK-COUNT-1:          arith.divf
     # CHECK-COUNT-1:          math.log2
+    # CHECK:                  %[[C1:.*]] = arith.cmpi sgt, %[[COUNT]], %[[C0]] : index
+    # CHECK:                  %[[C2:.*]] = arith.cmpi ne, %[[C1]], %[[FALSE]] : i1
+    # CHECK:                  scf.if %[[C2]] {
     # CHECK-COUNT-9:         vector.store
 
     with tk.gen.TestLaunchContext(

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -314,4 +314,4 @@ def testPagedFlashDecoding(
     else:
         ref_vllm_output = torch.load(os.path.join(artifact_directory, "output.pt"))
 
-    assert_close(output, ref_vllm_output.to(torch.float32), rtol=1e-3, atol=1e-3)
+    assert_close(output, ref_vllm_output, rtol=1e-3, atol=1e-3, check_dtype=False)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -38,6 +38,7 @@ from typing import List, Optional
 shapes = [(16, 1, 64, 64, 32, 2, 100)]
 shapes += [(64, 1, 80, 80, 32, 2, 128)]
 shapes += [(128, 2, 80, 80, 32, 2, 500)]
+shapes += [(128, 2, 80, 80, 32, 2, 5)]
 
 
 def ref_paged_attn(

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -38,7 +38,6 @@ from typing import List, Optional
 shapes = [(16, 1, 64, 64, 32, 2, 100)]
 shapes += [(64, 1, 80, 80, 32, 2, 128)]
 shapes += [(128, 2, 80, 80, 32, 2, 500)]
-shapes += [(128, 2, 80, 80, 32, 2, 5)]
 
 
 def ref_paged_attn(


### PR DESCRIPTION
* Fix `proxy.create_arg` as `sympy.StrictlyLessThan` and friends are not subclass of sympy.Expr.
* It is now possible to directly use sympy expressions in `@conditional` arg.
* Fix `DCE` to not remove ops if they contain nested ops with side-effects (e.g. writes inside conditional).
* Update `get_users`/`get_inputs`/`node_args` ops to properly handle vars captured through placeholders.
* Update `CustomOp.erase` to cleanup dead captures when deleting placeholders.
* Update paged attention template.