### PR TITLE
Add print options to Wave pass pipeline

### DIFF
--- a/iree/turbine/kernel/compiler/kernel_codegen.py
+++ b/iree/turbine/kernel/compiler/kernel_codegen.py
@@ -320,11 +320,16 @@ class KernelSignature:
     def __repr__(self):
         parts = []
         for b in self.bindings:
-            part = repr(b.reference)
-            if b.name:
-                part = f"{b.name}: {part}"
-            parts.append(part)
-        return f"Signature({', '.join(parts)})"
+            name = b.name or repr(b.reference)
+
+            type_str = b.binding_type.name
+            if b.binding_type == BindingType.KERNEL_BUFFER:
+                type_str += f".{b.kernel_buffer_type.usage.name}.{b.kernel_buffer_type}"
+            elif b.binding_type == BindingType.SYMBOL_VALUE:
+                type_str += f".{b.symbol_type}"
+
+            parts.append(f"{name}: {type_str}")
+        return f"KernelSignature({', '.join(parts)})"
 
 
 class BoundKernelSignature(ABC):

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -158,7 +158,8 @@ def print_trace(trace: CapturedTrace, custom_print: bool = True):
     for name, subgraph in reversed(list(trace.region_graph.subgraphs.items())):
         if name == trace.root_graph:
             name = f"{name} [root]"
-        print(f"{name}:\n{subgraph}")
+        print(f"{name}:\n")
+        print_graph(subgraph)
         if custom_print:
             print("Custom format:")
             for node in subgraph.nodes:

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -153,9 +153,12 @@ def print_trace(trace: CapturedTrace, custom_print: bool = True):
     then using our custom node format.
     """
     # The root graph is at the back so we print the subgraphs in reverse order
-    for subgraph in reversed(list(trace.region_graph.subgraphs.values())):
-        print(subgraph)
+    for name, subgraph in reversed(list(trace.region_graph.subgraphs.items())):
+        if name == trace.root_graph:
+            name = f"{name} [root]"
+        print(f"{name}:\n{subgraph}")
         if custom_print:
+            print("Custom format:")
             for node in subgraph.nodes:
                 print(get_custom(node))
 
@@ -166,7 +169,6 @@ def print_subgraph(trace: CapturedTrace, subgraph_name: str, custom_print: bool 
     The graphs are printed first in the torch printing format and
     then using our custom node format.
     """
-    # The root graph is at the back so we print the subgraphs in reverse order
     for name, subgraph in trace.region_graph.subgraphs.items():
         if name == subgraph_name:
             print(subgraph)

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -3,6 +3,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import functools
+
 from ..compiler.ir import (
     builtin_d,
     InsertionPoint,
@@ -1433,3 +1435,10 @@ def initialize_iter_args(trace: CapturedTrace) -> None:
             if isinstance(custom, IterArg):
                 custom.iter_idx = count
                 count += 1
+
+
+def partial(func, *args, **kwargs):
+    """functools.partial but with function attributes copied to the partial function."""
+    partial_func = functools.partial(func, *args, **kwargs)
+    functools.update_wrapper(partial_func, func)
+    return partial_func

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -453,7 +453,7 @@ class LaunchableWave(Launchable):
         kernel_sig.add_grid(self.grid_type)
         kernel_sig.determine_input_output_buffers(root_graph)
         if compile_config.get("print_signature", False):
-            print(f"Kernel signature: {kernel_sig}")
+            print(kernel_sig)
 
         mb = builder.ModuleBuilder(context=context, module_op=module_op)
         entrypoint_name = self._name

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -729,29 +729,29 @@ def test_gemm_non_direct_acc():
         set_post_expansion_indices(graph, constraints)
         print_trace(graph)
         # CHECK: %add_M:0_N:0_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.add](args = (%exp2_M:0_N:0_K:0, %acc_M:0_N:0_K:0), kwargs = {})
+        # CHECK-SAME: [add](args = (%exp2_M:0_N:0_K:0, %acc_M:0_N:0_K:0), kwargs = {})
         # CHECK: %add_M:0_N:1_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.add](args = (%exp2_M:0_N:1_K:0, %acc_M:0_N:1_K:0), kwargs = {})
+        # CHECK-SAME: [add](args = (%exp2_M:0_N:1_K:0, %acc_M:0_N:1_K:0), kwargs = {})
         # CHECK: %add_M:1_N:0_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.add](args = (%exp2_M:1_N:0_K:0, %acc_M:1_N:0_K:0), kwargs = {})
+        # CHECK-SAME: [add](args = (%exp2_M:1_N:0_K:0, %acc_M:1_N:0_K:0), kwargs = {})
         # CHECK: %add_M:1_N:1_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.add](args = (%exp2_M:1_N:1_K:0, %acc_M:1_N:1_K:0), kwargs = {})
+        # CHECK-SAME: [add](args = (%exp2_M:1_N:1_K:0, %acc_M:1_N:1_K:0), kwargs = {})
         # CHECK: %mma_M:0_N:0_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:0_N:0_K:0, %read_M:0_N:0_K:0, %add_M:0_N:0_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:0_N:0_K:0, %read_M:0_N:0_K:0, %add_M:0_N:0_K:0, None), kwargs = {})
         # CHECK: %mma_M:0_N:0_K:1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:0_N:0_K:1, %read_M:0_N:0_K:1, %mma_M:0_N:0_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:0_N:0_K:1, %read_M:0_N:0_K:1, %mma_M:0_N:0_K:0, None), kwargs = {})
         # CHECK: %mma_M:0_N:1_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:0_N:0_K:0, %read_M:0_N:1_K:0, %add_M:0_N:1_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:0_N:0_K:0, %read_M:0_N:1_K:0, %add_M:0_N:1_K:0, None), kwargs = {})
         # CHECK: %mma_M:0_N:1_K:1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:0_N:0_K:1, %read_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:0_N:0_K:1, %read_M:0_N:1_K:1, %mma_M:0_N:1_K:0, None), kwargs = {})
         # CHECK: %mma_M:1_N:0_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:1_N:0_K:0, %read_M:0_N:0_K:0, %add_M:1_N:0_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:1_N:0_K:0, %read_M:0_N:0_K:0, %add_M:1_N:0_K:0, None), kwargs = {})
         # CHECK: %mma_M:1_N:0_K:1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:1_N:0_K:1, %read_M:0_N:0_K:1, %mma_M:1_N:0_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:1_N:0_K:1, %read_M:0_N:0_K:1, %mma_M:1_N:0_K:0, None), kwargs = {})
         # CHECK: %mma_M:1_N:1_K:0
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:1_N:0_K:0, %read_M:0_N:1_K:0, %add_M:1_N:1_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:1_N:0_K:0, %read_M:0_N:1_K:0, %add_M:1_N:1_K:0, None), kwargs = {})
         # CHECK: %mma_M:1_N:1_K:1
-        # CHECK-SAME: call_function[target=iree.turbine.kernel.ops.wave_ops.mma](args = (%read_M:1_N:0_K:1, %read_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None), kwargs = {})
+        # CHECK-SAME: [mma](args = (%read_M:1_N:0_K:1, %read_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None), kwargs = {})
 
 
 @tkw.wave_trace_only()

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -94,7 +94,7 @@ def test_read_write_equal_sizes():
         # CHECK-SAME: (%read_M:1_N:1, %c, 4, None, ())
         # CHECK-NEXT: return
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=c
         # CHECK-NEXT: read(memory=a
@@ -172,7 +172,7 @@ def test_read_write():
         # CHECK-SAME: (%read_M:1_N:0_K:0, %c, 4, None, ())
         # CHECK-NEXT: return None
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=c
         # CHECK-NEXT: read(memory=a
@@ -246,7 +246,7 @@ def test_write_in_reduction():
         # CHECK: %write_M:0_K:0 :
         # CHECK-SAME: (%getresult_M:0_K:0, %c, 4,
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK: reduction(axis=K,
         # CHECK: get_result(value=reduction, res_idx=0)
         # CHECK: write(register_=getresult_M:0_K:0, memory=c, elements_per_thread=4,
@@ -262,7 +262,7 @@ def test_write_in_reduction():
         # CHECK: %write_M:0_K:1 :
         # CHECK-SAME: (%read_M:0_K:1, %b, 4,
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK: read(memory=a, elements_per_thread=4,
         # CHECK: read(memory=a, elements_per_thread=4,
         # CHECK: write(register_=read_M:0_K:0, memory=b, elements_per_thread=4,
@@ -326,6 +326,7 @@ def test_no_writes():
         # CHECK: %read :
         # CHECK-SAME: (args = (%a, 16, None, (), None), kwargs = {})
         # CHECK: return None
+        # CHECK: Custom format:
         # CHECK: placeholder(_name=a, _type=Memory[M, K].of(f16))
         # CHECK: read(memory=a, elements_per_thread=16
         # CHECK: output(return_vals=(None,))
@@ -382,7 +383,7 @@ def test_gemm():
         # CHECK-SAME: (%getresult_M:1_N:1_K:0, %c, 4, None, ())
         # CHECK-NEXT: return None
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
@@ -449,7 +450,7 @@ def test_gemm():
         # CHECK-SAME: (%read_M:1_N:0_K:1, %read_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
         # CHECK-NEXT: return [mma_M:0_N:0_K:1, mma_M:0_N:1_K:1, mma_M:1_N:0_K:1, mma_M:1_N:1_K:1]
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:0_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:1_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:1_N:0_K:0
@@ -569,7 +570,7 @@ def test_batched_gemm():
         # CHECK-SAME: (%getresult_M:1_N:1_K:0, %c, 4, None, ())
         # CHECK-NEXT: return None
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
@@ -637,7 +638,7 @@ def test_batched_gemm():
         # CHECK-SAME: (%read_M:1_N:0_K:1, %read_M:0_N:1_K:1, %mma_M:1_N:1_K:0, None)
         # CHECK-NEXT: return [mma_M:0_N:0_K:1, mma_M:0_N:1_K:1, mma_M:1_N:0_K:1, mma_M:1_N:1_K:1]
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:0_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:1_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:1_N:0_K:0
@@ -839,7 +840,7 @@ def test_gemm_reduction_expansion_only():
         # CHECK-SAME: (%getresult_M:0_N:0_K:0, %c, 4, None, ())
         # CHECK-NEXT: return None
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
@@ -873,7 +874,7 @@ def test_gemm_reduction_expansion_only():
 
         # CHECK-NEXT: return [mma_M:0_N:0_K:1]
 
-        # Custom format:
+        # CHECK: Custom format:
 
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:0_K:0
         # CHECK-NEXT: placeholder(_name=a
@@ -1097,7 +1098,7 @@ def py_arithmetic_different_dims():
         # CHECK-SAME: (%neg_M:1_N:0_K:0, %c, 4, None, ())
         # CHECK-NEXT: return None
 
-        # Custom format:
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=c
         # CHECK-NEXT: read(memory=a, elements_per_thread=4, mapping_dynamic_vals=(), index={M: $T0*BLOCK_M/128 + $T0 + $WG0*BLOCK_M : 1 : 16, N: $T1*BLOCK_N/4 + 4*$T1 + $WG1*BLOCK_N : 4 : 1}

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -183,7 +183,7 @@ def test_gemm():
         # CHECK-SAME: (%extract_slice_15, %c, 1, None, ())
         # CHECK-NEXT: return None
 
-        # Root graph (custom format):
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
@@ -307,7 +307,7 @@ def test_gemm():
         # CHECK-NEXT: %mma_M:1_N:1_K:2
         # CHECK-NEXT: %mma_M:1_N:1_K:3
 
-        # Reduction subgraph (custom format):
+        # CHECK: Custom format:
         # CHECK: placeholder(_name=acc_M:0_N:0_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:1_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:1_N:0_K:0

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -133,7 +133,7 @@ def test_gemm():
         # CHECK-SAME: (%getresult_M:1_N:1_K:0, %c, 4, None, ())
         # CHECK-NEXT: return None
 
-        # Root graph (custom format):
+        # CHECK: Custom format:
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
@@ -220,7 +220,7 @@ def test_gemm():
         # CHECK-NEXT: %mma_M:1_N:1_K:2
         # CHECK-NEXT: %mma_M:1_N:1_K:3
 
-        # Reduction subgraph (custom format):
+        # CHECK: Custom format:
         # CHECK: placeholder(_name=acc_M:0_N:0_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:1_K:0
         # CHECK-NEXT: placeholder(_name=acc_M:1_N:0_K:0

--- a/lit_tests/kernel/wave/tracing.py
+++ b/lit_tests/kernel/wave/tracing.py
@@ -24,7 +24,7 @@ def test_trace_empty():
     # CHECK: %a
     # CHECK-NEXT: return None
 
-    # Custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-SAME: _type=Memory[M, N].of(f16)
     # CHECK-NEXT: output
@@ -55,7 +55,7 @@ def test_trace_empty_then_add_nodes():
     # CHECK-NEXT: %write
     # CHECK-NEXT: return None
 
-    # Custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-SAME: _type=Memory[M, N].of(f16)
     # CHECK-NEXT: read(memory=a
@@ -87,7 +87,7 @@ def test_trace_py_arithmetic():
     # CHECK-SAME: (%neg, %a, 4, None, ())
     # CHECK-NEXT: return None
 
-    # Custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: read(memory=a
     # CHECK-NEXT: add(lhs=read, rhs=read)
@@ -109,7 +109,7 @@ def test_trace_read():
     # CHECK-NEXT: %read
     # CHECK-NEXT: return None
 
-    # Custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: read(memory=a
     # CHECK-NEXT: output
@@ -129,7 +129,7 @@ def test_trace_register():
     # CHECK-NEXT: %register
     # CHECK-NEXT: return None
 
-    # Custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: register
     # CHECK-SAME: shape=[M, N], dtype=f16
@@ -152,7 +152,7 @@ def test_trace_write():
     # CHECK-NEXT: %write
     # CHECK-NEXT: return None
 
-    # Custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: register
     # CHECK-NEXT: write
@@ -179,7 +179,7 @@ def test_trace_mma():
     # CHECK-NEXT: %mma
     # CHECK-NEXT: return None
 
-    # Custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: read(memory=a
     # CHECK-NEXT: read(memory=a
@@ -219,7 +219,7 @@ def test_trace_gemm():
     # CHECK-NEXT: %write
     # CHECK-NEXT: return None
 
-    # Root graph in custom format:
+    # CHECK: Custom format:
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: placeholder
@@ -238,8 +238,8 @@ def test_trace_gemm():
     # CHECK-NEXT: %mma
     # CHECK-NEXT: return register
 
-    # Subgraph in custom format:
-    # CHECK-NEXT: placeholder
+    # CHECK: Custom format:
+    # CHECK: placeholder
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: read
     # CHECK-NEXT: placeholder


### PR DESCRIPTION
I found these very helpful while debugging. I actually didn't realize there was a `print_trace` function before, so I had modified the `__str__` method on `CapturedTrace`. I've adapted it to use `print_trace` instead. I ported over some of the things I put in the `__str__` method though, like labels for the regions. I think those might be useful for lit tests as well (I had to update the lit tests for it).

Note that I removed a number of comments that mostly repeated the name of the function. I kept ones that seemed like they were elaborating though.