### PR TITLE
[TKW] Extend attention RPE `F32_32x32x8_F16`

### DIFF
--- a/iree/turbine/kernel/wave/templates/extend_attention_rpe.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention_rpe.py
@@ -315,13 +315,13 @@ def get_extend_attention_rpe_kernel(
             i = tkw.self_index(N_Q, tkl.i64, elements_per_thread=1)
             i = tkw.broadcast(i, target_shape=[H, N_Q, N_KV])
             j = tkw.self_index(
-                N_KV, tkl.i64, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK
+                N_KV, tkl.i64, elements_per_thread=STORE_ELEMS_PER_THREAD
             )
             rpe_reg = tkw.read(
                 rpe,
                 mapping=rpe_mapping,
                 mapping_dynamic_vals=(i, j),
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
+                elements_per_thread=STORE_ELEMS_PER_THREAD,
             )
             # Layer and RPE scaling since we use log2 instead of ln
             x_j = x_j * layer_scale_reg + rpe_reg * rpe_scale_reg

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -430,6 +430,7 @@ def testExtendAttention(
     "mfma_variant",
     [
         (MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16),
+        (MMAType.F32_32x32x8_F16, MMAType.F32_32x32x8_F16),
     ],
 )
 def testExtendRpeAttention(


### PR DESCRIPTION
Need to use `STORE_ELEMS_PER_THREAD` for RPE as we are applying RPE to mma accumulator.