### PR TITLE
Bring back maskedload and maskedstore

### DIFF
--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -414,9 +414,14 @@ def _create_vec_read(
             )
             mask = _constant_mask(mask_vec_type)
 
-        return vector_d.gather(
-            vector_type, mem, start_indices, offsets_vec, mask, passthru
-        )
+        if offsets_vec is None:
+            return vector_d.maskedload(
+                vector_type, kb_src, start_indices, mask, passthru
+            )
+        else:
+            return vector_d.gather(
+                vector_type, mem, start_indices, offsets_vec, mask, passthru
+            )
 
 
 @handle_op(read)
@@ -533,7 +538,10 @@ def _create_vec_write(
             )
             mask = _constant_mask(mask_vec_type)
 
-        vector_d.scatter(mem, start_indices, offsets_vec, mask, value)
+        if offsets_vec is None:
+            vector_d.maskedstore(mem, start_indices, mask, value)
+        else:
+            vector_d.scatter(mem, start_indices, offsets_vec, mask, value)
 
 
 @handle_op(write)


### PR DESCRIPTION
In a previous PR, we lost the ability to generate maskedload and maskedstore (buffer load and store were the only option). This PR enables folks to use maskedloads and maskedstores if they dont want buffer ops.