### PR TITLE
[Wave] Add physical layout to cache key

### DIFF
--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -66,7 +66,10 @@ def extract_mappings(kernel_fn: Callable):
 
 def extract_arg_types(kernel_fn: Callable):
     """Look for arg types used in the kernel by iterating over arg signature."""
-    return [arg.annotation for arg in inspect.signature(kernel_fn).parameters.values()]
+    return [
+        (arg.annotation, arg.annotation.physical_layout)
+        for arg in inspect.signature(kernel_fn).parameters.values()
+    ]
 
 
 def anonymize_constraints(input_constraints: list[Constraint]):


### PR DESCRIPTION
Different input arguments can have the same logical shape but different physical shape, so we add the physical layout to the key when caching the kernel.