### PR TITLE
Remove transpose v in extend attention

### DIFF
--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -73,6 +73,7 @@ def get_extend_attention_kernel(
     ]
     constraints += [tkw.WorkgroupConstraint(D_KV, BLOCK_D_KV, 1)]
     constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 2)]
+    constraints += [tkw.WorkgroupConstraint(H_KV, BLOCK_H, 2, primary=False)]
     constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 3)]
     constraints += [tkw.TilingConstraint(N_KV, BLOCK_N_KV)]
     constraints += [tkw.WaveConstraint(N_Q, BLOCK_N_Q / M_WAVES)]
@@ -90,7 +91,7 @@ def get_extend_attention_kernel(
             threads_per_wave=64,
             waves_per_block=(M_WAVES, N_WAVES, 1),
             mma_type=mfma_variant[1],
-            vector_shapes={H: 0, N_Q: Mvec, D_KV: Nvec, S: 0},
+            vector_shapes={H: 0, H_KV: 0, N_Q: Mvec, D_KV: Nvec, S: 0},
         )
     ]
 
@@ -113,26 +114,26 @@ def get_extend_attention_kernel(
     head_ratio = shape.num_query_heads // shape.num_kv_heads
     k_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={H: i // head_ratio, N_KV: j + EXT_IDX, D_Q: k},
-        outputs={H: i, N_KV: j, D_Q: k},
+        inputs={H_KV: i // head_ratio, N_KV: j + EXT_IDX, D_Q: k},
+        outputs={H_KV: i, N_KV: j, D_Q: k},
     )
     # TODO: Need to add SEQ_IDX below
     k_cache_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={H: i // head_ratio, N_KV: j + SEQ_IDX, D_Q: k},
-        outputs={H: i, N_KV: j, D_Q: k},
+        inputs={H_KV: i // head_ratio, N_KV: j + SEQ_IDX, D_Q: k},
+        outputs={H_KV: i, N_KV: j, D_Q: k},
     )
 
     v_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={H: i // head_ratio, D_KV: j, N_KV: k + EXT_IDX},
-        outputs={H: i, D_KV: j, N_KV: k},
+        inputs={H_KV: i // head_ratio, D_KV: j, N_KV: k + EXT_IDX},
+        outputs={H_KV: i, D_KV: j, N_KV: k},
     )
 
     v_cache_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={H: i // head_ratio, D_KV: j, N_KV: k + SEQ_IDX},
-        outputs={H: i, D_KV: j, N_KV: k},
+        inputs={H_KV: i // head_ratio, D_KV: j, N_KV: k + SEQ_IDX},
+        outputs={H_KV: i, D_KV: j, N_KV: k},
     )
 
     block_table_mapping = tkw.IndexMapping(
@@ -152,13 +153,13 @@ def get_extend_attention_kernel(
     @tkw.wave(constraints)
     def extend_attention(
         q: tkl.Memory[N_Q, H, D_Q, GLOBAL_ADDRESS_SPACE, wave_input_dtype, q_layout],
-        k: tkl.Memory[N_KV, H, D_Q, ADDRESS_SPACE, wave_input_dtype, k_layout],
-        v: tkl.Memory[H, D_KV, N_KV, ADDRESS_SPACE, wave_input_dtype, v_layout],
+        k: tkl.Memory[N_KV, H_KV, D_Q, ADDRESS_SPACE, wave_input_dtype, k_layout],
+        v: tkl.Memory[N_KV, H_KV, D_KV, ADDRESS_SPACE, wave_input_dtype, v_layout],
         k_cache: tkl.Memory[
-            N_KV, H, D_Q, ADDRESS_SPACE, wave_input_dtype, k_cache_layout
+            N_KV, H_KV, D_Q, ADDRESS_SPACE, wave_input_dtype, k_cache_layout
         ],
         v_cache: tkl.Memory[
-            H, D_KV, N_KV, ADDRESS_SPACE, wave_input_dtype, v_cache_layout
+            N_KV, H_KV, D_KV, ADDRESS_SPACE, wave_input_dtype, v_cache_layout
         ],
         block_table: tkl.Memory[
             S, N_KV, GLOBAL_ADDRESS_SPACE, wave_size_dtype, block_table_layout
@@ -281,6 +282,7 @@ def get_extend_attention_kernel(
         BLOCK_N_KV: SEQ_TILE_SIZE,
         BLOCK_S: 1,
         H: shape.num_query_heads,
+        H_KV: shape.num_kv_heads,
         D_KV: shape.head_size_kv,
         D_Q: shape.head_size,
         S: shape.num_seqs,

--- a/lit_tests/kernel/wave/attention.py
+++ b/lit_tests/kernel/wave/attention.py
@@ -1259,6 +1259,10 @@ def test_extend_attention():
         # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-1:            vector.gather
+        # CHECK-COUNT-1:            vector.store
+        # CHECK-COUNT-1:            vector.gather
+        # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-16:           vector.load
         # CHECK-COUNT-16:           amdgpu.mfma
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
@@ -1269,9 +1273,9 @@ def test_extend_attention():
         # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.gather
         # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.gather
         # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-32:           vector.load
         # CHECK-COUNT-16:           amdgpu.mfma

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -267,10 +267,10 @@ def testExtendAttention(
         mfma_variant,
         q_extend.shape,
         k_extend.shape,
-        v_extend.permute(1, 2, 0).shape,
+        v_extend.shape,
         req_to_tokens.shape,
         k_buffer.shape,
-        v_buffer.permute(1, 2, 0).shape,
+        v_buffer.shape,
         output.shape,
     )
     hyperparams.update(get_default_scheduling_params())
@@ -303,9 +303,9 @@ def testExtendAttention(
         mb_qk = extend_attention(
             q_extend * dk_sqrt * log2e,
             k_extend,
-            v_extend.permute(1, 2, 0),
+            v_extend,
             k_buffer,
-            v_buffer.permute(1, 2, 0),
+            v_buffer,
             req_to_tokens,
             b_req_idx,
             b_seq_len,


### PR DESCRIPTION
This PR removes the need for the value tensors to be permuted for the attention kernel.