### PR TITLE
[TKW] Fix RPE 32x32x8 MMA

### DIFF
--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -261,6 +261,11 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                 ] = updated_dim_with_gpr_offset
 
                 if hasattr(custom, "mapping_dynamic_vals"):
+                    # If we are partitioning read/write ops, dynamic_vals can be
+                    # potentially partitioned as well. Partitioned dyn vals are
+                    # are merged into single value using Reshape op which still
+                    # holds the original index containing `GPR_NUM`.
+                    # Extract corresponding partitioned chunk from such ops.
                     new_dynamic_vals = []
                     for dyn_val in custom.mapping_dynamic_vals:
                         if any(
@@ -319,6 +324,9 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                 )
                 reshape.expanded_dims = custom.expanded_dims
                 reshape.vector_shapes = custom.vector_shapes
+
+                # Save the original index on the reshape op so later we can
+                # detect if op was part of `gpr_offset` partition.
                 reshape.index = custom.index
                 custom.replace_all_uses_with(reshape)
 

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -284,6 +284,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                         extract,
                         custom.memory,
                         mapping=custom.mapping,
+                        mapping_dynamic_vals=new_dynamic_vals,
                         elements_per_thread=gpr_size,
                     ).add_to_graph(custom.graph)
                 elif isinstance(custom, Read):

--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -10,7 +10,6 @@ from ..ops.wave_ops import (
     Broadcast,
     CustomOp,
     ExtractSlice,
-    get_custom,
     IterArg,
     MMA,
     NestedRegionOp,
@@ -22,6 +21,7 @@ from ..ops.wave_ops import (
     Reshape,
     SelfIndex,
     Write,
+    get_custom,
 )
 from .constraints import (
     Constraint,
@@ -200,7 +200,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
         }
         if isinstance(custom, SelfIndex):
             # If specified use element_per_thread instead of IndexExpr size.
-            elements_per_thread = (
+            elements_per_thread = subs_idxc(
                 custom.elements_per_thread or custom.index[custom.dim].size
             )
         else:
@@ -278,6 +278,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                         custom.memory,
                         elements_per_thread=gpr_size,
                         mapping=custom.mapping,
+                        mapping_dynamic_vals=custom.mapping_dynamic_vals,
                         _write_dependency=custom._write_dependency,
                     ).add_to_graph(custom.graph)
                 elif isinstance(custom, SelfIndex):
@@ -304,6 +305,7 @@ def partition_ops_with_gpr_offsets(trace: CapturedTrace, constraints: list[Const
                 reshape.expanded_dims = custom.expanded_dims
                 reshape.vector_shapes = custom.vector_shapes
                 custom.replace_all_uses_with(reshape)
+
             custom.graph.erase_node(custom.fx_node)
 
 

--- a/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
+++ b/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
@@ -78,7 +78,11 @@ def get_t5_rpe_attention_kernel(
 
     d0, d1 = [tkw.IndexMapping.dynamic_val(i) for i in range(2)]
     clip = sympy.Piecewise(
+<<<<<<< HEAD
         (d0 - d1, (d0 - d1 < max_context_length) & (d0 - d1 >= 0)), (0, True)
+=======
+        (d0 - d1, (d0 - d1 < max_context_length) & (d0 - d1 > 0)), (0, True)
+>>>>>>> 5d9d3f1 (actual fix)
     )
     offset_mapping = tkw.IndexMapping(
         num_iterators=2,

--- a/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
+++ b/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
@@ -121,8 +121,8 @@ def get_t5_rpe_attention_kernel(
             # Fused T5 RPE adds attention bias pre-softmax normalization.
             # When fusing into the FA variant, adding locally before the max and
             # the partial softmax should be equivalent.
-            i = tkw.self_index(M, tkl.i64, elements_per_thread=1)
-            j = tkw.self_index(K2, tkl.i64, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            i = tkw.self_index(M, tkl.i64)
+            j = tkw.self_index(K2, tkl.i64)
             rpe_reg = tkw.read(
                 rpe,
                 mapping=offset_mapping,

--- a/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
+++ b/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
@@ -129,7 +129,7 @@ def get_t5_rpe_attention_kernel(
                 rpe,
                 mapping=offset_mapping,
                 mapping_dynamic_vals=(i, j),
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
+                elements_per_thread=STORE_ELEMS_PER_THREAD,
             )
             x_j = x_j + rpe_reg
 

--- a/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
+++ b/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
@@ -122,9 +122,7 @@ def get_t5_rpe_attention_kernel(
             # When fusing into the FA variant, adding locally before the max and
             # the partial softmax should be equivalent.
             i = tkw.self_index(M, tkl.i64, elements_per_thread=1)
-            j = tkw.self_index(
-                K2, tkl.i64, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK
-            )
+            j = tkw.self_index(K2, tkl.i64, elements_per_thread=STORE_ELEMS_PER_THREAD)
             rpe_reg = tkw.read(
                 rpe,
                 mapping=offset_mapping,

--- a/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
+++ b/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
@@ -78,11 +78,7 @@ def get_t5_rpe_attention_kernel(
 
     d0, d1 = [tkw.IndexMapping.dynamic_val(i) for i in range(2)]
     clip = sympy.Piecewise(
-<<<<<<< HEAD
         (d0 - d1, (d0 - d1 < max_context_length) & (d0 - d1 >= 0)), (0, True)
-=======
-        (d0 - d1, (d0 - d1 < max_context_length) & (d0 - d1 > 0)), (0, True)
->>>>>>> 5d9d3f1 (actual fix)
     )
     offset_mapping = tkw.IndexMapping(
         num_iterators=2,

--- a/tests/kernel/wave/attention/t5_rpe_attention_test.py
+++ b/tests/kernel/wave/attention/t5_rpe_attention_test.py
@@ -92,7 +92,10 @@ def create_inputs(
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize(
     "mfma_variant",
-    [(MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16)],
+    [
+        (MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16),
+        (MMAType.F32_32x32x8_F16, MMAType.F32_32x32x8_F16),
+    ],
 )
 def test_t5_rpe_attention(
     shape: Tuple[int],


### PR DESCRIPTION
* Add missing `subs_idxc` in `has_gpr_offsets`
* Handle `mapping_dynamic_vals` for read/write ops in `has_gpr_offsets`
* Propagate index to generated `Reshape` op, which needed for proper detection dynamic vals handling
* Use `STORE_ELEMS_PER_THREAD` for RPE read in RPE kernel as the result is combined with mma result
* Remove `elements_per_thread` from `self_index` as they can be inferred