### PR TITLE
Attention with Linear Biases

### DIFF
--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -533,7 +533,7 @@ def handle_minimum(lhs: Value, rhs: Value) -> OpResult:
     if _is_float_type(element_type):
         result = arith_d.minimumf(lhs, rhs)
     elif _is_integer_like_type(element_type) and (
-        element_type.is_signed() or element_type.is_signless()
+        element_type.is_signed or element_type.is_signless
     ):
         result = arith_d.minsi(lhs, rhs)
     else:

--- a/iree/turbine/kernel/wave/templates/alibi_attention.py
+++ b/iree/turbine/kernel/wave/templates/alibi_attention.py
@@ -1,0 +1,176 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from typing import Optional
+
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.utils import (
+    get_mfma_load_elems_per_thread,
+    get_mfma_store_elems_per_thread,
+)
+from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
+
+
+def get_alibi_attention_kernel(
+    shape: AttentionShape, mfma_variant: MMAType, dynamic_dims: bool
+):
+    """Produces an attention kernel with linear biases (ALiBi).
+
+    Note that this uses the numeric equality exp(x) = pow(2, x * log2(e)) for
+    efficiency reasons internally, therefore, either the Q or the K matrix
+    _and_ the linear biases must be pre-scaled by log2(e) before being passed
+    into the generated kernel.
+    """
+
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
+    # Workgroup tile sizes
+    BLOCK_B = tkl.sym.BLOCK_B
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K2 = tkl.sym.BLOCK_K2
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+    # Other hyperparameters
+    LOAD_ELEMS_PER_THREAD_QK = index_symbol("LOAD_ELEMS_PER_THREAD_QK")
+    LOAD_ELEMS_PER_THREAD_PV = index_symbol("LOAD_ELEMS_PER_THREAD_PV")
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.TilingConstraint(K2, BLOCK_K2)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 4)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 1)]
+
+    if mfma_variant[1] == MMAType.F32_16x16x16_F16:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant[1] == MMAType.F32_32x32x8_F16:
+        Mvec = 32
+        Nvec = 32
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(4, 1, 1),
+            mma_type=mfma_variant[1],
+            vector_shapes={B: 0, M: Mvec, N: Nvec},
+        )
+    ]
+
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K2 > BLOCK_K2 * 4)]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    mapping = tkw.IndexMapping(
+        num_iterators=3, inputs={B: i, N: j, M: k}, outputs={B: i, M: k, N: j}
+    )
+
+    @tkw.wave(constraints)
+    def alibi_attention(
+        q: tkl.Memory[B, M, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        k: tkl.Memory[B, K2, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
+        v: tkl.Memory[B, N, K2, ADDRESS_SPACE, tkl.f16],
+        m: tkl.Memory[B, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[B, N, M, tkl.f32](0.0)
+        init_sum = tkl.Register[B, M, tkl.f32](0.0)
+        init_max = tkl.Register[B, M, tkl.f32](-1e6)
+        m_reg = tkw.read(m, elements_per_thread=1)
+
+        # This microkernel encodes the fact that if the reduction
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, M, tkl.f32],
+            partial_sum: tkl.Register[B, M, tkl.f32],
+            acc: tkl.Register[B, N, M, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, K2, M, tkl.f32](0.0)
+            q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
+            k_reg = tkw.read(k, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
+            x_j = tkw.permute(inner_acc, target_shape=[B, M, K2])
+
+            ####################################################################
+            # ALiBi
+            ####################################################################
+            # ALiBi is essentially adding a lower-triangular matrix of constants
+            # to the result of QK product. The triangular matrix is obtained by
+            # doing min(j - i, 0).
+            i = tkw.self_index(M, tkl.i64, elements_per_thread=1)
+            i = tkw.broadcast(i, target_shape=[B, M, K2])
+            j = tkw.self_index(K2, tkl.i64, elements_per_thread=4)
+            zero = tkl.Register[B, M, K2, tkl.i64](0)
+            idx = tkw.minimum(j - i, zero)
+            local_m = tkw.broadcast(m_reg, target_shape=[B, M, K2])
+            bias = local_m * tkw.cast(idx, tkl.f32)
+            x_j = x_j + bias
+
+            m_j = tkw.max(x_j, partial_max, dim=K2)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=K2)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(v, elements_per_thread=LOAD_ELEMS_PER_THREAD_PV)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
+        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        LOAD_ELEMS_PER_THREAD_QK: get_mfma_load_elems_per_thread(mfma_variant[0]),
+        LOAD_ELEMS_PER_THREAD_PV: get_mfma_load_elems_per_thread(mfma_variant[1]),
+        STORE_ELEMS_PER_THREAD: get_mfma_store_elems_per_thread(mfma_variant[1]),
+        BLOCK_B: 1,
+        BLOCK_M: 128,
+        BLOCK_N: 64,
+        BLOCK_K2: 64,
+        B: shape.num_query_heads,
+        M: shape.query_seq_len,
+        N: shape.head_size_kv,
+        K1: shape.head_size,
+        K2: shape.kv_seq_len,
+    }
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+    if dynamic_dims:
+        dynamic_symbols_map[M] = hyperparams[M]
+        dynamic_symbols_map[N] = hyperparams[N]
+        dynamic_symbols_map[B] = hyperparams[B]
+        dynamic_symbols_map[K2] = hyperparams[K2]
+        dynamic_symbols.append(M)
+        dynamic_symbols.append(N)
+        dynamic_symbols.append(B)
+        dynamic_symbols.append(K2)
+        del hyperparams[M]
+        del hyperparams[N]
+        del hyperparams[B]
+        del hyperparams[K2]
+
+    return alibi_attention, hyperparams, dynamic_symbols, dynamic_symbols_map

--- a/tests/kernel/wave/attention/alibi_attention_test.py
+++ b/tests/kernel/wave/attention/alibi_attention_test.py
@@ -1,0 +1,173 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import torch
+import math
+import iree.turbine.kernel as tk
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.utils import (
+    get_default_run_config,
+    get_default_scheduling_params,
+    device_arange,
+    device_full,
+    device_randn,
+    device_zeros,
+    to_default_device,
+)
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.templates.alibi_attention import (
+    get_alibi_attention_kernel,
+)
+from iree.turbine.kernel.wave.templates.attention_common import (
+    AttentionShape,
+)
+import os
+from torch.testing import assert_close
+from ..common.utils import (
+    require_e2e,
+    require_cdna3,
+    enable_scheduling_barriers,
+    dump_generated_mlir,
+    get_default_arch,
+)
+from ..common.shapes import get_test_shapes
+from typing import List, Optional, Tuple
+
+shapes = [(128, 128, 128, 128, 128, 128)]
+
+
+def get_relative_positions(
+    seq_len: int, kv_seq_len: Optional[int] = None
+) -> torch.Tensor:
+    """Returns a lower-trinagular tensor with distance between rows and columns.
+
+    The tensor resembles the following:
+
+        [ 0  0  0  0  0]
+        [-1  0  0  0  0]
+        [-2 -1  0  0  0]
+        [-3 -2 -1  0  0]
+    """
+    if not kv_seq_len:
+        kv_seq_len = seq_len
+    x = torch.arange(kv_seq_len)[None, :]
+    y = torch.arange(seq_len)[:, None]
+    return to_default_device(torch.minimum(x - y, torch.zeros(seq_len, kv_seq_len)))
+
+
+def precompute_alibi_slopes(n_heads: int) -> torch.Tensor:
+    """Computes the constant slopes of linear biases to be added to the attention scores."""
+    n = 2 ** math.floor(math.log2(n_heads))
+    m_0 = 2.0 ** (-8.0 / n)
+    m = torch.pow(m_0, torch.arange(1, 1 + n))
+    if n < n_heads:
+        m_hat_0 = 2.0 ** (-4.0 / n)
+        m_hat = torch.pow(m_hat_0, torch.arange(1, 1 + 2 * (n_heads - n), 2))
+        m = torch.cat([m, m_hat])
+    return to_default_device(m)
+
+
+def validate_accuracy(
+    query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, output: torch.Tensor
+) -> torch.Tensor:
+    # Precompute values.
+    dk_sqrt = math.sqrt(1.0 / query.shape[-1])
+    alibi_slopes = precompute_alibi_slopes(query.shape[0])
+
+    # Straightforward implementation of attention with bias.
+    scores = torch.matmul(query, key.transpose(-1, -2)) * dk_sqrt
+    bias = alibi_slopes.unsqueeze(-1).unsqueeze(-1) * get_relative_positions(
+        query.shape[1], key.shape[1]
+    )
+    bias = bias.to(dtype=scores.dtype)
+    scores = scores + bias
+    reference = torch.matmul(torch.softmax(scores, dim=-1), value)
+    assert_close(reference, output, check_dtype=False, rtol=2e-3, atol=2e-3)
+    return reference
+
+
+def create_inputs(
+    shape: AttentionShape, dtype: torch.dtype
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    q_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size)
+    k_shape = (shape.num_kv_heads, shape.kv_seq_len, shape.head_size)
+    v_shape = (shape.num_kv_heads, shape.kv_seq_len, shape.head_size_kv)
+    q = device_randn(q_shape, dtype=dtype)
+    k = device_randn(k_shape, dtype=dtype)
+    v = device_randn(v_shape, dtype=dtype)
+    return (q, k, v)
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", shapes)
+@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [(MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16)],
+)
+def test_alibi_attention(
+    shape: tuple[int],
+    dtype: torch.dtype,
+    mfma_variant: MMAType,
+    request,
+):
+    torch.manual_seed(0)
+    shape = AttentionShape(
+        num_query_heads=shape[0],
+        num_kv_heads=shape[1],
+        head_size=shape[2],
+        head_size_kv=shape[3],
+        query_seq_len=shape[4],
+        kv_seq_len=shape[5],
+    )
+    assert shape.num_query_heads % shape.num_kv_heads == 0
+
+    (query, key, value) = create_inputs(shape, dtype)
+    alibi_attention, hyperparams, _, _ = get_alibi_attention_kernel(
+        shape, mfma_variant, dynamic_dims=False
+    )
+    output_shape = (shape.num_query_heads, shape.query_seq_len, shape.head_size_kv)
+
+    hyperparams.update(get_default_scheduling_params())
+    config = get_default_run_config()
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    if run_bench:
+        config["benchmark_batch_size"] = 10
+        config["benchmark_repetitions"] = 3
+    if dump_perf is not None:
+        perf_filename = request.node.name + ".json"
+        config["benchmark_results_file"] = os.path.join(
+            dump_perf, "tk_" + perf_filename
+        )
+
+    log2e = 1.44269504089
+    dk_sqrt = math.sqrt(1.0 / shape.head_size)
+    alibi_slopes = precompute_alibi_slopes(shape.head_size)
+
+    with tk.gen.TestLaunchContext(
+        hyperparams,
+        canonicalize=True,
+        run=True,
+        run_bench=run_bench,
+        run_config=config,
+        use_scheduling_barriers=enable_scheduling_barriers,
+    ):
+        output = device_zeros(output_shape, dtype=torch.float32)
+        # TODO: Add scaling of QK and ALiBi as part of kernel.
+        alibi_attention(
+            query * dk_sqrt * log2e,
+            key,
+            value.permute([0, 2, 1]),
+            # NOTE: since the kernel uses exp2 instead of exp, the ALiBi slopes must be
+            # multiplied by the same factor as the Q matrix to preserve the result post
+            # softmax:  exp(x + alibi) = exp2((x + alibi) * log2(e))
+            alibi_slopes * log2e,
+            output,
+        )
+
+        validate_accuracy(query, key, value, output)


### PR DESCRIPTION
This implements (causal) ALiBi, attention with linear biases, following
the paper "Train Short, Test Long: Attention with Linear Biases Enables
Input Length Extrapolation" by Press et.al in ICLR 2022.