### PR TITLE
Improvements to caching

### DIFF
--- a/iree/turbine/kernel/wave/assumptions.py
+++ b/iree/turbine/kernel/wave/assumptions.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from .._support.indexing import IndexExpr
 
 
-@dataclass(frozen=True)
+@dataclass
 class Assumption:
     """
     Assumptions are sympy assumptions that can be used to

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -103,7 +103,6 @@ def anonymize_constraints(input_constraints: list[Constraint]):
             constraint.wave_id = None
         else:
             continue
-    return tuple(processed_constraints)
 
 
 class WaveCacheManager(object):
@@ -126,10 +125,9 @@ class WaveCacheManager(object):
         self.lock = threading.Lock()
         self.update_file_cache()
 
-    @staticmethod
-    @functools.lru_cache(maxsize=MAX_LRU_CACHE_SIZE)
     def get_hash(
-        processed_constraints: list[Constraint],
+        self,
+        constraints: list[Constraint],
         kernel_fn: Callable,
         hyperparams: dict[IndexExpr, Any],
         dynamic_symbols: list[IndexExpr, Any],
@@ -151,6 +149,7 @@ class WaveCacheManager(object):
             # We also taught load_kernel and store_kernel to skip
             # if kernel_hash is None.
             return None
+        processed_constraints = anonymize_constraints(constraints)
         key = [
             kernel_src,
             processed_constraints,
@@ -299,6 +298,7 @@ def invoke_cached_kernel(
     dynamic_symbols_map: dict[IndexExpr, int],
     run: bool,
     run_bench: bool,
+    kernel_hash: str,
 ):
     kernel_inputs = []
     kernel_outputs = []
@@ -326,4 +326,5 @@ def invoke_cached_kernel(
         run,
         run_bench,
         inplace=True,
+        kernel_hash=kernel_hash,
     )

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -109,30 +109,6 @@ class HardwareConstraint(Constraint):
     vector_shapes: Optional[dict[IndexSymbol, int]] = None
     max_bits_per_load: int = 128
 
-    def __eq__(self, value):
-        if not isinstance(value, HardwareConstraint):
-            return False
-        return (
-            self.threads_per_wave == value.threads_per_wave
-            and self.waves_per_block == value.waves_per_block
-            and self.mma_type == value.mma_type
-            and self.vector_shapes == value.vector_shapes
-            and self.max_bits_per_load == value.max_bits_per_load
-        )
-
-    def __hash__(self):
-        from .utils import safe_dict_to_tuple
-
-        return hash(
-            (
-                self.threads_per_wave,
-                self.waves_per_block,
-                self.mma_type,
-                safe_dict_to_tuple(self.vector_shapes),
-                self.max_bits_per_load,
-            )
-        )
-
     def max_elems_per_load(self, element_type: DataType) -> int:
         return self.max_bits_per_load // element_type.bitwidth()
 
@@ -402,30 +378,6 @@ class WorkgroupConstraint(Constraint):
     primary: Optional[bool] = True
     iters: Optional[IndexExpr | int] = None
 
-    def __eq__(self, value):
-        if not isinstance(value, WorkgroupConstraint):
-            return False
-        return (
-            self.dim == value.dim
-            and self.tile_size == value.tile_size
-            and self.workgroup_dim == value.workgroup_dim
-            and self.apply_fn == value.apply_fn
-            and self.primary == value.primary
-            and self.iters == value.iters
-        )
-
-    def __hash__(self):
-        return hash(
-            (
-                self.dim,
-                self.tile_size,
-                self.workgroup_dim,
-                self.apply_fn,
-                self.primary,
-                self.iters,
-            )
-        )
-
     def __post_init__(self):
         self.wg_dim = None
         match self.workgroup_dim:
@@ -492,9 +444,6 @@ class TilingConstraint(Constraint):
             and self.iters == value.iters
         )
 
-    def __hash__(self):
-        return hash((self.dim, self.tile_size, self.induction_var, self.iters))
-
     @property
     def count(self) -> IndexExpr:
         """
@@ -543,14 +492,6 @@ class WaveConstraint(Constraint):
     dim: IndexExpr
     tile_size: IndexExpr
     wave_id: Optional[IndexExpr] = None
-
-    def __eq__(self, value):
-        if not isinstance(value, WaveConstraint):
-            return False
-        return self.dim == value.dim and self.tile_size == value.tile_size
-
-    def __hash__(self):
-        return hash((self.dim, self.tile_size))
 
     def apply(self) -> IndexSequence:
         if self.wave_id is None:

--- a/iree/turbine/kernel/wave/symbolic_constraints.py
+++ b/iree/turbine/kernel/wave/symbolic_constraints.py
@@ -16,7 +16,7 @@ from .constraints import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass
 class SymbolicAlias:
     """
     A constraint of the form `tkw.SymbolicConstraint(K, SYMBOLIC_K)` specifies

--- a/iree/turbine/kernel/wave/templates/attention_common.py
+++ b/iree/turbine/kernel/wave/templates/attention_common.py
@@ -10,7 +10,7 @@ from typing import Optional
 import iree.turbine.kernel.lang as tkl
 
 
-@dataclass
+@dataclass(frozen=True)
 class AttentionShape:
     num_query_heads: int
     num_kv_heads: int

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -59,7 +59,6 @@ from .utils import (
     canonicalize_module,
     compile_to_vmfb,
     invoke_vmfb,
-    safe_dict_to_tuple,
     safe_subs,
     remove_chained_getresult,
     remove_chained_extractslice,
@@ -74,7 +73,6 @@ from .cache import (
     is_cache_enabled,
     get_cache_manager,
     invoke_cached_kernel,
-    anonymize_constraints,
 )
 
 # Others
@@ -521,23 +519,30 @@ class LaunchableWave(Launchable):
         config = kwargs.get("run_config", None)
         use_scheduling = kwargs.get("schedule", False)
         use_scheduling_barriers = kwargs.get("use_scheduling_barriers", False)
+        # When this is passed in from the user, we will populate it with the kernel hash.
+        cached_kernel_hash = kwargs.get("kernel_hash", [])
 
         # Get cached kernel when available.
         cache_enabled = is_cache_enabled()
+        kernel_hash = None
         if cache_enabled:
             cache_manager = get_cache_manager()
             # TODO: Move use_scheduling, use_scheduling_barriers, etc. into the config so everything is contained there.
-            processed_constraints = anonymize_constraints(self.constraints)
-            kernel_hash = cache_manager.get_hash(
-                processed_constraints,
-                self._f,
-                safe_dict_to_tuple(IndexingContext.current().subs),
-                tuple(dynamic_symbols),
-                safe_dict_to_tuple(config),
-                use_scheduling=use_scheduling,
-                use_scheduling_barriers=use_scheduling_barriers,
-                run_bench=run_bench,
-            )
+            if cached_kernel_hash:
+                kernel_hash = cached_kernel_hash[0]
+            if not kernel_hash:
+                kernel_hash = cache_manager.get_hash(
+                    self.constraints,
+                    self._f,
+                    IndexingContext.current().subs,
+                    dynamic_symbols,
+                    config,
+                    use_scheduling=use_scheduling,
+                    use_scheduling_barriers=use_scheduling_barriers,
+                    run_bench=run_bench,
+                )
+                cached_kernel_hash.append(kernel_hash)
+
             cached_kernel = cache_manager.load_kernel(kernel_hash)
             if cached_kernel and (run or run_bench):
                 invoke_cached_kernel(
@@ -548,6 +553,7 @@ class LaunchableWave(Launchable):
                     dynamic_symbols_map,
                     run,
                     run_bench,
+                    kernel_hash,
                 )
                 return cached_kernel
 
@@ -611,6 +617,7 @@ class LaunchableWave(Launchable):
                 run,
                 run_bench,
                 inplace=True,
+                kernel_hash=kernel_hash,
             )
 
         return mb

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -520,15 +520,18 @@ class LaunchableWave(Launchable):
         use_scheduling = kwargs.get("schedule", False)
         use_scheduling_barriers = kwargs.get("use_scheduling_barriers", False)
         # When this is passed in from the user, we will populate it with the kernel hash.
+        # It will always be returned with just one entry which is the hash of the kernel.
         cached_kernel_hash = kwargs.get("kernel_hash", [])
 
         # Get cached kernel when available.
         cache_enabled = is_cache_enabled()
         kernel_hash = None
         if cache_enabled:
-            cache_manager = get_cache_manager()
             # TODO: Move use_scheduling, use_scheduling_barriers, etc. into the config so everything is contained there.
+            cache_manager = get_cache_manager()
             if cached_kernel_hash:
+                # If a cached_kernel_hash is passed in, we assume it was generated in a previous run
+                # and since we always return a list of size 1, we can just grab the first element.
                 kernel_hash = cached_kernel_hash[0]
             if not kernel_hash:
                 kernel_hash = cache_manager.get_hash(
@@ -541,7 +544,7 @@ class LaunchableWave(Launchable):
                     use_scheduling_barriers=use_scheduling_barriers,
                     run_bench=run_bench,
                 )
-                cached_kernel_hash.append(kernel_hash)
+                cached_kernel_hash[:] = [kernel_hash]
 
             cached_kernel = cache_manager.load_kernel(kernel_hash)
             if cached_kernel and (run or run_bench):

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -8,6 +8,7 @@ import math
 import pytest
 import torch
 from torch.nn import functional as F
+from dataclasses import replace
 
 
 import iree.turbine.kernel as tk
@@ -291,7 +292,7 @@ def create_inputs(
     ],
 )
 def testExtendAttention(
-    shape: list[AttentionShape],
+    shape: AttentionShape,
     dtype: torch.dtype,
     enable_scheduling: bool,
     is_causal: bool,
@@ -322,7 +323,7 @@ def testExtendAttention(
         _,
         _,
     ) = create_inputs(shape, dtype)
-    shape.max_seq_len = max_len_extend
+    shape = replace(shape, max_seq_len=max_len_extend)
 
     if mfma_variant[0] == MMAType.F32_16x16x16_F16:
         num_waves = 4
@@ -434,7 +435,7 @@ def testExtendAttention(
     ],
 )
 def testExtendRpeAttention(
-    shape: list[AttentionShape],
+    shape: AttentionShape,
     dtype: torch.dtype,
     enable_scheduling: bool,
     is_causal: bool,
@@ -464,7 +465,7 @@ def testExtendRpeAttention(
         rpe_bias,
         max_rpe_context_length,
     ) = create_inputs(shape, dtype)
-    shape.max_seq_len = max_len_extend
+    shape = replace(shape, max_seq_len=max_len_extend)
 
     if mfma_variant[0] == MMAType.F32_16x16x16_F16:
         num_waves = 4


### PR DESCRIPTION
This PR improves the way caching was done. Rather than use functools.lru_cache, users can now pass in a kernel_hash argument which will return the kernel hash for the kernel. This can then be reused in subsequent calls to avoid the hash computation.

Furthermore, we add a runtime cache to cache the system context and function to lower overheads.
