### PR TITLE
[Wave] Remove polynomial approx with iree compile flag

### DIFF
--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -609,6 +609,9 @@ def compile_to_vmfb(
     if backend == "rocm":
         target = config["target"]
         flags.append(f"--iree-hip-target={target}")
+        # Polynomial approximation passes in MLIR/IREE often generate
+        # suboptimal code with redundant clamps and fptosi. This flag
+        # allows us to skip unnecessary approx for GPU.
         flags.append("--iree-codegen-gpu-native-math-precision=true")
 
     if config.get("print_ir_after_all", False):

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -609,6 +609,7 @@ def compile_to_vmfb(
     if backend == "rocm":
         target = config["target"]
         flags.append(f"--iree-hip-target={target}")
+        flags.append("--iree-codegen-gpu-native-math-precision=true")
 
     if config.get("print_ir_after_all", False):
         flags.append("--mlir-print-ir-after-all")


### PR DESCRIPTION
Polynomial approximation causes major slowdown, so we add a IREE compile flag to remove it. The changes wouldn't be visible at Wave level but will give good perf boost in generated LLVMIR