### PR TITLE
Include Github run numbered in release candidate version

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Build iree-turbine release candidate
         run: |
-          ./build_tools/compute_local_version.py -rc --write-json
+          ./build_tools/compute_local_version.py \
+            -rc --write-json \
+            --version-suffix "-${{ github.run_number }}"
           ./build_tools/build_release.py --no-download
 
       - name: Upload python wheels

--- a/build_tools/compute_local_version.py
+++ b/build_tools/compute_local_version.py
@@ -19,12 +19,12 @@ import subprocess
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--write-json", action="store_true")
+parser.add_argument("--version-suffix", action="store", type=str)
 
 release_type = parser.add_mutually_exclusive_group(required=True)
 release_type.add_argument("-stable", "--stable-release", action="store_true")
 release_type.add_argument("-rc", "--nightly-release", action="store_true")
 release_type.add_argument("-dev", "--development-release", action="store_true")
-release_type.add_argument("--version-suffix", action="store", type=str)
 
 args = parser.parse_args()
 
@@ -55,7 +55,8 @@ elif args.development_release:
         ".dev0+"
         + subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
     )
-elif args.version_suffix:
+
+if args.version_suffix:
     current_version += args.version_suffix
 
 if args.write_json:


### PR DESCRIPTION
We can't make multiple different versions for the same day.

With this change the release candidates will have a version of the form
3.2.0rc20250205-0
3.2.0rc20250205-1
...
instead of just 3.2.0rc20250205.