### PR TITLE
Mark args as outputs if *any* user is a write

### DIFF
--- a/iree/turbine/kernel/compiler/kernel_codegen.py
+++ b/iree/turbine/kernel/compiler/kernel_codegen.py
@@ -281,10 +281,10 @@ class KernelSignature:
                 [isinstance(get_custom(x), Read) for x in get_users_recursive(node)]
             )
 
-        def only_write_dependencies(node):
+        def any_write_dependencies(node):
             if len(node.users) == 0:
                 return False
-            return all(
+            return any(
                 [isinstance(get_custom(x), Write) for x in get_users_recursive(node)]
             )
 
@@ -302,7 +302,7 @@ class KernelSignature:
             if only_read_dependencies(node):
                 usage = KernelBufferUsage.INPUT
 
-            if only_write_dependencies(node):
+            if any_write_dependencies(node):
                 usage = KernelBufferUsage.OUTPUT
 
             # Create new Memory type with the correct usage

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -499,7 +499,7 @@ def _inplace_invoke(vm_context, device, entry_function, inputs, outputs, dynamic
         else:
             raise ValueError(f"Unsupported input type: {type(input)}")
     for output in outputs:
-        if isinstance(input, torch.Tensor):
+        if isinstance(output, torch.Tensor):
             push_tensor_to_arg_list(output)
         else:
             raise ValueError(f"Unsupported output type: {type(output)}")

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -519,6 +519,61 @@ def test_offset_read_one(shape, request):
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_copy"))
+def test_read_write_same(shape, request):
+    run_bench = request.config.getoption("--runperf")
+    M = tkl.sym.M
+    N = tkl.sym.N
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Each workgroup works on single row of input data, and rows are further
+    # split into blocks of size up to 256. We have single wave per WG,
+    # and with default wave size of 64, each thread is operating on up to 4
+    # elements.
+    wave_size = 64
+    BLOCK_M = 1
+    # Tile size cannot be dynamic, so we use a fixed value here.
+    BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
+    ELEMS_PER_THREAD = BLOCK_N / wave_size
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: BLOCK_M, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    @tkw.wave(constraints)
+    def double(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+        double = res+res
+        tkw.write(double, a, elements_per_thread=ELEMS_PER_THREAD)
+
+    config = get_default_run_config()
+
+    a = device_randn(shape, dtype=torch.float16)
+    ref = a+a
+    with tk.gen.TestLaunchContext(
+        {
+            M: shape[0],
+            N: shape[1],
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+    ):
+        double(a)
+        assert_close(a, ref)
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_copy"))
 def test_set_symbol(shape, request):
     run_bench = request.config.getoption("--runperf")
     M = tkl.sym.M


### PR DESCRIPTION
Input arguments are marked as read-only. Therefore, if there's any write the argument has to be marked as an output.

This fixes most of the issues noted in https://github.com/iree-org/iree-turbine/issues/375 (reordering and removing arguments is still a problem).