### PR TITLE
[Wave] Make extend sequence dimension dynamic

### DIFF
--- a/iree/turbine/kernel/_support/indexing.py
+++ b/iree/turbine/kernel/_support/indexing.py
@@ -241,6 +241,8 @@ class IndexingContext:
         return sympy.sympify(expr).subs(self.frozen_subs).simplify()
 
     def get_static_value(self, expr: IndexExpr | int) -> Optional[int]:
+        if not expr:
+            return None
         expr = self.simplify_expr(expr)
         try:
             return int(expr)

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -37,6 +37,10 @@ def memref_to_tensor(memrefs: list[IrType]):
 def get_dynamic_dims(bindings: list[BindingDesc], dynamic_symbols: list[IndexSymbol]):
     dynamic_dims: list[IndexSymbol] = []
     for b in bindings:
+        node_type = b.reference[1].type
+        if node_type.physical_layout:
+            if all(node_type.physical_layout.shape):
+                continue
         for dim in b.kernel_buffer_type.symbolic_shape:
             if dim in dynamic_symbols:
                 dynamic_dims.append(dim)

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -143,10 +143,13 @@ def get_extend_attention_kernel(
         outputs={S: i, N_KV: j},
     )
 
-    q_layout = tkl.MemoryLayout(shape=q_shape)
-    k_layout = tkl.MemoryLayout(shape=k_shape)
-    v_layout = tkl.MemoryLayout(shape=v_shape)
-    o_layout = tkl.MemoryLayout(shape=o_shape)
+    # Set the dynamic shapes for the kernel. Here we set it to N_Q
+    # which is the first argument of the query and output.
+    set_dynamic_dim = lambda shape: [x if i != 0 else None for i, x in enumerate(shape)]
+    q_layout = tkl.MemoryLayout(shape=set_dynamic_dim(q_shape))
+    k_layout = tkl.MemoryLayout(shape=set_dynamic_dim(k_shape))
+    v_layout = tkl.MemoryLayout(shape=set_dynamic_dim(v_shape))
+    o_layout = tkl.MemoryLayout(shape=set_dynamic_dim(o_shape))
     block_table_layout = tkl.MemoryLayout(shape=block_table_shape)
     k_cache_layout = tkl.MemoryLayout(shape=k_cache_shape)
     v_cache_layout = tkl.MemoryLayout(shape=v_cache_shape)
@@ -298,4 +301,7 @@ def get_extend_attention_kernel(
         S: shape.num_seqs,
     }
 
-    return extend_attention, hyperparams
+    dynamic_symbols = [N_Q, N_KV]
+    dynamic_symbols_map = {N_Q: q_shape[0], N_KV: k_shape[0]}
+
+    return extend_attention, hyperparams, dynamic_symbols, dynamic_symbols_map

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -264,7 +264,12 @@ def testExtendAttention(
     output = device_zeros(
         extend_token_num, shape.num_query_heads, shape.head_size, dtype=torch.float32
     )
-    (extend_attention, hyperparams,) = get_extend_attention_kernel(
+    (
+        extend_attention,
+        hyperparams,
+        dynamic_symbols,
+        dynamic_symbols_map,
+    ) = get_extend_attention_kernel(
         shape,
         mfma_variant,
         q_extend.shape,
@@ -300,6 +305,8 @@ def testExtendAttention(
         run_config=config,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
     ):
         # TODO: Add scaling of QK as part of kernel.
         # TODO: Add variant of non-transposed V attention kernel.


### PR DESCRIPTION
This PR modifies the extend attention kernel so that the query/key/value/output extend sequence length is dynamic. This is required to avoid recompilation of the kernel for different values of the sequence length.