### PR TITLE
Add functions that prepare tensors as input args for IREE tools

### DIFF
--- a/docs/core/support.rst
+++ b/docs/core/support.rst
@@ -13,6 +13,7 @@ conversions
 
 .. autofunction:: dtype_to_element_type
 .. autofunction:: torch_dtype_to_numpy
+.. autofunction:: torch_dtyped_shape_to_iree_format
 
 debugging
 --------------
@@ -30,3 +31,11 @@ logging
 
 .. autoclass:: DefaultFormatter
 .. autofunction:: get_logger
+
+tools
+--------------
+
+.. py:module:: iree.turbine.support.tools
+
+.. autofunction:: iree_tool_format_cli_input_arg
+.. autofunction:: iree_tool_prepare_input_args

--- a/iree/turbine/support/tools.py
+++ b/iree/turbine/support/tools.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+from typing import Collection, Iterable
+from os import PathLike
+
+from .conversions import torch_dtyped_shape_to_iree_format
+
+
+def iree_tool_format_cli_input_arg(arg: torch.Tensor, file_path: str | PathLike) -> str:
+    """Format the CLI value for an input argument.
+    Example:
+    iree_tool_format_cli_input_arg(torch.empty([1,2], dtype=torch.float32), "arg0.bin")
+    Returns:
+    "1x2xf32=@arg0.bin"
+    """
+    return f"{torch_dtyped_shape_to_iree_format(arg)}=@{file_path}"
+
+
+def write_raw_tensor(tensor: torch.Tensor, file_path: str | PathLike):
+    """Write the contents of the tensor as they are in memory without any metadata."""
+    with open(file_path, "wb") as f:
+        f.write(tensor.cpu().view(dtype=torch.int8).numpy().data)
+
+
+def iree_tool_prepare_input_args(
+    args: Collection[torch.Tensor],
+    /,
+    *,
+    file_paths: Iterable[str | PathLike] | None = None,
+    file_path_prefix: str | PathLike | None = None,
+) -> list[str]:
+    """Write the raw contents of tensors to files without any metadata.
+    Returns the CLI input args description.
+
+    If file_path_prefix is given, will chose a default naming for argument files.
+    It is treated as a string prefix and not as directory.
+    Example:
+    ```
+    file_path_prefix="/some/path/arg"
+    ```
+
+    returns
+    ```
+    [
+        "1x2x3xf32=@/some/path/arg0.bin",
+        "4x5xi8=@/some/path/arg1.bin"
+    ]
+    ```
+
+    This results can be prefixed with "--input=" to arrive at the final CLI flags
+    expected by IREE tools.
+
+    Exactly one of file_paths and file_path_prefix must be provided.
+    Does not create parent directory(s).
+    """
+    if file_paths is not None and file_path_prefix is not None:
+        raise ValueError(
+            "file_paths and file_path_prefix are mutually exclusive arguments."
+        )
+    if file_paths is None and file_path_prefix is None:
+        raise ValueError("One of file_paths and file_path_prefix must be provided.")
+
+    if file_paths is None:
+        file_paths = [f"{file_path_prefix}{i}.bin" for i in range(len(args))]
+    for tensor, file_path in zip(args, file_paths, strict=True):
+        write_raw_tensor(tensor, file_path)
+    return [
+        iree_tool_format_cli_input_arg(tensor, file_path)
+        for tensor, file_path in zip(args, file_paths, strict=True)
+    ]

--- a/tests/support/conversions_test.py
+++ b/tests/support/conversions_test.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+import pytest
+from collections.abc import Sequence
+from iree.turbine.support.conversions import torch_dtyped_shape_to_iree_format
+
+
+@pytest.mark.parametrize(
+    "shape_or_tensor,dtype,expected",
+    [
+        [[1, 2, 3], torch.bfloat16, "1x2x3xbf16"],
+        # From tensor
+        [torch.empty([4, 5], dtype=torch.float32), None, "4x5xf32"],
+        # Zero-rank shape
+        [[], torch.float8_e4m3fn, "f8E4M3FN"],
+        # Tuple as shape
+        [(6,), torch.int8, "6xi8"],
+        # torch.Size as shape
+        [torch.Size([7, 8]), torch.quint8, "7x8xi8"],
+    ],
+)
+def test_torch_dtyped_shape_to_iree_format(
+    shape_or_tensor: Sequence[int] | torch.Tensor, dtype: torch.dtype, expected: str
+):
+    iree_format = torch_dtyped_shape_to_iree_format(shape_or_tensor, dtype)
+    assert iree_format == expected
+
+
+def test_torch_dtyped_shape_to_iree_format_missing_dtype():
+    with pytest.raises(ValueError):
+        torch_dtyped_shape_to_iree_format([1, 2], None)

--- a/tests/support/tools_test.py
+++ b/tests/support/tools_test.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+from iree.turbine.support.tools import iree_tool_prepare_input_args
+from pathlib import Path
+
+
+def test_iree_tool_prepare_input_args(tmp_path: Path):
+    arg0 = torch.tensor([1.1, 2.2, 3.3, 4.4], dtype=torch.bfloat16)
+    arg1 = torch.tensor([[4, 5], [6, 7]], dtype=torch.int8)
+    args = [arg0, arg1]
+    cli_arg_values = iree_tool_prepare_input_args(
+        args, file_path_prefix=tmp_path / "arg"
+    )
+
+    expected_arg_file_paths = [
+        tmp_path / "arg0.bin",
+        tmp_path / "arg1.bin",
+    ]
+
+    assert cli_arg_values[0] == f"4xbf16=@{expected_arg_file_paths[0]}"
+    assert cli_arg_values[1] == f"2x2xi8=@{expected_arg_file_paths[1]}"
+
+    for arg, file_path in zip(args, expected_arg_file_paths):
+        with open(file_path, "rb") as f:
+            actual_bytes = f.read()
+            assert arg.cpu().view(dtype=torch.int8).numpy().tobytes() == actual_bytes


### PR DESCRIPTION
One drawback of using npy files is that they don't support some datatypes.

This change adds functionality to prepare arguments from Torch tensors in the form
--input=1x2xbf16=@arg0.bin
These can then be passed to tools like iree-run-module and iree-benchmark-module.