### PR TITLE
Revert "Include numbered version for release candidates"

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -36,9 +36,7 @@ jobs:
 
       - name: Build iree-turbine release candidate
         run: |
-          ./build_tools/compute_local_version.py \
-            -rc --write-json \
-            --version-suffix ".${{ github.run_number }}"
+          ./build_tools/compute_local_version.py -rc --write-json
           ./build_tools/build_release.py --no-download
 
       - name: Upload python wheels


### PR DESCRIPTION
Reverts iree-org/iree-turbine#458.

The workflow failed: https://github.com/iree-org/iree-turbine/actions/runs/13172140306/job/36764292832. See also https://github.com/iree-org/iree-turbine/pull/458#discussion_r1945051587.