### PR TITLE
[Wave] Fixes to extend attention 

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -560,7 +560,7 @@ class CustomOp(ABC):
         for i, arg in enumerate(self.fx_node.args):
             if isinstance(arg, fx.Node):
                 custom_args[i] = propagate(arg)
-            if isinstance(arg, list) and all(isinstance(x, fx.Node) for x in arg):
+            if isinstance(arg, Sequence) and all(isinstance(x, fx.Node) for x in arg):
                 custom_args[i] = [propagate(x) for x in arg]
         return custom_args
 

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -71,7 +71,7 @@ def get_extend_attention_kernel(
     LOG2E = 1.44269504089
     logit_cap *= LOG2E
     dk_sqrt = math.sqrt(1.0 / shape.head_size)
-    layer_scaling = layer_scaling or dk_sqrt * LOG2E
+    layer_scaling = (layer_scaling or dk_sqrt) * LOG2E
 
     constraints: list[tkw.Constraint] = []
     constraints += [

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -34,6 +34,7 @@ def get_extend_attention_kernel(
     size_dtype: Optional[torch.dtype] = torch.int32,
     is_causal: Optional[bool] = False,
     logit_cap: Optional[float] = 0.0,
+    layer_scaling: Optional[float] = None,
 ):
     # Determine dtype of operands.
     wave_input_dtype = torch_dtype_to_wave(input_dtype)
@@ -69,6 +70,8 @@ def get_extend_attention_kernel(
     N_WAVES = 1
     LOG2E = 1.44269504089
     logit_cap *= LOG2E
+    dk_sqrt = math.sqrt(1.0 / shape.head_size)
+    layer_scaling = layer_scaling or dk_sqrt * LOG2E
 
     constraints: list[tkw.Constraint] = []
     constraints += [
@@ -103,6 +106,7 @@ def get_extend_attention_kernel(
     i = tkw.IndexMapping.iterator(0)
     j = tkw.IndexMapping.iterator(1)
     k = tkw.IndexMapping.iterator(2)
+    d0 = tkw.IndexMapping.dynamic_val(0)
 
     mapping = tkw.IndexMapping(
         num_iterators=3,
@@ -124,8 +128,9 @@ def get_extend_attention_kernel(
     )
     k_cache_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={H_KV: i // head_ratio, N_KV: j + SEQ_IDX, D_Q: k},
+        inputs={H_KV: i // head_ratio, N_KV: d0, D_Q: k},
         outputs={H_KV: i, N_KV: j, D_Q: k},
+        dynamic_val_mappings={N_KV: j},
     )
 
     v_mapping = tkw.IndexMapping(
@@ -136,14 +141,15 @@ def get_extend_attention_kernel(
 
     v_cache_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={H_KV: i // head_ratio, D_KV: j, N_KV: k + SEQ_IDX},
+        inputs={H_KV: i // head_ratio, D_KV: j, N_KV: d0},
         outputs={H_KV: i, D_KV: j, N_KV: k},
+        dynamic_val_mappings={N_KV: k},
     )
 
     block_table_mapping = tkw.IndexMapping(
-        num_iterators=2,
-        inputs={S: REQ_IDX, N_KV: j},
-        outputs={S: i, N_KV: j},
+        num_iterators=1,
+        inputs={S: REQ_IDX, N_KV: i},
+        outputs={N_KV: i},
     )
 
     # Set the dynamic shapes for the kernel. Here we set it to N_Q
@@ -182,6 +188,7 @@ def get_extend_attention_kernel(
         init_max = tkl.Register[H, N_Q, tkl.f32](-1e6)
         zero = tkl.Register[N_Q, N_KV, tkl.f32](0.0)
         neg_infinity = tkl.Register[N_Q, N_KV, tkl.f32](-1e6)
+        layer_scale_reg = tkl.Register[H, N_Q, N_KV, tkl.f32](layer_scaling)
         if logit_cap > 0:
             logit_cap_reg = tkl.Register[H, N_Q, N_KV, tkl.f32](logit_cap)
 
@@ -196,12 +203,6 @@ def get_extend_attention_kernel(
         seq_len_prefix = seq_len - seq_len_extend
 
         tkw.set_symbol(N_KV, seq_len_prefix)
-        block_indices = tkw.read(
-            block_table,
-            elements_per_thread=1,
-            mapping=block_table_mapping,
-        )
-        tkw.set_symbol(SEQ_IDX, block_indices)
 
         @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
         def first_loop(
@@ -214,14 +215,26 @@ def get_extend_attention_kernel(
                 elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
                 mapping=q_mapping,
             )
+            block_indices_v = tkw.read(
+                block_table,
+                elements_per_thread=LOAD_ELEMS_PER_THREAD_PV,
+                mapping=block_table_mapping,
+            )
+            block_indices_k = tkw.read(
+                block_table,
+                elements_per_thread=1,
+                mapping=block_table_mapping,
+            )
             k_reg = tkw.read(
                 k_cache,
                 elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
                 mapping=k_cache_mapping,
+                mapping_dynamic_vals=(block_indices_k,),
             )
             imm_reg = tkl.Register[H, N_KV, N_Q, tkl.f32](0.0)
             inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
             x_j = tkw.permute(inner_acc, target_shape=[H, N_Q, N_KV])
+            x_j = x_j * layer_scale_reg
             if logit_cap > 0:
                 x_j = logit_cap_reg * tkw.tanh(x_j / logit_cap_reg)
             n_kv_index = tkw.self_index(N_KV, tkl.i32)
@@ -240,6 +253,7 @@ def get_extend_attention_kernel(
                 v_cache,
                 elements_per_thread=LOAD_ELEMS_PER_THREAD_PV,
                 mapping=v_cache_mapping,
+                mapping_dynamic_vals=(block_indices_v,),
             )
             new_acc = acc * e_delta_max
             acc = tkw.mma(v_reg, imm_f16, new_acc)
@@ -268,6 +282,7 @@ def get_extend_attention_kernel(
             )
             inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
             x_j = tkw.permute(inner_acc, target_shape=[H, N_Q, N_KV])
+            x_j = x_j * layer_scale_reg
             if logit_cap > 0:
                 x_j = logit_cap_reg * tkw.tanh(x_j / logit_cap_reg)
             n_kv_index = tkw.self_index(N_KV, tkl.i32)

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -368,8 +368,8 @@ class LaunchableWave(Launchable):
         graph_passes += [
             partial(decompose_vmma_ops, trace, self.constraints),
             partial(hoist_loop_invariant_ops, trace, self.constraints),
-            partial(reuse_shared_allocs, trace),
             partial(minimize_global_loads, trace, self.constraints),
+            partial(reuse_shared_allocs, trace),
             partial(apply_shared_memory_indexing_corrections, trace, self.constraints),
         ]
 

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -92,7 +92,6 @@ def test_extend_attention():
         )
 
         # CHECK-LABEL:       func.func @extend_attention
-        # CHECK-COUNT-1:        vector.maskedload
         # CHECK-DAG:            stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x16x64xf16, strided<[1024, 64, 1], offset: ?>>
         # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<1x64x36xf16, #gpu.address_space<workgroup>>
         # CHECK-DAG:            %[[ALLOC2:.*]] = memref.alloc() : memref<1x32x68xf16, #gpu.address_space<workgroup>>
@@ -209,7 +208,6 @@ def test_causal_extend_attention():
         )
 
         # CHECK-LABEL:       func.func @extend_attention
-        # CHECK-COUNT-1:        vector.maskedload
         # CHECK-DAG:            stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x16x64xf16, strided<[1024, 64, 1], offset: ?>>
         # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<1x64x36xf16, #gpu.address_space<workgroup>>
         # CHECK-DAG:            %[[ALLOC2:.*]] = memref.alloc() : memref<1x32x68xf16, #gpu.address_space<workgroup>>

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -309,9 +309,6 @@ def testExtendAttention(
         )
         config["benchmark_results_file"] = os.path.join(dump_perf, perf_filename)
 
-    log2e = 1.44269504089
-    dk_sqrt = math.sqrt(1.0 / shape.head_size)
-
     with tk.gen.TestLaunchContext(
         hyperparams,
         canonicalize=True,
@@ -323,10 +320,8 @@ def testExtendAttention(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        # TODO: Add scaling of QK as part of kernel.
-        # TODO: Add variant of non-transposed V attention kernel.
         mb_qk = extend_attention(
-            q_extend * dk_sqrt * log2e,
+            q_extend,
             k_extend,
             v_extend,
             k_buffer,


### PR DESCRIPTION
This PR adds the following fixes to extend attention:
1. Fixes the way the block indices were being read for the v matrix in the first loop. Because of the layout differences between the first and second mma, we need to read block indices with a different layout and correspondingly elements per thread when loading from the kv cache.
2. Moves the qk-transpose scaling inside the kernel for accuracy reasons.
3. Moves reuse shared allocs pass after minimize global loads.
4. Minor compiler fix regarding use of Sequence vs list