### PR TITLE
Use LRU cache when retrieving kernel hash

### DIFF
--- a/iree/turbine/kernel/wave/assumptions.py
+++ b/iree/turbine/kernel/wave/assumptions.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from .._support.indexing import IndexExpr
 
 
-@dataclass
+@dataclass(frozen=True)
 class Assumption:
     """
     Assumptions are sympy assumptions that can be used to

--- a/iree/turbine/kernel/wave/symbolic_constraints.py
+++ b/iree/turbine/kernel/wave/symbolic_constraints.py
@@ -16,7 +16,7 @@ from .constraints import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class SymbolicAlias:
     """
     A constraint of the form `tkw.SymbolicConstraint(K, SYMBOLIC_K)` specifies

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1624,3 +1624,13 @@ def print_live_tensors():
         except:
             pass
     print("-----------------------------")
+
+
+def safe_dict_to_tuple(d: dict) -> tuple:
+    """
+    Convert a dictionary to a tuple if not None,
+    else return None.
+    """
+    if d is None:
+        return None
+    return tuple(d.items())

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -59,6 +59,7 @@ from .utils import (
     canonicalize_module,
     compile_to_vmfb,
     invoke_vmfb,
+    safe_dict_to_tuple,
     safe_subs,
     remove_chained_getresult,
     remove_chained_extractslice,
@@ -69,7 +70,12 @@ from .utils import (
     partial,
     print_trace,
 )
-from .cache import is_cache_enabled, get_cache_manager, invoke_cached_kernel
+from .cache import (
+    is_cache_enabled,
+    get_cache_manager,
+    invoke_cached_kernel,
+    anonymize_constraints,
+)
 
 # Others
 from typing import Any, Callable, Optional
@@ -521,12 +527,13 @@ class LaunchableWave(Launchable):
         if cache_enabled:
             cache_manager = get_cache_manager()
             # TODO: Move use_scheduling, use_scheduling_barriers, etc. into the config so everything is contained there.
+            processed_constraints = anonymize_constraints(self.constraints)
             kernel_hash = cache_manager.get_hash(
-                self.constraints,
+                processed_constraints,
                 self._f,
-                IndexingContext.current().subs,
-                dynamic_symbols,
-                config,
+                safe_dict_to_tuple(IndexingContext.current().subs),
+                tuple(dynamic_symbols),
+                safe_dict_to_tuple(config),
                 use_scheduling=use_scheduling,
                 use_scheduling_barriers=use_scheduling_barriers,
                 run_bench=run_bench,

--- a/tests/kernel/wave/runtime/cache_test.py
+++ b/tests/kernel/wave/runtime/cache_test.py
@@ -213,6 +213,15 @@ def testSameConfig(request):
         assert (
             len(cache_manager.session_cache) == 1
         ), "Expected len == 1, after caching first kernel."
+        assert (
+            cache_manager.get_hash.cache_info().hits == 0
+        ), "Expected to get no LRU cache hits"
+        assert (
+            cache_manager.get_hash.cache_info().misses == 1
+        ), "Expected to get 1 LRU cache miss"
+        assert (
+            cache_manager.get_hash.cache_info().currsize == 1
+        ), "Expected to get 1 element in cache"
 
         # Subsequent run/call to kernel, this should be using cached.
         output = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
@@ -226,6 +235,15 @@ def testSameConfig(request):
         assert isinstance(
             cached_kernel, WaveCache
         ), "Expected subsequent call to be cached."
+        assert (
+            cache_manager.get_hash.cache_info().hits == 1
+        ), "Expected to get 1 LRU cache hit"
+        assert (
+            cache_manager.get_hash.cache_info().misses == 1
+        ), "Expected to get 1 LRU cache miss"
+        assert (
+            cache_manager.get_hash.cache_info().currsize == 1
+        ), "Expected to get 1 element in cache"
 
 
 @require_e2e


### PR DESCRIPTION
This PR annotates the get_hash function for retrieving cached kernels with functools.lru_cache to ensure that we don't pay the cost for computing the hash for a particular kernel more than once per session.

get_hash used to take 2.5ms, and with this PR that goes down to 0.9ms , since we are avoiding the hash calculation and just doing a lookup.