### PR TITLE
Include numbered version for release candidates

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,8 +25,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-tags: true
 
       - name: "Setting up Python"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -38,13 +36,10 @@ jobs:
 
       - name: Build iree-turbine release candidate
         run: |
-          version_name="$(./build_tools/compute_local_version.py -rc --write-json)"
+          ./build_tools/compute_local_version.py \
+            -rc --write-json \
+            --version-suffix ".${{ github.run_number }}"
           ./build_tools/build_release.py --no-download
-
-      - name: Tag version
-        run: |
-          git tag "$version_name"
-          git push origin "$version_name"
 
       - name: Upload python wheels
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-tags: true
 
       - name: "Setting up Python"
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -36,8 +38,13 @@ jobs:
 
       - name: Build iree-turbine release candidate
         run: |
-          ./build_tools/compute_local_version.py -rc --write-json
+          version_name="$(./build_tools/compute_local_version.py -rc --write-json)"
           ./build_tools/build_release.py --no-download
+
+      - name: Tag version
+        run: |
+          git tag "$version_name"
+          git push origin "$version_name"
 
       - name: Upload python wheels
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/build_tools/compute_local_version.py
+++ b/build_tools/compute_local_version.py
@@ -44,41 +44,12 @@ def write_version_to_file(version_file, version):
         f.write("\n")
 
 
-def represents_int(s: str) -> bool:
-    try:
-        int(s)
-    except ValueError:
-        return False
-    else:
-        return True
-
-
-def get_next_available_tag(tag_prefix: str) -> str:
-    """
-    Get the next numbered tag that does not exists.
-    E.g. iree-turbine-3.1.0rc20250205. -> iree-turbine-3.1.0rc20250205.3
-    """
-    tags = (
-        subprocess.check_output(["git", "tag", "--list", f"{tag_prefix}*"])
-        .decode()
-        .strip()
-        .splitlines()
-    )
-    tag_suffixes = [tag.removeprefix(tag_prefix) for tag in tags]
-    tag_suffix_nums = [int(suffix) for suffix in tag_suffixes if represents_int(suffix)]
-    max_num = -1
-    if len(tag_suffix_nums) > 0:
-        max_num = max(tag_suffix_nums)
-    return f"{tag_prefix}{max_num+1}"
-
-
 version_info = load_version_from_file(VERSION_FILE_PATH)
 package_version = version_info.get("package-version")
 current_version = Version(package_version).base_version
 
 if args.nightly_release:
     current_version += "rc" + datetime.today().strftime("%Y%m%d")
-    current_version = get_next_available_tag(f"{current_version}.")
 elif args.development_release:
     current_version += (
         ".dev0+"


### PR DESCRIPTION
We can't make multiple different versions for the same day.

With this change the release candidates will have a version of the form

3.2.0rc20250205.0
3.2.0rc20250205.1
...

instead of just
3.2.0rc20250205