### PR TITLE
[TKW] Fix memory leak

### DIFF
--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1610,6 +1610,8 @@ def print_live_tensors():
     """
     import gc
 
+    gc.collect()
+
     print("------ live tensors ---------")
     for obj in gc.get_objects():
         try:

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -524,7 +524,7 @@ def _invoke(vm_context, device, entry_function, inputs, outputs, dynamic_dims):
 
 
 _dl_tensor_name = ctypes.create_string_buffer(b"dltensor")
-_set_capsule_name = ctypes.pythonapi.PyCapsule_setName
+_set_capsule_name = ctypes.pythonapi.PyCapsule_SetName
 
 
 def _inplace_invoke(vm_context, device, entry_function, inputs, outputs, dynamic_dims):

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -335,35 +335,19 @@ def testExtendAttention(
         use_buffer_load_ops=use_buffer_ops,
         use_buffer_store_ops=use_buffer_ops,
     ):
-        from iree.turbine.kernel.wave.utils import print_live_tensors
-
-        print_live_tensors()
-        if True:
-            mb_qk = extend_attention(
-                q_extend,
-                k_extend,
-                v_extend,
-                k_buffer,
-                v_buffer,
-                req_to_tokens,
-                b_req_idx,
-                b_seq_len,
-                b_seq_len_extend,
-                b_start_loc_extend,
-                output,
-            )
-        del q_extend
-        del k_extend
-        del v_extend
-        del k_buffer
-        del v_buffer
-        del req_to_tokens
-        del b_req_idx
-        del b_seq_len
-        del b_seq_len_extend
-        del b_start_loc_extend
-        del output
-        print_live_tensors()
+        mb_qk = extend_attention(
+            q_extend,
+            k_extend,
+            v_extend,
+            k_buffer,
+            v_buffer,
+            req_to_tokens,
+            b_req_idx,
+            b_seq_len,
+            b_seq_len_extend,
+            b_start_loc_extend,
+            output,
+        )
 
     if dump_generated_mlir:
         filename = f"wave_extend_attention_kernel_{'x'.join(map(str, shape))}.mlir"
@@ -371,19 +355,19 @@ def testExtendAttention(
             f.write(mb_qk.module_op.get_asm())
 
     # Run the reference implementation.
-    # ref_output = ref_extend_attn(
-    #     q_extend=q_extend,
-    #     k_buffer=k_buffer,
-    #     v_buffer=v_buffer,
-    #     b_req_idx=b_req_idx,
-    #     b_start_loc=b_start_loc,
-    #     b_seq_len=b_seq_len,
-    #     b_seq_len_prefix=b_seq_len_prefix,
-    #     max_len_in_batch=max_len_in_batch,
-    #     extend_token_num=extend_token_num,
-    #     dtype=dtype,
-    #     is_causal=is_causal,
-    #     logit_cap=logit_cap,
-    # )
+    ref_output = ref_extend_attn(
+        q_extend=q_extend,
+        k_buffer=k_buffer,
+        v_buffer=v_buffer,
+        b_req_idx=b_req_idx,
+        b_start_loc=b_start_loc,
+        b_seq_len=b_seq_len,
+        b_seq_len_prefix=b_seq_len_prefix,
+        max_len_in_batch=max_len_in_batch,
+        extend_token_num=extend_token_num,
+        dtype=dtype,
+        is_causal=is_causal,
+        logit_cap=logit_cap,
+    )
 
-    # assert_allclose(output, ref_output, rtol=1e-3, atol=1e-3)
+    assert_allclose(output, ref_output, rtol=1e-3, atol=1e-3)

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -337,7 +337,7 @@ def testExtendAttention(
     ):
         from iree.turbine.kernel.wave.utils import print_live_tensors
 
-        print_tensors()
+        print_live_tensors()
         if True:
             mb_qk = extend_attention(
                 q_extend,
@@ -363,7 +363,7 @@ def testExtendAttention(
         del b_seq_len_extend
         del b_start_loc_extend
         del output
-        print_tensors()
+        print_live_tensors()
 
     if dump_generated_mlir:
         filename = f"wave_extend_attention_kernel_{'x'.join(map(str, shape))}.mlir"

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -234,7 +234,7 @@ def create_inputs(
 
 # TODO: Investigate errors on MI250.
 @require_e2e
-# @require_cdna3
+@require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("extend"))
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("enable_scheduling", [False])

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -41,16 +41,21 @@ from ..common.shapes import get_test_shapes, construct_test_name
 
 # Reference paged attention implementation from vLLM and sglang.
 
+
 def print_tensors():
     import gc
+
     print("alive tensors ---------------")
     for obj in gc.get_objects():
         try:
-            if torch.is_tensor(obj) or (hasattr(obj, 'data') and torch.is_tensor(obj.data)):
-                print(type(obj), obj.size())
+            if torch.is_tensor(obj) or (
+                hasattr(obj, "data") and torch.is_tensor(obj.data)
+            ):
+                print(hex(id(obj)), type(obj), obj.size())
         except:
             pass
     print("-----------------------------")
+
 
 def context_attention_fwd(
     q: torch.Tensor,
@@ -346,19 +351,20 @@ def testExtendAttention(
         use_buffer_store_ops=use_buffer_ops,
     ):
         print_tensors()
-        mb_qk = extend_attention(
-            q_extend,
-            k_extend,
-            v_extend,
-            k_buffer,
-            v_buffer,
-            req_to_tokens,
-            b_req_idx,
-            b_seq_len,
-            b_seq_len_extend,
-            b_start_loc_extend,
-            output,
-        )
+        if True:
+            mb_qk = extend_attention(
+                q_extend,
+                k_extend,
+                v_extend,
+                k_buffer,
+                v_buffer,
+                req_to_tokens,
+                b_req_idx,
+                b_seq_len,
+                b_seq_len_extend,
+                b_start_loc_extend,
+                output,
+            )
         del q_extend
         del k_extend
         del v_extend

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -42,21 +42,6 @@ from ..common.shapes import get_test_shapes, construct_test_name
 # Reference paged attention implementation from vLLM and sglang.
 
 
-def print_tensors():
-    import gc
-
-    print("alive tensors ---------------")
-    for obj in gc.get_objects():
-        try:
-            if torch.is_tensor(obj) or (
-                hasattr(obj, "data") and torch.is_tensor(obj.data)
-            ):
-                print(hex(id(obj)), type(obj), obj.size())
-        except:
-            pass
-    print("-----------------------------")
-
-
 def context_attention_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -350,6 +335,8 @@ def testExtendAttention(
         use_buffer_load_ops=use_buffer_ops,
         use_buffer_store_ops=use_buffer_ops,
     ):
+        from iree.turbine.kernel.wave.utils import print_live_tensors
+
         print_tensors()
         if True:
             mb_qk = extend_attention(


### PR DESCRIPTION
We are converting kernel args to dlpack capsule to feed them into IREE runtime, unfortunately, IREE runtime renames all incoming capsules from "dltensor" to "dltensor_used" for some reason and also will never delete capsule if its name not a "dltensor". This causes incoming tensors lifetime to be prolonged indefinitely and to be never released.

Rename capsule back after `device.from_dlpack_capsule`