### PR TITLE
[Wave] Improve support for non-primary wg constraint to fix GQA decode

### DIFF
--- a/iree/turbine/kernel/wave/templates/attention_common.py
+++ b/iree/turbine/kernel/wave/templates/attention_common.py
@@ -29,8 +29,8 @@ class AttentionShape:
 
 # Commonly-used attention symbols.
 H = tkl.sym.H  # number of heads
-H_Q = tkl.sym.H  # number of query heads
-H_KV = tkl.sym.H  # number of key/value heads
+H_Q = tkl.sym.H_Q  # number of query heads
+H_KV = tkl.sym.H_KV  # number of key/value heads
 N_Q = tkl.sym.N_D  # query sequence length
 N_KV = tkl.sym.N_KV  # key/value sequence length
 D_Q = tkl.sym.D_Q  # query head size

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -268,10 +268,9 @@ class LaunchableWave(Launchable):
         # Only take account primary dim for delinearize shape.
         shape = [subs_idxc(x.count) for x in dims_to_delinearize if x.primary]
         new_workgroup_dims = delinearize_index(WORKGROUP_2, shape)
-        rank = len(shape)
         for delinearize_dim in dims_to_delinearize:
             delinearize_dim.wg_dim = new_workgroup_dims[
-                delinearize_dim.workgroup_dim - rank
+                delinearize_dim.workgroup_dim - 2
             ]
         self.update_aliased_workgroup_constraints(workgroup_dims)
 

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -234,11 +234,9 @@ class LaunchableWave(Launchable):
         aliased_dims = [
             x.source for x in self.constraints if isinstance(x, SymbolicAlias)
         ]
-        workgroup_dims = {
-            x.workgroup_dim: x
-            for x in self.workgroup_constraints
-            if x.dim not in aliased_dims
-        }
+        workgroup_dims = [
+            x for x in self.workgroup_constraints if x.dim not in aliased_dims
+        ]
         return workgroup_dims
 
     def update_aliased_workgroup_constraints(
@@ -263,15 +261,18 @@ class LaunchableWave(Launchable):
         """
 
         workgroup_dims = self.get_workgroup_dims()
-        if all(x <= 2 for x in workgroup_dims.keys()):
+        # Filter to WG2 and above.
+        dims_to_delinearize = [x for x in workgroup_dims if x.workgroup_dim >= 2]
+        if all(x.workgroup_dim <= 2 for x in dims_to_delinearize):
             return
-        shape = [
-            subs_idxc(workgroup_dims[i].count)
-            for i in range(2, max(workgroup_dims.keys()) + 1)
-        ]
+        # Only take account primary dim for delinearize shape.
+        shape = [subs_idxc(x.count) for x in dims_to_delinearize if x.primary]
         new_workgroup_dims = delinearize_index(WORKGROUP_2, shape)
-        for i in range(2, max(workgroup_dims.keys()) + 1):
-            workgroup_dims[i].wg_dim = new_workgroup_dims[i - 2]
+        rank = len(shape)
+        for delinearize_dim in dims_to_delinearize:
+            delinearize_dim.wg_dim = new_workgroup_dims[
+                delinearize_dim.workgroup_dim - rank
+            ]
         self.update_aliased_workgroup_constraints(workgroup_dims)
 
     def initialize_symbolic_constraints(self, trace: CapturedTrace) -> None:

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1171,9 +1171,9 @@ def test_prefill_attention():
         # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.gather
         # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.gather
         # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-32:           vector.load
         # CHECK-COUNT-16:           amdgpu.mfma

--- a/tests/kernel/wave/attention/prefill_attention_test.py
+++ b/tests/kernel/wave/attention/prefill_attention_test.py
@@ -124,7 +124,7 @@ def testPrefillAttention(
     (query, key, value, start_offsets, seq_lens) = create_inputs(shape, seq_lens, dtype)
 
     output_shape = (shape.total_seq_len, shape.num_query_heads, shape.head_size_kv)
-    permuted_value = value.permute(1, 2, 0)
+    permuted_value = value
     # Run the wave kernel.
     (prefill, hyperparams) = get_prefill_attention_kernel(
         shape,

--- a/tests/kernel/wave/attention/prefill_attention_test.py
+++ b/tests/kernel/wave/attention/prefill_attention_test.py
@@ -124,14 +124,13 @@ def testPrefillAttention(
     (query, key, value, start_offsets, seq_lens) = create_inputs(shape, seq_lens, dtype)
 
     output_shape = (shape.total_seq_len, shape.num_query_heads, shape.head_size_kv)
-    permuted_value = value
     # Run the wave kernel.
     (prefill, hyperparams) = get_prefill_attention_kernel(
         shape,
         mfma_variant,
         query.shape,
         key.shape,
-        permuted_value.shape,
+        value.shape,
         output_shape,
     )
 
@@ -166,7 +165,7 @@ def testPrefillAttention(
         mb = prefill(
             query * dk_sqrt * log2e,
             key,
-            permuted_value,
+            value,
             start_offsets,
             seq_lens,
             output,


### PR DESCRIPTION
This PR implements missing feature to enabled GQA for non-transposedV on prefill attention. In order to do that there are two main things this PR introduces:

1. GQA by definition dictates that Q_head >> KV_head. However, previously we set the same symbolic dims `H` on `Q_head` and `KV_head`, this ends up giving incorrect result during GQA non transposedV extend attention. For example, in the case of `seq_len=64, q_head=4, kv_head=1, h_dim=128` with same symbolic dim, it still expect v_shape of (tensor<64x4x128xf16>) which will produce transposed-v read/gather with `stride=128*4=512` but in reality it should be `tensor<64x1x128xf16>` with `stride=128*1=128`.

2. Once we have the proper/correct "non-primary" workgroup constraint set, kernel starts giving numerically wrong results. Upon investigation this is because once we set a "non-primary" workgroup constraint, the original/primary workgroup constraint does not get delinearized since it is overwritten in `get_workgroup_dims` by the new/"non-primary" workgroupConstraint. To fix this, we refactored `get_workgroup_dims` to return all the dims as a lit, and refactored `initialize_workgroup_constraint` to be able to delinearize both "primary" and "non-primary" workgroupConstraints and dims. 