### PR TITLE
[TKW] Less conservative partition

### DIFF
--- a/iree/turbine/kernel/wave/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/index_sequence_analysis.py
@@ -143,7 +143,7 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
             """
             Check if resulted partitioned write is equivalent to contiguous write.
 
-            Write is contiguous if offsets has form `x + [0,1,2...N]` for
+            Write is contiguous if offsets has form `[0,1,2...N]` for
             the fastest mem dim and 0s for all others dims.
             """
             fastest_mem_dim = custom.memory.type.symbolic_shape[-1]
@@ -156,7 +156,7 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
 
             fastest_mem_dim_idx = symbolic_shape.index(fastest_mem_dim)
 
-            # Construct expected effsets in the form
+            # Construct expected offsets in the form:
             # [[0 0 0]
             #  [0 1 0]
             #  [0 2 0]

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -136,7 +136,7 @@ def test_extend_attention():
         # CHECK-COUNT-2:            arith.addf
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
-        # CHECK-COUNT-16:      vector.maskedstore
+        # CHECK-COUNT-4:       vector.maskedstore
 
 
 @run_test
@@ -281,7 +281,7 @@ def test_causal_extend_attention():
 
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
-        # CHECK-COUNT-16:      vector.maskedstore
+        # CHECK-COUNT-4:       vector.maskedstore
 
 
 @run_test
@@ -417,4 +417,4 @@ def test_causal_extend_attention_32x32x8():
 
         # CHECK-COUNT-2:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-8:            amdgpu.mfma
-        # CHECK-COUNT-8:       vector.maskedstore
+        # CHECK-COUNT-2:       vector.maskedstore

--- a/lit_tests/kernel/wave/attention/pipelined_attention.py
+++ b/lit_tests/kernel/wave/attention/pipelined_attention.py
@@ -174,7 +174,7 @@ def test_dynamic_attention_pipelined():
         # CHECK-COUNT-15:            {{.*}} = amdgpu.mfma
         # CHECK-COUNT-5:            {{.*}} = gpu.shuffle xor {{.*}}
         # CHECK-COUNT-1:            {{.*}} = amdgpu.mfma
-        # CHECK-COUNT-16:       vector.maskedstore {{.*}}
+        # CHECK-COUNT-4:        vector.maskedstore {{.*}}
 
 
 @run_test

--- a/lit_tests/kernel/wave/attention/prefill_attention.py
+++ b/lit_tests/kernel/wave/attention/prefill_attention.py
@@ -64,4 +64,4 @@ def test_prefill_attention():
         # CHECK-COUNT-16:           amdgpu.mfma
         # CHECK-COUNT-4:            gpu.shuffle xor {{.*}}
         # CHECK-COUNT-16:           amdgpu.mfma
-        # CHECK-COUNT-16:      vector.maskedstore
+        # CHECK-COUNT-4:       vector.maskedstore


### PR DESCRIPTION
Previously, `partition_strided_operators` was always partitioning writes if input register index was strided. Add an additional check if the result partitioned writes are equivalent to contiguous when combined with index and mapping.

This helps to vectorize various attention kernels result writes.