### PR TITLE
[Wave] Teach compiler to handle batched MMA for VMFMAOps

### DIFF
--- a/iree/turbine/kernel/wave/decompose_vmma_ops.py
+++ b/iree/turbine/kernel/wave/decompose_vmma_ops.py
@@ -30,23 +30,39 @@ VMMA_TO_NATIVE_MAP = {
 }
 
 
-def get_m_dim(mma_op):
-    m_dims = set(mma_op.lhs_type.symbolic_shape).difference(
+def get_m_dim(mma_op, vmma_expr):
+    m_sets = set(mma_op.lhs_type.symbolic_shape).difference(
         mma_op.rhs_type.symbolic_shape
+    )
+    vmma_expr = vmma_expr.subs({MMA_ACC: 0})
+    m_dims = set(
+        [
+            m_candidate
+            for m_candidate in m_sets
+            if len(mma_op.lhs.index[m_candidate].start.find(vmma_expr)) != 0
+        ]
     )
     assert len(m_dims) == 1, "Expect to have single M-dim."
     return m_dims.pop()
 
 
-def get_n_dim(mma_op):
-    n_dims = set(mma_op.rhs_type.symbolic_shape).difference(
+def get_n_dim(mma_op, vmma_expr):
+    n_sets = set(mma_op.rhs_type.symbolic_shape).difference(
         mma_op.lhs_type.symbolic_shape
+    )
+    vmma_expr = vmma_expr.subs({MMA_ACC: 0})
+    n_dims = set(
+        [
+            n_candidate
+            for n_candidate in n_sets
+            if len(mma_op.rhs.index[n_candidate].start.find(vmma_expr)) != 0
+        ]
     )
     assert len(n_dims) == 1, "Expect to have single N-dim."
     return n_dims.pop()
 
 
-def get_k_dim(mma_op):
+def get_k_dim(mma_op, vmma_expr):
     k_dims = set(mma_op.lhs_type.symbolic_shape).intersection(
         mma_op.rhs_type.symbolic_shape
     )
@@ -137,9 +153,9 @@ def decompose_vmma_ops(
                     slice_lhs, slice_rhs, mma_acc, native_mma_type
                 ).add_to_graph(mma_op.graph)
                 mma_acc.index = copy.deepcopy(mma_op.index)
-                m_dim = get_m_dim(mma_op)
-                n_dim = get_n_dim(mma_op)
-                k_dim = get_k_dim(mma_op)
+                m_dim = get_m_dim(mma_op, vmma_expr[MMAOperand.M.value])
+                n_dim = get_n_dim(mma_op, vmma_expr[MMAOperand.N.value])
+                k_dim = get_k_dim(mma_op, vmma_expr[MMAOperand.K.value])
                 # Replace expression based on virtual with it's equivalence in the native layout.
                 replace_subexpr(
                     mma_acc.index[m_dim].start,

--- a/iree/turbine/kernel/wave/decompose_vmma_ops.py
+++ b/iree/turbine/kernel/wave/decompose_vmma_ops.py
@@ -34,12 +34,14 @@ def get_m_dim(mma_op, vmma_expr):
     m_sets = set(mma_op.lhs_type.symbolic_shape).difference(
         mma_op.rhs_type.symbolic_shape
     )
+    # Filters candidate for M-dims. Adds candidate dim to list iff we find any occurrence
+    # of the reference MMA template expression in the candidate dim's index expression
     vmma_expr = vmma_expr.subs({MMA_ACC: 0})
     m_dims = set(
         [
             m_candidate
             for m_candidate in m_sets
-            if len(mma_op.lhs.index[m_candidate].start.find(vmma_expr)) != 0
+            if mma_op.lhs.index[m_candidate].start.find(vmma_expr)
         ]
     )
     assert len(m_dims) == 1, "Expect to have single M-dim."
@@ -50,12 +52,14 @@ def get_n_dim(mma_op, vmma_expr):
     n_sets = set(mma_op.rhs_type.symbolic_shape).difference(
         mma_op.lhs_type.symbolic_shape
     )
+    # Filters candidate for N-dims. Adds candidate dim to list iff we find any occurrence
+    # of the reference MMA template expression in the candidate dim's index expression
     vmma_expr = vmma_expr.subs({MMA_ACC: 0})
     n_dims = set(
         [
             n_candidate
             for n_candidate in n_sets
-            if len(mma_op.rhs.index[n_candidate].start.find(vmma_expr)) != 0
+            if mma_op.rhs.index[n_candidate].start.find(vmma_expr)
         ]
     )
     assert len(n_dims) == 1, "Expect to have single N-dim."


### PR DESCRIPTION
This handles support of VMFMA for broadcasted batched gemm. i.e the batch size of one of the operand is broadcasted onto the other. i.e this is to support virtual MMA intrinsics in GQA. 

For example in a GQA like gemm we will have (B_KV, M, K) * (B, K, N) -> (B, M, N). In this case, with set operation alone it is hard to see that `B_KV` is also a batch dimension and not M-dim.  

Initial prototype adds an additional set intersection with acc_index.type. Whilst that would work for some cases, it wouldn't work for the operand with the same batch size as the acc/output. i.e in our case above we will fail to determine the right N-dim.
 m-dim = (B_KV, M, K)  - (B, K, N)  ∩  (B, M, N) = (M,) - OK
 n-dim =  (B, K, N)  - (B_KV, M, K)  ∩  (B, M, N) = (B, N) - NG
 
Hence, we added a filter that ensures the mma indexing expression can be found in said dimension, making it more robust to false batch/m-dims in the future.
