### PR TITLE
[Wave] Make maximum extend sequence length dynamic

### DIFF
--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -60,6 +60,10 @@ def isolated_test_call(
         argument_dims = get_dynamic_dims(sig.kernel_buffer_bindings, dynamic_symbols)
         # Adding unique dynamic dims as inputs.
         input_tensors += [IndexType.get() for _ in list(dict.fromkeys(argument_dims))]
+        # Add additional dynamic symbols as inputs.
+        input_tensors += [
+            IndexType.get() for _ in set(dynamic_symbols).difference(argument_dims)
+        ]
 
         output_types = [b.as_mlir_type() for b in sig.kernel_buffer_output_bindings]
         output_tensors = memref_to_tensor(output_types)

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -91,11 +91,11 @@ def test_extend_attention():
             ).module_op
         )
         # This part ensure correctness of WG distribution for extend attention.
-        # CHECK:              stream.executable.export public @extend_attention workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
-        # CHECK:                %[[D0:.+]] = arith.subi %[[ARG0]], %c1 : index
+        # CHECK:              stream.executable.export public @extend_attention workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
+        # CHECK:                %[[D0:.+]] = arith.subi %[[ARG3]], %c1 : index
         # CHECK:                %[[D1:.+]] = arith.divui %[[D0]], %c64 : index
         # CHECK:                %[[D2:.+]] = arith.addi %[[D1]], %c1 : index
-        # CHECK:                %[[D3:.+]] = arith.cmpi eq, %[[ARG0]], %c0 : index
+        # CHECK:                %[[D3:.+]] = arith.cmpi eq, %[[ARG3]], %c0 : index
         # CHECK:                %[[NQ_GRID:.+]] = arith.select %[[D3]], %c0, %[[D2]] : index
         # CHECK:                %[[NUM_SEQ:.+]] = arith.muli %[[ARG2]], %c16 overflow<nsw, nuw> : index
         # CHECK:                stream.return %[[NQ_GRID]], %c1, %[[NUM_SEQ]] : index, index, index


### PR DESCRIPTION
This PR makes the maximum extend sequence a dynamic kernel argument that is used in the grid calculation. 
Tested with gsm8k to 0.816.