### PR TITLE
[TKW] Warn if IREE versions is too low

### DIFF
--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -89,6 +89,14 @@ __all__ = ["wave", "wave_trace_only"]
 _warned = False
 
 
+def _are_versions_compatible(ver1: "Version", ver2: "Version") -> bool:
+    if ver1.is_prerelease or ver2.is_prerelease:
+        return ver1 == ver2
+    else:
+        # For stable releases, it is fine if the patch level mismatches.
+        return (ver1.major == ver2.major) and (ver1.minor == ver2.minor)
+
+
 def _warn_iree_is_too_old():
     """
     Issue a warning if IREE runtime and compiler versions mismatch or IREE
@@ -110,7 +118,7 @@ def _warn_iree_is_too_old():
 
     iree_compiler_ver = Version(version("iree-base-compiler"))
     iree_runtime_ver = Version(version("iree-base-runtime"))
-    if iree_compiler_ver != iree_runtime_ver:
+    if not _are_versions_compatible(iree_compiler_ver, iree_runtime_ver):
         warnings.warn(
             f"IREE compiler and runtime versions mismatch: {iree_compiler_ver} and {iree_runtime_ver}"
         )

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -90,6 +90,12 @@ _warned = False
 
 
 def _warn_iree_is_too_old():
+    """
+    Issue a warning if IREE runtime and compiler versions mismatch or IREE
+    version is too low.
+
+    Warning is issued only once.
+    """
     global _warned
     if _warned:
         return
@@ -480,6 +486,10 @@ class LaunchableWave(Launchable):
         kernel_codegen.KernelSignature,
         str,
     ]:
+        # Issue a warning if IREE ver is too low.
+        # Warning will only be issued if we are compileing the kernel and won't
+        # if we are using cached kernel as we don't want to add any additional
+        # overhead to 'happy' path.
         _warn_iree_is_too_old()
 
         compile_config = kwargs.get("compile_config", {})

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -80,6 +80,30 @@ from typing import Any, Callable, Dict, Optional, Sequence
 import torch.fx as fx
 import inspect
 import sympy
+import warnings
+
+try:
+    from packaging.version import Version
+    from importlib.metadata import version
+except ImportError:
+    Version = None
+
+if Version:
+    _iree_compiler_ver = Version(version("iree-base-compiler"))
+    _iree_runtime_ver = Version(version("iree-base-runtime"))
+    if _iree_compiler_ver != _iree_runtime_ver:
+        warnings.warn(
+            f"IREE compiler and runtime versions mismatch: {_iree_compiler_ver} and {_iree_runtime_ver}"
+        )
+
+    # Increment only when IREE has breaking changes.
+    # We don't want to enforce it on package level or make it a hard error just yet.
+    _min_iree_version = Version("3.3.0rc20250228")
+    if _iree_compiler_ver < _min_iree_version:
+        warnings.warn(
+            f"IREE version is too old: {_iree_compiler_ver}, min version: {_min_iree_version}"
+        )
+
 
 __all__ = ["wave", "wave_trace_only"]
 

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -495,7 +495,7 @@ class LaunchableWave(Launchable):
         str,
     ]:
         # Issue a warning if IREE ver is too low.
-        # Warning will only be issued if we are compileing the kernel and won't
+        # Warning will only be issued if we are compiling the kernel and won't
         # if we are using cached kernel as we don't want to add any additional
         # overhead to 'happy' path.
         _warn_iree_is_too_old()


### PR DESCRIPTION
Emit a warning if IREE version is too low. Warning is only emitted when we trying to compile kernel, so if users don't use Wave they won't see it. We also don't emit it if user uses a cached kernel to not add any additional overhead to 'happy' path.