### PR TITLE
[TKW] Reuse allocs fix

### DIFF
--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -19,7 +19,6 @@ from .._support.tracing import CapturedTrace
 from .._support.indexing import IndexExpr, IndexingContext, IndexSymbol, IndexSequence
 from ..lang.global_symbols import *
 from ..ops.wave_ops import (
-    ApplyExpr,
     Conditional,
     CustomOp,
     ExtractSlice,
@@ -33,6 +32,7 @@ from ..ops.wave_ops import (
     Reduction,
     Reshape,
     SetSymbol,
+    SharedMemoryBarrier,
     Write,
     get_custom,
 )
@@ -214,7 +214,7 @@ def DCE(trace: CapturedTrace):
 
         if (
             custom.users
-            or isinstance(custom, (Output, SetSymbol, ApplyExpr))
+            or isinstance(custom, (Output, SetSymbol, SharedMemoryBarrier))
             or is_global_write(node)
         ):
             return False

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -368,8 +368,8 @@ class LaunchableWave(Launchable):
         graph_passes += [
             partial(decompose_vmma_ops, trace, self.constraints),
             partial(hoist_loop_invariant_ops, trace, self.constraints),
-            partial(reuse_shared_allocs, trace),
             partial(minimize_global_loads, trace, self.constraints),
+            partial(reuse_shared_allocs, trace),
             partial(apply_shared_memory_indexing_corrections, trace, self.constraints),
         ]
 

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -110,6 +110,8 @@ def test_extend_attention():
         # CHECK-COUNT-2:            arith.addf
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
+        # CHECK:                amdgpu.lds_barrier
+        # CHECK-NOT:            amdgpu.lds_barrier
         # CHECK-COUNT-4:        vector.maskedload
         # CHECK:                stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x4x64xf16, strided<[256, 64, 1], offset: ?>>
         # CHECK:                stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x4x64xf16, strided<[256, 64, 1], offset: ?>>
@@ -235,6 +237,8 @@ def test_causal_extend_attention():
 
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
+        # CHECK:                amdgpu.lds_barrier
+        # CHECK-NOT:            amdgpu.lds_barrier
         # CHECK-COUNT-4:        vector.maskedload
         # CHECK:                stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x4x64xf16, strided<[256, 64, 1], offset: ?>>
         # CHECK:                stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x4x64xf16, strided<[256, 64, 1], offset: ?>>


### PR DESCRIPTION
* Move `reuse_shared_allocs` after `minimize_global_loads`, as `minimize_global_loads` gets confused by the new alloc structure.
* Insert barrier when replacing alloc to make sure all threads finished their reads/writes to would-be-reused alloc.
* Do not kill `SharedMemoryBarrier` by `DCE`