### PR TITLE
[TKW] Avoid redefining test options from utils

### DIFF
--- a/tests/kernel/wave/attention/alibi_attention_test.py
+++ b/tests/kernel/wave/attention/alibi_attention_test.py
@@ -29,10 +29,7 @@ import os
 from torch.testing import assert_close
 from ..common.utils import (
     require_e2e,
-    require_cdna3,
     enable_scheduling_barriers,
-    dump_generated_mlir,
-    get_default_arch,
 )
 from ..common.shapes import get_test_shapes
 from typing import List, Optional, Tuple

--- a/tests/kernel/wave/common/utils.py
+++ b/tests/kernel/wave/common/utils.py
@@ -11,6 +11,9 @@ from iree.turbine.kernel.wave.utils import (
 )
 
 require_e2e = pytest.mark.require_e2e
+require_cdna2 = pytest.mark.skipif(
+    "gfx90" not in get_default_arch(), reason="Default device is not CDNA2"
+)
 require_cdna3 = pytest.mark.skipif(
     "gfx94" not in get_default_arch(), reason="Default device is not CDNA3"
 )

--- a/tests/kernel/wave/runtime/cache_test.py
+++ b/tests/kernel/wave/runtime/cache_test.py
@@ -41,8 +41,9 @@ from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
 from iree.turbine.kernel.wave.templates.vanilla_attention import (
     get_vanilla_attention_kernel,
 )
-
-require_e2e = pytest.mark.require_e2e
+from ..common.utils import (
+    require_e2e,
+)
 
 require_cache = pytest.mark.skipif(
     not is_cache_enabled(), reason="filesystem cache is disabled"

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -22,6 +22,11 @@ from iree.turbine.kernel.wave.utils import (
     device_randperm,
     device_zeros,
 )
+from .common.utils import (
+    require_e2e,
+    require_cdna3,
+    perf_test,
+)
 import torch
 from torch.testing import assert_close
 import pytest
@@ -30,10 +35,6 @@ import os
 import torch
 import json
 
-require_e2e = pytest.mark.require_e2e
-require_cdna3 = pytest.mark.skipif(
-    "gfx94" not in get_default_arch(), reason="Default device is not CDNA3"
-)
 default_test_shapes = [
     (1, 27),
     (111, 813),
@@ -1417,7 +1418,6 @@ _igemm_cases = [
     (1, 5, 5, 1, 3, 3, 1, 1),
 ]
 
-perf_test = lambda *a: pytest.param(*a, marks=pytest.mark.perf_only)
 validation_test = lambda *a: pytest.param(*a, marks=pytest.mark.validate_only)
 
 _igemm_cases += [


### PR DESCRIPTION
There was a lot of copypasta in tests redefining these common options
that are now defined in utils.
