### PR TITLE
Global to shared gathers

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1023,6 +1023,7 @@ class Allocate(CustomOp):
     distributed_shape: tuple[IndexExpr]
     dtype: DataType
     address_space: AddressSpace
+    padding: int = 0
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:
@@ -1288,7 +1289,7 @@ class Read(CustomOp):
         if mapping is None:
             return True
 
-        mem_shape = self.memory.type.symbolic_shape
+        mem_shape = get_custom(self.memory).type.symbolic_shape
         if mapping.is_identity() and mapping.input_shape == mem_shape:
             return True
 
@@ -1303,7 +1304,7 @@ class Read(CustomOp):
 
         mapping = self.mapping
 
-        mem_shape = self.memory.type.symbolic_shape
+        mem_shape = get_custom(self.memory).type.symbolic_shape
 
         from ..wave.utils import check_is_mapping_contiguous
 
@@ -1588,7 +1589,7 @@ class Write(CustomOp):
         if mapping is None:
             return True
 
-        mem_shape = self.memory.type.symbolic_shape
+        mem_shape = get_custom(self.memory).type.symbolic_shape
         if mapping.is_identity() and mapping.output_shape == mem_shape:
             return True
 
@@ -1602,7 +1603,7 @@ class Write(CustomOp):
             return True
         mapping = self.mapping
 
-        mem_shape = self.memory.type.symbolic_shape
+        mem_shape = get_custom(self.memory).type.symbolic_shape
 
         from ..wave.utils import check_is_mapping_contiguous
 

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -144,7 +144,7 @@ def handle_register(emitter: WaveEmitter, node: fx.Node):
 @handle_op(allocate)
 def handle_allocate(emitter: WaveEmitter, node: fx.Node):
     try:
-        shape, distributed_shape, dtype, address_space = node.args
+        shape, distributed_shape, dtype, address_space, padding = node.args
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
     memref_shape = cast_py_literal(emitter, distributed_shape)

--- a/iree/turbine/kernel/wave/global_to_shared_gathers.py
+++ b/iree/turbine/kernel/wave/global_to_shared_gathers.py
@@ -1,0 +1,301 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ..wave.constraints import (
+    Constraint,
+    HardwareConstraint,
+    WorkgroupConstraint,
+    TilingConstraint,
+)
+from .._support.tracing import CapturedTrace
+from .._support.indexing import IndexSequence, IndexSymbol, IndexExpr
+from ..lang.wave_types import IndexMapping
+from ..ops.wave_ops import Read, Write, get_custom
+from ..lang.global_symbols import *
+from .utils import subs_idxc, is_gather
+from math import prod
+import torch.fx as fx
+from collections import defaultdict
+from copy import deepcopy
+from .utils import is_shared_read, is_shared_write
+from .minimize_global_loads import (
+    has_write_shared_user,
+    construct_min_global_access_pattern,
+    materialize_shape,
+    identify_optimizable_loads,
+    update_write_dependencies,
+    SharedReadMetadata,
+)
+
+"""
+We are given N global gathers that are promoted to shared memory. This function
+allows us to convert these to:
+ - M contiguous loads from global memory, M writes to shared memory, and N gathers from shared memory.
+
+Promotion allows us to shift the burden of gathers up the memory hierarchy, which can be beneficial for performance.
+
+Given a gather with an access pattern and mapping of the form:
+*** Global gather ***
+index = {H_KV: h : 1 : 1, D_KV: d : 1 : 1, N_KV: n : 4 : 1}
+mapping = input: {H_KV: i // 4, D_KV: j, N_KV: d0},
+          output: {H_KV: i, D_KV: j, N_KV: k}
+          dynamic_val: {N_KV: j}
+
+where d0 is a dynamic value from another read of possibly more
+than one element.
+
+We transform this to (assuming D_KV is the contiguous dimension):
+*** Global load ***
+Linear access pattern along read dimension, permuted mapping.
+index = {H_KV: h : 1 : 1, N_KV: n_new : 1 : 1, D_KV: d_new : 8 : 1}
+mapping = input: {N_KV: d1, H_KV: j // 4, D_KV: k},
+          output: {N_KV: i, H_KV: j, D_KV: k}
+          dynamic_val: {N_KV: i}
+
+The value of d1 is determined by reading from the n_new offset.
+
+*** Shared store ***
+Linear access pattern, identity mapping.
+index = {H_KV: h_new : 1 : 1, D_KV: d_new : 8 : 1, N_KV: n_new : 1 : 1}
+mapping = input: {H_KV: i, N_KV: j, D_KV: k},
+          output: {H_KV: i, N_KV: j, D_KV: k}
+
+*** Shared gather ***
+MMA access pattern, identity mapping.
+index = {H_KV: h : 1 : 1, D_KV: d : 1 : 1, N_KV: n : 4 : 1}
+mapping = input: {H_KV: i , D_KV: j, N_KV: k},
+          output: {H_KV: i, D_KV: j, N_KV: k}
+
+TODO: Support load -> scatter -> load pattern
+We can also modify this function to load contiguously from global memory, scatter to shared memory
+and the load contiguously from global memory.
+
+"""
+
+
+def is_valid_global_gather(node: fx.Node) -> bool:
+    custom = get_custom(node)
+    return (
+        isinstance(custom, Read)
+        and subs_idxc(custom.memory_type.address_space) == GLOBAL_ADDRESS_SPACE
+        and has_write_shared_user(custom)
+        and is_gather(custom)
+    )
+
+
+def make_contiguous_index(read: Read) -> dict[IndexSymbol, IndexSequence]:
+    """
+    This function modifies the index so that we are loading the most
+    elements along the contiguous dimension. This results in an invalid
+    MMA access pattern but that is okay since we are modifying the access
+    pattern from an MMA to linear access pattern.
+    """
+    contiguous_index = {}
+    max_load_size = max(x.size for x in read.index.values())
+    for i, dim in enumerate(read.memory_type.symbolic_shape):
+        contiguous_index[dim] = read.index[dim]
+        if i == len(read.memory_type.symbolic_shape) - 1:
+            contiguous_index[dim].size = max_load_size
+        else:
+            contiguous_index[dim].size = 1
+    return contiguous_index
+
+
+def construct_global_read_mapping(read: Read) -> IndexMapping:
+    """
+    This function constructs a new mapping for the read node.
+    """
+    # Create new identity output mapping.
+    mapping = read.mapping
+    new_mapping = deepcopy(mapping)
+    new_mapping.output_mapping = {}
+    assert mapping.is_output_identity(), "Output mapping must be an identity mapping."
+    for dim, iter in zip(read.memory_type.symbolic_shape, mapping.iters):
+        new_mapping.output_mapping[dim] = iter
+
+    # Find the iter permutation.
+    old_to_new_iter = {}
+    for dim in mapping.output_mapping:
+        old_to_new_iter[mapping.output_mapping[dim]] = new_mapping.output_mapping[dim]
+
+    # Create new input mapping with only dynamic values and additive offsets
+    # in the swapped dimensions. For other dimensions, retain the original
+    # mapping.
+    new_mapping.input_mapping = {}
+    find_iter = lambda x: mapping.input_mapping[dim].find(x)
+    for dim in read.memory_type.symbolic_shape:
+        dim_iter = [find_iter(x) for x in mapping.iters if find_iter(x)]
+        if not dim_iter:
+            new_mapping.input_mapping[dim] = mapping.input_mapping[dim]
+            continue
+        dim_iter = dim_iter[0].pop()
+        new_mapping.input_mapping[dim] = mapping.input_mapping[dim].subs(
+            {dim_iter: old_to_new_iter[dim_iter]}
+        )
+
+    # Update iters for dynamic values in the mapping.
+    for dynamic_mapping in new_mapping.dynamic_val_mappings:
+        for dim in dynamic_mapping:
+            dynamic_mapping[dim] = dynamic_mapping[dim].subs(old_to_new_iter)
+
+    return new_mapping
+
+
+def construct_shared_read_mapping(read: Read) -> IndexMapping:
+    """
+    This function constructs a new mapping for the shared read node.
+    """
+    # Create new identity output mapping.
+    mapping = read.mapping
+    new_mapping = deepcopy(mapping)
+    dynamic_vals = list(mapping.dynamic_val_indices.keys())
+    assert mapping.is_output_identity(), "Output mapping must be an identity mapping."
+    dim_to_iter = {
+        dim: iter for dim, iter in zip(mapping.output_mapping, mapping.iters)
+    }
+
+    # Find the iter permutation.
+    old_to_new_iter = {}
+    for dim in mapping.output_mapping:
+        old_to_new_iter[mapping.output_mapping[dim]] = new_mapping.output_mapping[dim]
+
+    for dim, expr in new_mapping.input_mapping.items():
+        iter = dim_to_iter[dim]
+        new_mapping.input_mapping[dim] = old_to_new_iter[iter]
+
+    new_mapping.dynamic_val_mappings = None
+    new_mapping.dynamic_val_indices = {}
+
+    return new_mapping
+
+
+def update_read_mapping_dynamic_values(read: Read) -> list[fx.Node]:
+    """
+    Since every thread is now only reading one element along the gather dimension,
+    we need to modify the read of the dynamic value to read only one element
+    and do it at the specified index.
+    """
+    for dyn_val in read.mapping_dynamic_vals:
+        custom = get_custom(dyn_val)
+        custom.update_arg("elements_per_thread", 1)
+        for dim in dyn_val.index:
+            if dim in read.index:
+                dyn_val.index[dim] = read.index[dim]
+
+
+def add_optimized_nodes(
+    optimizable_loads: dict[fx.Node, tuple[int, Read]],
+    constraint_tile_size: dict[IndexSymbol, int],
+    hardware_constraint: HardwareConstraint,
+    max_elements_per_load: int,
+    load_elems_per_thread: int,
+) -> dict[fx.Node, list[fx.Node]]:
+    """
+    Add optimized global read nodes and shared write nodes to the graph.
+    This follows the original implementation in minimize_global_loads, with a couple of changes:
+    - We update the mapping of the global reads.
+    - We propagate the reads to indirect reads if we have dynamic values.
+    - We maintain metadata to update the shared reads in the next function.
+    """
+    optimized_writes = defaultdict(list)
+    shared_read_metadata: dict[Write, SharedReadMetadata] = {}
+    for memory, (expected_number_of_loads, custom_loads) in optimizable_loads.items():
+        original_access_pattern = deepcopy(custom_loads[0].index)
+        access_pattern = make_contiguous_index(custom_loads[0])
+        for i in range(expected_number_of_loads):
+            custom = custom_loads[i]
+            with custom.graph.inserting_before(custom.fx_node):
+                read = Read(
+                    memory,
+                    load_elems_per_thread,
+                    custom.mapping,
+                    custom.mapping_dynamic_vals,
+                ).add_to_graph(custom.graph)
+                global_offset = (
+                    hardware_constraint.linearized_thread_id * load_elems_per_thread
+                    + i * max_elements_per_load
+                )
+                materialized_shape = materialize_shape(
+                    constraint_tile_size, custom.memory_type.symbolic_shape
+                )
+                read.index = construct_min_global_access_pattern(
+                    access_pattern,
+                    global_offset,
+                    load_elems_per_thread,
+                    materialized_shape,
+                )
+                new_custom_read = get_custom(read)
+                if new_custom_read.mapping_dynamic_vals:
+                    update_read_mapping_dynamic_values(new_custom_read)
+
+                new_custom_read.update_arg(
+                    "mapping", construct_global_read_mapping(new_custom_read)
+                )
+                for custom_user in custom.users:
+                    if (
+                        isinstance(custom_user, Write)
+                        and custom_user.type.address_space == SHARED_ADDRESS_SPACE
+                    ):
+                        write = Write(
+                            read, custom_user.memory, load_elems_per_thread
+                        ).add_to_graph(custom.graph)
+                        write.index = read.index
+                        optimized_writes[custom_user.memory].append(write)
+                        write.vector_shapes = custom.vector_shapes
+                        shared_read_metadata[write] = SharedReadMetadata(
+                            index=original_access_pattern,
+                            mapping=construct_shared_read_mapping(custom),
+                            memory_shape=custom.memory_type.symbolic_shape,
+                        )
+                        break
+    return optimized_writes, shared_read_metadata
+
+
+def global_to_shared_gathers(trace: CapturedTrace, constraints: list[Constraint]):
+    """
+    This function converts global gathers to shared gathers.
+    Unlike minimize_global_loads, this function does not change the widths
+    of the loads.
+    """
+    global_gathers = trace.walk(is_valid_global_gather)
+    if not global_gathers:
+        return
+
+    hardware_constraint = next(
+        c for c in constraints if isinstance(c, HardwareConstraint)
+    )
+    constraint_tile_size = {
+        c.dim: c.tile_size
+        for c in constraints
+        if isinstance(c, TilingConstraint) or isinstance(c, WorkgroupConstraint)
+    }
+
+    total_number_of_threads = hardware_constraint.threads_per_wave * prod(
+        hardware_constraint.waves_per_block
+    )
+    element_type = get_custom(global_gathers[0]).type.dtype
+    load_elems_per_thread = hardware_constraint.max_elems_per_load(element_type)
+    max_elements_per_load = total_number_of_threads * load_elems_per_thread
+
+    optimizable_loads = identify_optimizable_loads(
+        global_gathers,
+        constraint_tile_size,
+        max_elements_per_load,
+        allow_mapping_dynamic_values=True,
+        use_memory_type=True,
+    )
+
+    # Construct new global read nodes and write shared nodes.
+    optimized_writes, shared_read_metadata = add_optimized_nodes(
+        optimizable_loads,
+        constraint_tile_size,
+        hardware_constraint,
+        max_elements_per_load,
+        load_elems_per_thread,
+    )
+
+    # Update all write dependencies.
+    update_write_dependencies(optimized_writes, trace, shared_read_metadata)

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -71,10 +71,16 @@ def test_paged_flash_decoding():
     # CHECK:                        amdgpu.lds_barrier
     # CHECK-COUNT-3:                vector.maskedload
     # CHECK-COUNT-8:                vector.store
-    # TODO: Remove gathers for performance
-    # CHECK-COUNT-2:                vector.gather
-    # CHECK-COUNT-8:                vector.store
+    # CHECK-COUNT-1:                vector.maskedload
+    # CHECK-COUNT-1:                vector.store
+    # CHECK-COUNT-1:                vector.maskedload
+    # CHECK-COUNT-1:                vector.store
+    # CHECK-COUNT-1:                vector.maskedload
+    # CHECK-COUNT-1:                vector.store
+    # CHECK-COUNT-1:                vector.maskedload
+    # CHECK-COUNT-1:                vector.store
     # CHECK:                        amdgpu.lds_barrier
+    # CHECK-COUNT-8:                vector.gather
     # CHECK-COUNT-8:                vector.load
     # CHECK-COUNT-8:                amdgpu.mfma
     # CHECK:                  %[[COND:.*]] = arith.cmpi sgt, %[[COUNT]], %[[C0]] : index

--- a/lit_tests/kernel/wave/attention/evoformer.py
+++ b/lit_tests/kernel/wave/attention/evoformer.py
@@ -196,9 +196,10 @@ def test_evoformer():
         # CHECK:                {{.*}} = scf.for
         # CHECK:                    {{.*}} = vector.load
         # CHECK:                    vector.store {{.*}}
+        # CHECK:                    {{.*}} = vector.maskedload
+        # CHECK:                    vector.store {{.*}}
         # CHECK:                    amdgpu.lds_barrier
-        # CHECK-COUNT-4:            {{.*}} = vector.load
-        # CHECK-COUNT-4:            {{.*}} = vector.load
+        # CHECK-COUNT-4:            {{.*}} = vector.gather
         # CHECK-COUNT-4:            {{.*}} = vector.load
         # CHECK-COUNT-8:           {{.*}} = amdgpu.mfma
         # CHECK-COUNT-2:            {{.*}} = vector.load

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -102,15 +102,15 @@ def test_extend_attention():
 
         # CHECK-LABEL:       func.func @extend_attention
         # CHECK-DAG:            stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x16x64xf16, strided<[1024, 64, 1], offset: ?>>
-        # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<1x64x36xf16, #gpu.address_space<workgroup>>
+        # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<32x1x68xf16, #gpu.address_space<workgroup>>
         # CHECK-DAG:            %[[ALLOC2:.*]] = memref.alloc() : memref<1x32x68xf16, #gpu.address_space<workgroup>>
         # CHECK-COUNT-4:        vector.maskedload
         # CHECK:                scf.for
+        # CHECK-COUNT-11:           vector.maskedload
+        # CHECK-COUNT-8:            vector.store %{{.*}}, %[[ALLOC2]]
         # CHECK-COUNT-1:            vector.maskedload
-        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC2]]
-        # CHECK-COUNT-1:            vector.gather
         # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC1]]
-        # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
+        # CHECK-COUNT-8:            vector.gather %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
         # CHECK-COUNT-2:            arith.cmpi slt
@@ -126,9 +126,7 @@ def test_extend_attention():
         # CHECK:                scf.for
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC2]]
-        # CHECK-COUNT-1:            vector.gather
-        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC1]]
-        # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
+        # CHECK-COUNT-8:            vector.gather %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
         # CHECK-COUNT-2:            arith.cmpi slt
@@ -220,15 +218,15 @@ def test_causal_extend_attention():
 
         # CHECK-LABEL:       func.func @extend_attention
         # CHECK-DAG:            stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x16x64xf16, strided<[1024, 64, 1], offset: ?>>
-        # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<1x64x36xf16, #gpu.address_space<workgroup>>
+        # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<32x1x68xf16, #gpu.address_space<workgroup>>
         # CHECK-DAG:            %[[ALLOC2:.*]] = memref.alloc() : memref<1x32x68xf16, #gpu.address_space<workgroup>>
         # CHECK-COUNT-4:        vector.maskedload
         # CHECK:                scf.for
+        # CHECK-COUNT-11:           vector.maskedload
+        # CHECK-COUNT-8:            vector.store %{{.*}}, %[[ALLOC2]]
         # CHECK-COUNT-1:            vector.maskedload
-        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC2]]
-        # CHECK-COUNT-1:            vector.gather
         # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC1]]
-        # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
+        # CHECK-COUNT-8:            vector.gather %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
 
@@ -252,9 +250,7 @@ def test_causal_extend_attention():
         # CHECK:                scf.for
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC2]]
-        # CHECK-COUNT-1:            vector.gather
-        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC1]]
-        # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
+        # CHECK-COUNT-8:            vector.gather %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
 
@@ -357,15 +353,15 @@ def test_causal_extend_attention_32x32x8():
 
         # CHECK-LABEL:       func.func @extend_attention
         # CHECK-DAG:            stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x16x64xf16, strided<[1024, 64, 1], offset: ?>>
-        # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<1x64x36xf16, #gpu.address_space<workgroup>>
+        # CHECK-DAG:            %[[ALLOC1:.*]] = memref.alloc() : memref<32x1x68xf16, #gpu.address_space<workgroup>>
         # CHECK-DAG:            %[[ALLOC2:.*]] = memref.alloc() : memref<1x32x68xf16, #gpu.address_space<workgroup>>
         # CHECK-COUNT-8:        vector.maskedload
         # CHECK:                scf.for
-        # CHECK-COUNT-13:           vector.maskedload
+        # CHECK-COUNT-11:           vector.maskedload
         # CHECK-COUNT-8:            vector.store %{{.*}}, %[[ALLOC2]]
-        # CHECK-COUNT-8:            vector.gather
-        # CHECK-COUNT-8:            vector.store %{{.*}}, %[[ALLOC1]]
-        # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
+        # CHECK-COUNT-1:            vector.maskedload
+        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC1]]
+        # CHECK-COUNT-8:            vector.gather %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
 
@@ -389,13 +385,7 @@ def test_causal_extend_attention_32x32x8():
         # CHECK:                scf.for
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC2]]
-        # CHECK-COUNT-1:            vector.maskedload
-        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC2]]
-        # CHECK-COUNT-1:            vector.gather
-        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC1]]
-        # CHECK-COUNT-1:            vector.gather
-        # CHECK-COUNT-1:            vector.store %{{.*}}, %[[ALLOC1]]
-        # CHECK-COUNT-8:            vector.load %[[ALLOC1]]
+        # CHECK-COUNT-8:            vector.gather %[[ALLOC1]]
         # CHECK-COUNT-8:            vector.load %[[ALLOC2]]
         # CHECK-COUNT-8:            amdgpu.mfma
 

--- a/lit_tests/kernel/wave/attention/prefill_attention.py
+++ b/lit_tests/kernel/wave/attention/prefill_attention.py
@@ -57,11 +57,10 @@ def test_prefill_attention():
         # CHECK-COUNT-1:            vector.store
         # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-1:            vector.gather
+        # CHECK-COUNT-1:            vector.maskedload
         # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-1:            vector.gather
-        # CHECK-COUNT-1:            vector.store
-        # CHECK-COUNT-32:           vector.load
+        # CHECK-COUNT-16:           vector.gather
+        # CHECK-COUNT-16:           vector.load
         # CHECK-COUNT-16:           amdgpu.mfma
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-16:           amdgpu.mfma

--- a/lit_tests/kernel/wave/barriers.py
+++ b/lit_tests/kernel/wave/barriers.py
@@ -94,7 +94,7 @@ def test_read_write_equal_sizes():
         add_shared_memory_barriers(trace)
         print_trace(trace, False)
         # CHECK: %allocate
-        # CHECK-SAME: ((M, N), (BLOCK_M, BLOCK_N + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((M, N), (BLOCK_M, BLOCK_N + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read_M:0_N:0
@@ -192,9 +192,9 @@ def test_gemm():
         # CHECK-NEXT: %register_M:1_N:0_K:0
         # CHECK-NEXT: %register_M:1_N:1_K:0
         # CHECK-NEXT: %allocate_1
-        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %allocate
-        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: reduction
         # CHECK-SAME: (K, [%register_M:0_N:0_K:0, %register_M:0_N:1_K:0, %register_M:1_N:0_K:0, %register_M:1_N:1_K:0]
         # CHECK-NEXT: %getresult_M:0_N:0_K:0

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -104,9 +104,9 @@ def test_gemm():
         # CHECK-NEXT: %register_M:1_N:0_K:0
         # CHECK-NEXT: %register_M:1_N:1_K:0
         # CHECK-NEXT: %allocate_1
-        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %allocate
-        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: reduction
         # CHECK-SAME (K, [%register_M:0_N:0_K:0, %register_M:0_N:1_K:0, %register_M:1_N:0_K:0, %register_M:1_N:1_K:0]
         # CHECK-NEXT: %getresult_M:0_N:0_K:0

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -110,9 +110,9 @@ def test_gemm():
         # CHECK-NEXT: %register_M:1_N:0_K:0
         # CHECK-NEXT: %register_M:1_N:1_K:0
         # CHECK-NEXT: %allocate_1
-        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %allocate
-        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: reduction
         # CHECK-SAME (K, [%register_M:0_N:0_K:0, %register_M:1_N:1_K:0, %register_M:1_N:0_K:0, %register_M:0_N:1_K:0]
         # CHECK-NEXT: %getresult_M:0_N:0_K:0

--- a/lit_tests/kernel/wave/promotion.py
+++ b/lit_tests/kernel/wave/promotion.py
@@ -74,7 +74,7 @@ def test_read_write_equal_sizes():
         promote_node(read_node, None, SHARED_ADDRESS_SPACE, constraints)
         print_trace(trace, False)
         # CHECK: %allocate
-        # CHECK-SAME: ((M, N), (BLOCK_M, BLOCK_N + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((M, N), (BLOCK_M, BLOCK_N + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read
@@ -124,7 +124,7 @@ def test_read_write_equal_sizes_different_address_spaces():
         promote_placeholders(trace, constraints)
         print_trace(trace, False)
         # CHECK: %allocate
-        # CHECK-SAME: ((M, N), (BLOCK_M, BLOCK_N + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((M, N), (BLOCK_M, BLOCK_N + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %a
         # CHECK-NEXT: %c
         # CHECK-NEXT: %read
@@ -188,9 +188,9 @@ def test_gemm():
         # CHECK-NEXT: %c
         # CHECK-NEXT: %register
         # CHECK: %allocate_1
-        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %allocate
-        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE)
+        # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: reduction
         # CHECK-NEXT: %write
         # CHECK-SAME: (%reduction, %c, 4, None, ())


### PR DESCRIPTION
This PR adds support for transforming gathers from global memory to gather to shared memory. In order to do this,
we modify the loads from global and stores to shared to use all the threads available and then use gathers to obtain
the data from shared memory.

We add a new pass that closely follows minimize global loads as well as other changes to enable this.