### PR TITLE
Pin torch to <2.6.0 in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ wheel
 
 # It is expected that you have installed a PyTorch version/variant specific
 # to your needs, so we only include a minimum version spec.
-torch>=2.3.0
+torch>=2.3.0,<2.6.0
 torchaudio
 torchvision
 


### PR DESCRIPTION
Missed in https://github.com/iree-org/iree-turbine/pull/431.