### PR TITLE
Revert "Bump IREE requirement pins to their latest versions."

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -7,5 +7,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.2.0rc20250205
-iree-base-runtime==3.2.0rc20250205
+iree-base-compiler==3.2.0rc20250130
+iree-base-runtime==3.2.0rc20250130


### PR DESCRIPTION
Reverts iree-org/iree-turbine#460

Lit test failures due to out of date code when merged: https://github.com/iree-org/iree-turbine/actions/runs/13184412301/job/36802953389