### PR TITLE
[Wave] Get runperf working for extend attention

### DIFF
--- a/iree/turbine/kernel/wave/templates/attention_common.py
+++ b/iree/turbine/kernel/wave/templates/attention_common.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Optional
 
 import iree.turbine.kernel.lang as tkl
@@ -22,6 +22,8 @@ class AttentionShape:
     max_seq_len: Optional[int] = None
     total_seq_len: Optional[int] = None
     context_len: Optional[int] = None
+    fixed_seq_len_prefix: Optional[int] = None
+    fixed_seq_len_extend: Optional[int] = None
     # -----------------------
     # Vanilla attention
     query_seq_len: Optional[int] = None
@@ -29,6 +31,12 @@ class AttentionShape:
     # -----------------------
     # Decode specific
     block_size: Optional[int] = None
+
+    def __iter__(self):
+        for field in fields(AttentionShape):
+            field_value = getattr(self, field.name)
+            if field_value:
+                yield field_value
 
 
 # Commonly-used attention symbols.

--- a/tests/kernel/wave/common/shapes.py
+++ b/tests/kernel/wave/common/shapes.py
@@ -4,9 +4,17 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import pytest
+from typing import Sequence
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.templates.attention_common import (
+    AttentionShape,
+)
 
 # List of all test shapes for end to end tests.
 _e2e_test_shapes = {}
+
+# List of all test shapes for perf tests.
+_perf_test_shapes = {}
 
 # Order of shapes: (B, M, N, K1, K2)
 _e2e_test_shapes["attention"] = [
@@ -23,12 +31,61 @@ _e2e_test_shapes["all_attention"] = (
     _e2e_test_shapes["unaligned_attention"] + _e2e_test_shapes["attention"]
 )
 
-
 # Order of shapes: (B, BN, K2, H, K1, M, N)
 _e2e_test_shapes["evoformer"] = [
     (1, 256, 256, 4, 32, 256, 32),
     (1, 512, 256, 8, 8, 256, 8),
 ]
+
+_e2e_test_shapes["extend"] = [
+    AttentionShape(
+        num_seqs=2,
+        context_len=1024,
+        num_query_heads=16,
+        num_kv_heads=1,
+        head_size=128,
+        head_size_kv=128,
+        block_size=64,
+    )
+]
+
+test_names = [
+    "attention",
+    "chained_gemm",
+    "decode_attention",
+    "unaligned_attention",
+    "all_attention",
+    "evoformer",
+]
+for test in test_names:
+    _perf_test_shapes[test] = _e2e_test_shapes[test]
+
+_perf_test_shapes["extend"] = [
+    AttentionShape(
+        num_seqs=32,
+        context_len=1024,
+        num_query_heads=6,
+        num_kv_heads=1,
+        head_size=128,
+        head_size_kv=128,
+        block_size=64,
+        fixed_seq_len_prefix=512,
+        fixed_seq_len_extend=128,
+    )
+]
+
+
+def construct_test_name(
+    base_name: str,
+    mfma_variant: tuple[MMAType],
+    is_causal: bool,
+    shape: AttentionShape | Sequence[int],
+):
+    test_name = base_name
+    test_name += mfma_variant[0].name + "_" + mfma_variant[1].name + "_"
+    test_name += "causal" if is_causal else "noncausal"
+    test_name += "_" + "x".join([str(s) for s in shape])
+    return test_name + ".json"
 
 
 def get_test_shapes(test_name: str):
@@ -38,6 +95,6 @@ def get_test_shapes(test_name: str):
     ]
     shapes += [
         pytest.param(s, id="x".join(map(str, s)) + "-perf", marks=pytest.mark.perf_only)
-        for s in _e2e_test_shapes[test_name]
+        for s in _perf_test_shapes[test_name]
     ]
     return shapes


### PR DESCRIPTION
This PR fixes the benchmarking code to work for extend attention. Extend attention can now be profiled using:

pytest -s tests/kernel/wave/attention/extend_attention_test.py --runperf --run-e2e --dump-perf-files-path=<path>