### PR TITLE
[Wave] Teach compiler to handle unaligned attention

### DIFF
--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -455,6 +455,18 @@ def handle_div(lhs: Value, rhs: Value) -> OpResult:
     return result
 
 
+@handle_binary_op(operator.and_)
+def handle_and(lhs: Value, rhs: Value) -> OpResult:
+    element_type = get_type_or_element_type(lhs.type)
+    if _is_integer_like_type(element_type) and (
+        element_type.is_signed or element_type.is_signless
+    ):
+        result = arith_d.andi(lhs, rhs)
+    else:
+        raise ValidationError(f"Found unhandled operand type for div: {element_type}")
+    return result
+
+
 @handle_binary_op([operator.gt, gt])
 def handle_gt(lhs: Value, rhs: Value) -> OpResult:
     element_type = get_type_or_element_type(lhs.type)
@@ -830,13 +842,14 @@ def handle_extract_slice(emitter: WaveEmitter, node: fx.Node):
 @handle_op(broadcast)
 def handle_broadcast(emitter: WaveEmitter, node: fx.Node):
     try:
-        register, _ = node.args
+        register, target_shape = node.args
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
 
     # Get thread_shape/size for broadcast.
     get_thread_shape = lambda index: max(subs_idxc(x.size) for x in index.values())
 
+    src_thread_size = get_thread_shape(register.index) if register.index else None
     bcast_dim_lane_dim_size = get_thread_shape(node.index)
 
     # Check MLIR shape
@@ -849,6 +862,7 @@ def handle_broadcast(emitter: WaveEmitter, node: fx.Node):
         vector_type.rank == 0 or vector_type.rank == 1
     ), f"expected vector_type.rank == 1 but got {vector_type}"
 
+    # Handles scalar broadcast case.
     if vector_type.rank == 0:
         result_type = VectorType.get(
             [bcast_dim_lane_dim_size], vector_type.element_type
@@ -856,6 +870,16 @@ def handle_broadcast(emitter: WaveEmitter, node: fx.Node):
         element = vector_d.extract(vector_src, static_position=[], dynamic_position=[])
         splat = vector_d.splat(result_type, element)
         emitter.bind_node_proxy(node, IRProxyValue(splat))
+        return
+
+    # Handle broadcasting to unit dims as no-op.
+    # Most useful for handling broadcast in symbolic shapes.
+    src_dims = set(get_custom(register).indexing_dims)
+    bcast_dims = list(set(target_shape) - src_dims)
+    bcast_sizes = [subs_idxc(node.index[x].size) for x in bcast_dims]
+    lane_level_broadcast = bcast_dim_lane_dim_size != src_thread_size
+    if math.prod(bcast_sizes) == 1 and not lane_level_broadcast:
+        emitter.bind_node_proxy(node, IRProxyValue(vector_src))
         return
 
     assert (
@@ -931,7 +955,7 @@ def handle_cast(emitter: WaveEmitter, node: fx.Node):
     dst_vector_type = VectorType.get(src_vector_type.shape, dst_elem_type)
 
     if src_vector_type == dst_vector_type:
-        emitter.bind_node_proxy(node, vector_src)
+        emitter.bind_node_proxy(node, IRProxyValue(vector_src))
         return
 
     is_src_float = _is_float_type(src_elem_type)

--- a/iree/turbine/kernel/wave/expansion/expansion.py
+++ b/iree/turbine/kernel/wave/expansion/expansion.py
@@ -440,7 +440,7 @@ def populate_inputs(
                         mma_metadata.last_mma_node = True
                     new_nodes_to_expand.append((arg, mma_metadata))
                 continue
-            case Allocate() | SetSymbol() | ApplyExpr():
+            case Allocate() | SetSymbol():
                 alloc_metadata = deepcopy(metadata)
                 alloc_metadata.do_not_expand = True
                 new_nodes_to_expand.append((arg, alloc_metadata))

--- a/iree/turbine/kernel/wave/scheduling/graph_utils.py
+++ b/iree/turbine/kernel/wave/scheduling/graph_utils.py
@@ -312,11 +312,9 @@ def get_scheduling_weight(node: fx.Node) -> EdgeWeight:
             weight = EdgeWeight(0, delay_table[Operation.MMA])
         case IterArg():
             weight = EdgeWeight(1, 0)
-        case CastOp() | Extract() | Permute() | Broadcast() | Reshape():
+        case CastOp() | Extract() | Permute() | Broadcast() | Reshape() | SelfIndex():
             weight = EdgeWeight(0, delay_table[Operation.NOOP])
-        case UnaryPyOp():
-            weight = EdgeWeight(0, delay_table[Operation.VALU])
-        case BinaryPyOp():
+        case ApplyExpr() | UnaryPyOp() | BinaryOpBase() | SelectOp():
             weight = EdgeWeight(0, delay_table[Operation.VALU])
         case ShuffleOp():
             weight = EdgeWeight(0, delay_table[Operation.SHUFFLE])

--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -364,6 +364,9 @@ def test_attention():
         # CHECK-LABEL:       func.func @base_attention
         # CHECK:                {{.*}} = scf.for
         # CHECK-COUNT-16:           {{.*}} = amdgpu.mfma
+        # CHECK-COUNT-4:            {{.*}} = arith.cmpi slt
+        # CHECK-COUNT-4:            {{.*}} = arith.select
+        # CHECK-COUNT-8:            {{.*}} = arith.addf
         # CHECK-COUNT-8:            {{.*}} = gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            {{.*}} = amdgpu.mfma
 
@@ -420,7 +423,9 @@ def test_attention_causal():
         # CHECK:                %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
         # CHECK:                {{.*}} = scf.for
         # CHECK-COUNT-16:           {{.*}} = amdgpu.mfma
+        # CHECK-COUNT-4:            {{.*}} = arith.cmpi slt, {{.*}} : vector<4xindex>
         # CHECK-COUNT-8:            {{.*}} = arith.cmpi sge, {{.*}} : vector<4xi64>
+        # CHECK-COUNT-8:            {{.*}} = arith.andi {{.*}} : vector<4xi1>
         # CHECK-COUNT-8:            {{.*}} = arith.select %{{.*}}, %[[ZERO]], %[[NEG_INF]] : vector<4xi1>, vector<4xf32>
         # CHECK-COUNT-8:            {{.*}} = arith.addf %{{.*}}, %{{.*}} : vector<4xf32>
         # CHECK-COUNT-8:            {{.*}} = gpu.shuffle xor {{.*}}

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -105,6 +105,9 @@ def test_extend_attention():
         # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
+        # CHECK-COUNT-2:            arith.cmpi slt
+        # CHECK-COUNT-2:            arith.select
+        # CHECK-COUNT-2:            arith.addf
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
         # CHECK-COUNT-4:        vector.maskedload
@@ -118,6 +121,9 @@ def test_extend_attention():
         # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
+        # CHECK-COUNT-2:            arith.cmpi slt
+        # CHECK-COUNT-2:            arith.select
+        # CHECK-COUNT-2:            arith.addf
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
         # CHECK-COUNT-16:      vector.maskedstore
@@ -214,6 +220,9 @@ def test_causal_extend_attention():
         # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
+        # CHECK-COUNT-2:            arith.cmpi slt
+        # CHECK-COUNT-2:            arith.select
+        # CHECK-COUNT-2:            arith.addf
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
         # CHECK-COUNT-4:        vector.maskedload
@@ -227,6 +236,11 @@ def test_causal_extend_attention():
         # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
+        # CHECK-COUNT-1:            arith.cmpi slt
+        # CHECK-COUNT-2:            arith.cmpi sge
+        # CHECK-COUNT-2:            arith.andi
+        # CHECK-COUNT-2:            arith.select
+        # CHECK-COUNT-2:            arith.addf
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
         # CHECK-COUNT-16:      vector.maskedstore

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -140,20 +140,13 @@ def create_inputs(
     H_KV = shape.num_kv_heads
     H_Q = shape.num_query_heads
     D = shape.head_size
-    # TODO: Enable when we have proper masking for attention.
-    # b_seq_len_prefix = torch.randint(
-    #     1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
-    # )
-    b_seq_len_prefix = torch.empty((B,), dtype=torch.int32, device="cuda")
-    for i in range(B):
-        b_seq_len_prefix[i] = shape.block_size * (i + 1)
-    # TODO: Enable when we have proper masking for attention.
-    # b_seq_len_extend = torch.randint(
-    #     1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
-    # )
-    b_seq_len_extend = torch.empty((B,), dtype=torch.int32, device="cuda")
-    for i in range(B):
-        b_seq_len_extend[i] = shape.block_size * (i + 2)
+    torch.manual_seed(0)
+    b_seq_len_prefix = torch.randint(
+        1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
+    )
+    b_seq_len_extend = torch.randint(
+        1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
+    )
     b_seq_len = b_seq_len_prefix + b_seq_len_extend
     max_len_in_batch = torch.max(b_seq_len, 0)[0].item()
 

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -37,7 +37,7 @@ from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
 
 
 @require_e2e
-@pytest.mark.parametrize("shape", get_test_shapes("attention"))
+@pytest.mark.parametrize("input_shape", get_test_shapes("attention"))
 @pytest.mark.parametrize("enable_scheduling", [False, True])
 @pytest.mark.parametrize("dynamic_dims", [False, True])
 @pytest.mark.parametrize(
@@ -49,8 +49,8 @@ from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
         (MMAType.F32_32x32x8_F16, MMAType.F32_32x32x8_F16),
     ],
 )
-def testAttention(
-    shape: tuple[int],
+def testAttentionPure(
+    input_shape: tuple[int],
     enable_scheduling: bool,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
@@ -59,12 +59,12 @@ def testAttention(
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")
     shape = AttentionShape(
-        num_query_heads=shape[0],
-        num_kv_heads=shape[0],
-        query_seq_len=shape[1],
-        head_size_kv=shape[2],
-        head_size=shape[3],
-        kv_seq_len=shape[4],
+        num_query_heads=input_shape[0],
+        num_kv_heads=input_shape[0],
+        query_seq_len=input_shape[1],
+        head_size_kv=input_shape[2],
+        head_size=input_shape[3],
+        kv_seq_len=input_shape[4],
     )
     (
         base_attention,
@@ -114,7 +114,7 @@ def testAttention(
         )
 
         if dump_generated_mlir:
-            filename = f"wave_attention_{'x'.join(map(str, shape))}.mlir"
+            filename = f"wave_attention_{'x'.join(map(str, input_shape))}.mlir"
             with open(filename, "w") as f:
                 f.write(mb.module_op.get_asm())
 
@@ -122,7 +122,7 @@ def testAttention(
 
 
 @require_e2e
-@pytest.mark.parametrize("shape", get_test_shapes("attention"))
+@pytest.mark.parametrize("shape", get_test_shapes("all_attention"))
 @pytest.mark.parametrize("enable_scheduling", [False])
 @pytest.mark.parametrize("dynamic_dims", [False])
 @pytest.mark.parametrize(

--- a/tests/kernel/wave/common/shapes.py
+++ b/tests/kernel/wave/common/shapes.py
@@ -12,7 +12,6 @@ _e2e_test_shapes = {}
 _e2e_test_shapes["attention"] = [
     (8, 128, 128, 64, 256),
     (40, 1024, 64, 64, 1024),
-    (32, 1024, 128, 128, 1357),
 ]
 _e2e_test_shapes["chained_gemm"] = _e2e_test_shapes["attention"]
 _e2e_test_shapes["decode_attention"] = _e2e_test_shapes["attention"]

--- a/tests/kernel/wave/common/shapes.py
+++ b/tests/kernel/wave/common/shapes.py
@@ -12,9 +12,18 @@ _e2e_test_shapes = {}
 _e2e_test_shapes["attention"] = [
     (8, 128, 128, 64, 256),
     (40, 1024, 64, 64, 1024),
+    (32, 1024, 128, 128, 1357),
 ]
 _e2e_test_shapes["chained_gemm"] = _e2e_test_shapes["attention"]
 _e2e_test_shapes["decode_attention"] = _e2e_test_shapes["attention"]
+_e2e_test_shapes["unaligned_attention"] = [
+    (32, 1024, 128, 128, 1357),
+    (48, 1024, 128, 128, 1357),
+]
+_e2e_test_shapes["all_attention"] = (
+    _e2e_test_shapes["unaligned_attention"] + _e2e_test_shapes["attention"]
+)
+
 
 # Order of shapes: (B, BN, K2, H, K1, M, N)
 _e2e_test_shapes["evoformer"] = [


### PR DESCRIPTION
Most time on LLM, we'd be facing unaligned shapes since sequence length is not always aligned/padded. In order to support that, we implement unaligned attention kernel along with a couple compiler features S.T we can handle unaligned shapes. Features are:

1. Implement `&` operator to combine multiple masks (causal + unaligned shape)
2. Teach broadcast to handle symbolic broadcasts on unit dims as no-op (important for broadcasting K2 -> [M, K2] for masks)
3. Let ApplyExpr go through expansion, initially caused a numeric bug if not expanded properly.
4. Modify necessary LIT to check for unaligned mask, and e2e to handle unaligned shape