### PR TITLE
[TKW] Work on buffer ops

### DIFF
--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -378,16 +378,6 @@ def _linearize_memref(
         offset_th,
     )
 
-_current_op = 0
-_use_buffer = []
-
-def _check_buffer():
-    global _current_op
-    global _use_buffer
-    res = (_current_op in _use_buffer)
-    # print(_current_op) 58
-    _current_op += 1
-    return res
 
 def _create_vec_read(
     emitter: WaveEmitter,
@@ -422,7 +412,7 @@ def _create_vec_read(
     )
     if emitter.params.get("use_buffer_load_ops", False) and all(
         isinstance(s, int) for s in strides
-    ) and _check_buffer():
+    ):
         result = vector_d.splat(vector_type, zero)
 
         strides = [gen_sympy_index(add_emitter_subs(emitter), s) for s in strides]
@@ -577,7 +567,7 @@ def _create_vec_write(
     )
     if emitter.params.get("use_buffer_store_ops", False) and all(
         isinstance(s, int) for s in strides
-    ) and _check_buffer():
+    ):
         strides = [gen_sympy_index(add_emitter_subs(emitter), s) for s in strides]
         data, offset_th = _linearize_memref(
             mem, start_indices_wg, start_indices_th, strides

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -42,7 +42,7 @@ from ...ops.wave_ops import (
     write,
 )
 
-from ..utils import subs_idxc, find_index_bounds
+from ..utils import safe_subs, subs_idxc, find_index_bounds
 
 from ..._support.indexing import IndexingContext, IndexExpr, IndexSequence, index_symbol
 from ...lang.wave_types import IndexMapping
@@ -79,9 +79,9 @@ def _get_start_indices(
 def _split_index(src: IndexExpr) -> tuple[IndexExpr, IndexExpr]:
     subs_wg = {WORKGROUP_0: 0, WORKGROUP_1: 0, WORKGROUP_2: 0}
     subs_th = {THREAD_0: 0, THREAD_1: 0, THREAD_2: 0}
-    thread_dependend_index = src.subs(subs_wg)
+    thread_dependend_index = safe_subs(src, subs_wg)
     return (
-        sympy.simplify((src - thread_dependend_index).subs(subs_th)),
+        sympy.simplify(safe_subs(src - thread_dependend_index, subs_th)),
         thread_dependend_index,
     )
 

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -328,8 +328,6 @@ def _linearize_memref(
     no-op.
     """
     memref_type = mem.type
-    results = memref_d.extract_strided_metadata(mem)
-    base = results[0]
     offset = None
     offset_th = None
     overflow_flags = arith_d.IntegerOverflowFlags.nsw
@@ -369,7 +367,7 @@ def _linearize_memref(
     return (
         memref_d.reinterpret_cast(
             resut_type,
-            base,
+            mem,
             offsets=[offset],
             sizes=[size_full],
             strides=[],

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -89,6 +89,8 @@ def _split_index(src: IndexExpr | int) -> tuple[IndexExpr, IndexExpr]:
     # Compute thread-independent index as `orig_index - thread_dependend_index`
     # All thread symbols should cancel-out in the result, but to be sure
     # replace all thread symbols by 0 in the result.
+    # We cannot just replace all thread symbols without the subtraction as
+    # any constant or dynamic values will end up in both expressions.
     thread_indepdndent_index = sympy.simplify(
         safe_subs(src - thread_dependend_index, subs_th)
     )

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -378,6 +378,16 @@ def _linearize_memref(
         offset_th,
     )
 
+_current_op = 0
+_use_buffer = []
+
+def _check_buffer():
+    global _current_op
+    global _use_buffer
+    res = (_current_op in _use_buffer)
+    # print(_current_op) 58
+    _current_op += 1
+    return res
 
 def _create_vec_read(
     emitter: WaveEmitter,
@@ -412,7 +422,7 @@ def _create_vec_read(
     )
     if emitter.params.get("use_buffer_load_ops", False) and all(
         isinstance(s, int) for s in strides
-    ):
+    ) and _check_buffer():
         result = vector_d.splat(vector_type, zero)
 
         strides = [gen_sympy_index(add_emitter_subs(emitter), s) for s in strides]
@@ -567,7 +577,7 @@ def _create_vec_write(
     )
     if emitter.params.get("use_buffer_store_ops", False) and all(
         isinstance(s, int) for s in strides
-    ):
+    ) and _check_buffer():
         strides = [gen_sympy_index(add_emitter_subs(emitter), s) for s in strides]
         data, offset_th = _linearize_memref(
             mem, start_indices_wg, start_indices_th, strides

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -163,6 +163,49 @@ def test_read_mapped():
 
 
 @run_test
+def test_read_mapped_buffer():
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 16, N: 16}
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    mapping = tkw.IndexMapping(
+        num_iterators=2, inputs={N: i, M: j}, outputs={N: i, M: j}
+    )
+
+    @tkw.wave(constraints)
+    def read_mapped_buffer(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        tkw.read(a, mapping=mapping, elements_per_thread=16)
+
+    with tk.gen.TestLaunchContext(
+        {
+            M: 16,
+            N: 16,
+            K: 16,
+            BLOCK_M: 16,
+            BLOCK_N: 16,
+            BLOCK_K: 16,
+            ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
+        },
+        use_buffer_load_ops=True,
+        use_buffer_store_ops=True,
+    ):
+        a = torch.randn(16, 16, dtype=torch.float16)
+        print(read_mapped_buffer(a).module_op)
+
+        # CHECK-LABEL:    func.func @read_mapped_buffer
+        # CHECK-COUNT-1:    memref.reinterpret_cast
+        # CHECK-COUNT-16:   amdgpu.raw_buffer_load
+
+
+@run_test
 def test_read_write():
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -352,49 +395,6 @@ def test_read_write_masked():
         # CHECK-SAME:         strided<[3, 1], offset: ?>>
         # CHECK:            vector.maskedstore %[[D16]][%[[D5]], %[[D8]]], %[[D14]], %[[D15]] : memref<1x3xf16,
         # CHECK-SAME:         strided<[3, 1], offset: ?>>, vector<4xi1>, vector<4xf16>
-
-
-@run_test
-def test_read_write_buffer():
-    constraints: list[tkw.Constraint] = [
-        tkw.HardwareConstraint(
-            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 4, N: 4}
-        )
-    ]
-    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
-    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
-    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
-    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
-
-    @tkw.wave(constraints)
-    def read_write_buffer(
-        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
-        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
-    ):
-        res = tkw.read(a, elements_per_thread=4)
-        tkw.write(res, b, elements_per_thread=4)
-
-    with tk.gen.TestLaunchContext(
-        {
-            M: 1,
-            N: 3,
-            BLOCK_M: 4,
-            BLOCK_N: 4,
-            ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
-        },
-        canonicalize=True,
-        use_buffer_load_ops=True,
-        use_buffer_store_ops=True,
-    ):
-        a = torch.randn(4, 4, dtype=torch.float16)
-        b = torch.zeros(4, 4, dtype=torch.float16)
-        print(read_write_buffer(a, b).module_op)
-
-        # CHECK-LABEL:    func.func @read_write_buffer
-        # CHECK-COUNT-1:    memref.reinterpret_cast
-        # CHECK-COUNT-4:    amdgpu.raw_buffer_load
-        # CHECK-COUNT-1:    memref.reinterpret_cast
-        # CHECK-COUNT-4:    amdgpu.raw_buffer_store
 
 
 @run_test

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -314,11 +314,15 @@ def testExtendAttention(
     if run_bench:
         config["benchmark_batch_size"] = 1000
         config["benchmark_repetitions"] = 3
+        config["dump_intermediates"] = "./inter"
+
     if dump_perf is not None:
         perf_filename = construct_test_name(
             "wave_extend_attention", mfma_variant, is_causal, shape
         )
         config["benchmark_results_file"] = os.path.join(dump_perf, perf_filename)
+
+    # config["print_ir_after_all"] = True
 
     with tk.gen.TestLaunchContext(
         hyperparams,

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -239,6 +239,7 @@ def create_inputs(
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("enable_scheduling", [False])
 @pytest.mark.parametrize("is_causal", [False, True])
+@pytest.mark.parametrize("use_buffer_ops", [False, True])
 @pytest.mark.parametrize(
     "mfma_variant",
     [
@@ -251,6 +252,7 @@ def testExtendAttention(
     dtype: torch.dtype,
     enable_scheduling: bool,
     is_causal: bool,
+    use_buffer_ops: bool,
     mfma_variant: MMAType,
     request,
 ):
@@ -328,6 +330,8 @@ def testExtendAttention(
         use_scheduling_barriers=enable_scheduling_barriers,
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
+        use_buffer_load_ops=use_buffer_ops,
+        use_buffer_store_ops=use_buffer_ops,
     ):
         mb_qk = extend_attention(
             q_extend,

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -322,8 +322,6 @@ def testExtendAttention(
         )
         config["benchmark_results_file"] = os.path.join(dump_perf, perf_filename)
 
-    # config["print_ir_after_all"] = True
-
     with tk.gen.TestLaunchContext(
         hyperparams,
         canonicalize=True,


### PR DESCRIPTION
* Split read/write ops indexing on thread-dependent and thread-independent.
* Use symbolic vals for strides instead of extracting them from memref.
* For now only replace gather/scatter ops with buffer ops.