### PR TITLE
[TKW] Consistently return asm in test execution

### DIFF
--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -50,7 +50,7 @@ class WaveCache:
     vmfb: bytes
 
     @property
-    def module_op(self):
+    def asm(self):
         filepath = (CACHE_BASE_DIR / self.cache_id / self.cache_id).with_suffix(".mlir")
         with open(filepath, "r") as f:
             module_str = f.read()

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -124,6 +124,8 @@ class WaveCacheManager(object):
         self.session_cache: OrderedDict[str, WaveCache] = OrderedDict()
         self.lock = threading.Lock()
         self.update_file_cache()
+        self.cache_hits = 0
+        self.cache_misses = 0
 
     def get_hash(
         self,
@@ -268,9 +270,13 @@ class WaveCacheManager(object):
         with self.lock:
             if kernel_hash in self.session_cache:
                 self.session_cache.move_to_end(kernel_hash)
+                self.cache_hits += 1
             elif kernel_hash in self.file_cache:
                 cached_kernel = self.load_kernel_from_file(kernel_hash)
                 self.store_kernel_to_session(kernel_hash, cached_kernel)
+                self.cache_hits += 1
+            else:
+                self.cache_misses += 1
             return self.session_cache.get(kernel_hash, None)
 
 

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -635,7 +635,6 @@ class LaunchableWave(Launchable):
             entrypoint_name,
         ) = self._trace_and_get_kernel_signature(args, kwargs)
 
-        asm = mb.module_op.get_asm()
         if run or run_bench or create_vmfb_file:
             if not config:
                 raise ValueError("no config provided")
@@ -643,6 +642,7 @@ class LaunchableWave(Launchable):
             host_codegen.isolated_test_call(
                 mb, exe, kernel_sig, entrypoint_name, dynamic_symbols
             )
+            asm = mb.module_op.get_asm()
             if config.get("print_mlir", False):
                 print(asm)
 
@@ -694,7 +694,7 @@ class LaunchableWave(Launchable):
                 kernel_hash=kernel_hash,
             )
 
-        return asm
+        return mb.module_op.get_asm()
 
     def aot_execute(self, args, kwargs):
         raise NotImplementedError("AOT execution for wave not implemented yet.")

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -624,7 +624,7 @@ class LaunchableWave(Launchable):
                     run_bench,
                     kernel_hash,
                 )
-                return cached_kernel
+                return cached_kernel.asm
 
         # Recompile kernel from scratch if not found in cache.
         (

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -677,7 +677,7 @@ class LaunchableWave(Launchable):
                 cache_manager.store_kernel(
                     compiled_wave_vmfb,
                     kernel_usages,
-                    mb.module_op.get_asm(),
+                    asm,
                     kernel_hash,
                 )
 
@@ -694,7 +694,7 @@ class LaunchableWave(Launchable):
                 kernel_hash=kernel_hash,
             )
 
-        return mb
+        return asm
 
     def aot_execute(self, args, kwargs):
         raise NotImplementedError("AOT execution for wave not implemented yet.")

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -635,6 +635,7 @@ class LaunchableWave(Launchable):
             entrypoint_name,
         ) = self._trace_and_get_kernel_signature(args, kwargs)
 
+        asm = mb.module_op.get_asm()
         if run or run_bench or create_vmfb_file:
             if not config:
                 raise ValueError("no config provided")
@@ -642,7 +643,6 @@ class LaunchableWave(Launchable):
             host_codegen.isolated_test_call(
                 mb, exe, kernel_sig, entrypoint_name, dynamic_symbols
             )
-            asm = mb.module_op.get_asm()
             if config.get("print_mlir", False):
                 print(asm)
 

--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -149,7 +149,7 @@ def test_attention_32x32x8():
         k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-        print(base_attention_32x32x8(q, k, v, output).module_op)
+        print(base_attention_32x32x8(q, k, v, output))
 
         # CHECK-DAG:        #iree_codegen.translation_info
         # CHECK-SAME:       {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign"}
@@ -291,7 +291,7 @@ def test_dynamic_attention_32x32x8():
         k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-        print(dynamic_attention_32x32x8(q, k, v, output).module_op)
+        print(dynamic_attention_32x32x8(q, k, v, output))
 
         # CHECK-LABEL:      func.func @dynamic_attention_32x32x8
         # CHECK-DAG:            %[[IOTA:.+]] = arith.constant dense<[0, 1, 2, 3]> : vector<4xindex>
@@ -359,7 +359,7 @@ def test_attention():
             shape.head_size_kv,
             dtype=torch.float32,
         )
-        print(base_attention(q, k, v, output).module_op)
+        print(base_attention(q, k, v, output))
 
         # CHECK-LABEL:       func.func @base_attention
         # CHECK:                {{.*}} = scf.for
@@ -416,7 +416,7 @@ def test_attention_causal():
             shape.head_size_kv,
             dtype=torch.float32,
         )
-        print(base_attention(q, k, v, output).module_op)
+        print(base_attention(q, k, v, output))
 
         # CHECK-LABEL:       func.func @base_attention
         # CHECK:                %[[NEG_INF:.+]] = arith.constant dense<-1.000000e+06> : vector<4xf32>

--- a/lit_tests/kernel/wave/attention/attention_bias.py
+++ b/lit_tests/kernel/wave/attention/attention_bias.py
@@ -146,7 +146,7 @@ def test_attention_bias():
         k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-        print(base_attention_bias(q, k, v, output).module_op)
+        print(base_attention_bias(q, k, v, output))
 
         # CHECK:            func.func @base_attention_bias
         # CHECK:                {{.*}} = scf.for

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -61,7 +61,7 @@ def test_paged_flash_decoding():
         schedule=False,
         use_scheduling_barriers=False,
     ):
-        print(phase_0(q, k, v, logits, logits_max).module_op)
+        print(phase_0(q, k, v, logits, logits_max))
 
     # CHECK:                func.func @phase_0
     # CHECK-DAG:               %[[C0:.*]] = arith.constant 0 : index
@@ -94,7 +94,7 @@ def test_paged_flash_decoding():
         schedule=False,
         use_scheduling_barriers=False,
     ):
-        print(phase_1(logits, logits_max, output).module_op)
+        print(phase_1(logits, logits_max, output))
 
     # CHECK:            func.func @phase_1
     # CHECK:               scf.for
@@ -146,7 +146,7 @@ def test_flash_decoding():
         dynamic_symbols=dynamic_symbols_0,
         dynamic_symbols_map=dynamic_symbols_map_0,
     ):
-        print(phase_0(q, k, v, logits, logits_max).module_op)
+        print(phase_0(q, k, v, logits, logits_max))
 
     # CHECK:            func.func @phase_0
     # CHECK-NOT:               {{.*}} = scf.for
@@ -175,7 +175,7 @@ def test_flash_decoding():
         dynamic_symbols=dynamic_symbols_1,
         dynamic_symbols_map=dynamic_symbols_map_1,
     ):
-        print(phase_1(logits, logits_max, output).module_op)
+        print(phase_1(logits, logits_max, output))
 
     # CHECK:            func.func @phase_1
     # CHECK:               {{.*}} = scf.for

--- a/lit_tests/kernel/wave/attention/evoformer.py
+++ b/lit_tests/kernel/wave/attention/evoformer.py
@@ -190,7 +190,7 @@ def test_evoformer():
         k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-        print(evoformer(q, k, v, output).module_op)
+        print(evoformer(q, k, v, output))
 
         # CHECK:            func.func @evoformer
         # CHECK:                {{.*}} = scf.for

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -88,7 +88,7 @@ def test_extend_attention():
                 sequence_lengths_extend,
                 start_indices_extend,
                 output,
-            ).module_op
+            )
         )
         # This part ensure correctness of WG distribution for extend attention.
         # CHECK:              stream.executable.export public @extend_attention workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
@@ -215,7 +215,7 @@ def test_causal_extend_attention():
                 sequence_lengths_extend,
                 start_indices_extend,
                 output,
-            ).module_op
+            )
         )
 
         # CHECK-LABEL:       func.func @extend_attention
@@ -361,7 +361,7 @@ def test_causal_extend_attention_32x32x8():
                 sequence_lengths_extend,
                 start_indices_extend,
                 output,
-            ).module_op
+            )
         )
 
         # CHECK-LABEL:       func.func @extend_attention

--- a/lit_tests/kernel/wave/attention/pipelined_attention.py
+++ b/lit_tests/kernel/wave/attention/pipelined_attention.py
@@ -154,7 +154,7 @@ def test_dynamic_attention_pipelined():
         k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-        print(dynamic_attention_pipelined(q, k, v, output).module_op)
+        print(dynamic_attention_pipelined(q, k, v, output))
 
         # CHECK-LABEL:       func.func @dynamic_attention_pipelined
         # CHECK-COUNT-4:        {{.*}} = vector.maskedload {{.*}}
@@ -289,7 +289,7 @@ def test_attention_pipelined():
         k = torch.randn(shape[0], shape[4], shape[3], dtype=torch.float16)
         v = torch.randn(shape[0], shape[4], shape[2], dtype=torch.float16)
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-        print(base_attention_pipelined(q, k, v, output).module_op)
+        print(base_attention_pipelined(q, k, v, output))
 
         # CHECK-LABEL:       func.func @base_attention_pipelined
         # CHECK:                {{.*}} = scf.for

--- a/lit_tests/kernel/wave/attention/prefill_attention.py
+++ b/lit_tests/kernel/wave/attention/prefill_attention.py
@@ -49,7 +49,7 @@ def test_prefill_attention():
         output = torch.zeros(o_shape, dtype=torch.float32)
         offsets = torch.ones(shape.num_seqs, dtype=torch.int32)
         seq_lens = torch.ones(shape.num_seqs, dtype=torch.int32)
-        print(prefill_attention(q, k, v, offsets, seq_lens, output).module_op)
+        print(prefill_attention(q, k, v, offsets, seq_lens, output))
         # CHECK-LABEL:       func.func @prefill_attention
         # CHECK-COUNT-4:        vector.maskedload
         # CHECK:                scf.for

--- a/lit_tests/kernel/wave/casting.py
+++ b/lit_tests/kernel/wave/casting.py
@@ -74,7 +74,7 @@ def test_cast():
     with codegen_test_context(canonicalize=True):
         a = torch.randn(16, 16, dtype=torch.float16)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(test(a, b).module_op)
+        print(test(a, b))
 
         # CHECK:  %[[D0:.*]] = arith.extf {{.*}} : vector<16xf16> to vector<16xf32>
         # CHECK:  %[[D1:.*]] = arith.fptosi %[[D0]] : vector<16xf32> to vector<16xi8>

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -70,7 +70,7 @@ def test_read():
 
     with codegen_test_context():
         a = torch.randn(16, 16, dtype=torch.float16)
-        print(read(a).module_op)
+        print(read(a))
 
         # CHECK-LABEL:    func.func @read
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding)
@@ -125,7 +125,7 @@ def test_read_mapped():
 
     with codegen_test_context():
         a = torch.randn(16, 16, dtype=torch.float16)
-        print(read_mapped(a).module_op)
+        print(read_mapped(a))
 
         # CHECK-LABEL:    func.func @read_mapped
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding)
@@ -195,7 +195,7 @@ def test_read_mapped_buffer():
         use_buffer_store_ops=True,
     ):
         a = torch.randn(16, 16, dtype=torch.float16)
-        print(read_mapped_buffer(a).module_op)
+        print(read_mapped_buffer(a))
 
         # CHECK-LABEL:    func.func @read_mapped_buffer
         # CHECK-COUNT-1:    memref.reinterpret_cast
@@ -225,7 +225,7 @@ def test_read_write():
     with codegen_test_context(canonicalize=True):
         a = torch.randn(16, 16, dtype=torch.float16)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(read_write(a, b).module_op)
+        print(read_write(a, b))
 
         # CHECK-LABEL:    func.func @read_write
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding)
@@ -283,7 +283,7 @@ def test_read_write_diagonal():
 
     with codegen_test_context(canonicalize=True):
         c = torch.zeros(16, 16, dtype=torch.float16)
-        print(read_write_diagonal(c).module_op)
+        print(read_write_diagonal(c))
 
         # CHECK-LABEL:    func.func @read_write_diagonal
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding)
@@ -354,7 +354,7 @@ def test_read_write_masked():
     ):
         a = torch.randn(4, 4, dtype=torch.float16)
         b = torch.zeros(4, 4, dtype=torch.float16)
-        print(read_write_masked(a, b).module_op)
+        print(read_write_masked(a, b))
 
         # CHECK-LABEL:    func.func @read_write_masked
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding)
@@ -427,7 +427,7 @@ def test_read_write_masked_shared():
     ):
         a = torch.randn(4, 4, dtype=torch.float16)
         b = torch.zeros(4, 4, dtype=torch.float16)
-        print(read_write_masked_shared(a, b).module_op)
+        print(read_write_masked_shared(a, b))
 
         # CHECK-LABEL:    func.func @read_write_masked_shared
         # Check shared mem load stores are non masked
@@ -466,7 +466,7 @@ def test_read_write_mapping():
     with codegen_test_context(canonicalize=True):
         a = torch.randn(16, 16, dtype=torch.float16)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(read_write_mapping(a, b).module_op)
+        print(read_write_mapping(a, b))
 
         # CHECK-LABEL:    func.func @read_write_mapping
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding)
@@ -536,7 +536,7 @@ def test_read_write_dynamic_mapping():
         a = torch.randn(16, 16, dtype=torch.float16)
         off = torch.randint(16, (16, 16), dtype=torch.int32)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(read_write_dynamic_mapping(a, off, b).module_op)
+        print(read_write_dynamic_mapping(a, off, b))
 
         # CHECK-LABEL:    func.func @read_write_dynamic_mapping
         # CHECK-SAME:       (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding)
@@ -605,7 +605,7 @@ def test_read_write_dynamic_mapping_broadcast():
         a = torch.randn(16, 16, dtype=torch.float16)
         off = torch.randint(16, (16, 1), dtype=torch.int32)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(read_write_dynamic_mapping_broadcast(a, off, b).module_op)
+        print(read_write_dynamic_mapping_broadcast(a, off, b))
 
         # CHECK-LABEL:    func.func @read_write_dynamic_mapping_broadcast
         # CHECK:            %[[OFF:.*]] = vector.load %{{.*}}[%[[M:.*]], %{{.*}}] : memref<16x1xi32, strided<[1, 1], offset: ?>>, vector<1xi32>
@@ -676,7 +676,7 @@ def test_read_write_dynamic_mapping_chain():
         off1 = torch.randint(2, (16, 2), dtype=torch.int32)
         off2 = torch.randint(16, (16, 4), dtype=torch.int32)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(read_write_dynamic_mapping_chain(a, off1, off2, b).module_op)
+        print(read_write_dynamic_mapping_chain(a, off1, off2, b))
 
         # CHECK-LABEL:    func.func @read_write_dynamic_mapping_chain
         # CHECK:            %[[C8:.*]] = arith.constant 8 : index
@@ -741,7 +741,7 @@ def test_read_write_dynamic_symbol():
         a = torch.randn(16, 16, dtype=torch.float16)
         off = torch.randint(16, (16, 16), dtype=torch.int32)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(test_dyn_symbol(a, off, b).module_op)
+        print(test_dyn_symbol(a, off, b))
 
         # CHECK-LABEL:    func.func @test_dyn_symbol
         #  CHECK-SAME:      (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding, %[[ARG3:.*]]: index)
@@ -804,7 +804,7 @@ def test_read_write_dynamic_symbol_expr():
         a = torch.randn(16, 16, dtype=torch.float16)
         off = torch.randint(16, (16, 16), dtype=torch.int32)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(test_dyn_expr(a, off, b).module_op)
+        print(test_dyn_expr(a, off, b))
 
         # CHECK-LABEL:    func.func @test_dyn_expr
         #  CHECK-SAME:      (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding, %[[ARG3:.*]]: index)
@@ -857,7 +857,7 @@ def test_read_write_conditional():
         a = torch.randn(16, 16, dtype=torch.float16)
         mask = torch.randint(2, (16, 16), dtype=torch.int32)
         b = torch.zeros(16, 16, dtype=torch.float16)
-        print(test_conditional(a, mask, b).module_op)
+        print(test_conditional(a, mask, b))
 
         # CHECK-LABEL:    func.func @test_conditional
         #  CHECK-SAME:      (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding)
@@ -895,7 +895,7 @@ def test_dynamic_copy():
 
     with codegen_test_context(canonicalize=True, dynamic_symbols=[M, N]):
         a = torch.randn(16, 16, dtype=torch.float16)
-        print(dynamic_copy(a).module_op)
+        print(dynamic_copy(a))
 
     # CHECK-LABEL:    func.func @dynamic_copy(%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index)
     # CHECK-SAME:       attributes {translation_info = #[[TRANSLATION:.+]]} {
@@ -953,7 +953,7 @@ def test_add_float():
 
     with codegen_test_context():
         a = torch.randn(16, 16, dtype=torch.float16)
-        print(add(a).module_op)
+        print(add(a))
         # CHECK-LABEL: func @add
         # CHECK: %[[SLICE:.+]] = vector.load
         # CHECK: arith.addf %[[SLICE]], %[[SLICE]] : vector<16xf16>
@@ -978,7 +978,7 @@ def test_add_integer():
 
     with codegen_test_context():
         a = torch.ones(16, 16, dtype=torch.int32)
-        print(test(a).module_op)
+        print(test(a))
         # CHECK-LABEL: func @test
         # CHECK: %[[SLICE:.+]] = vector.load
         # CHECK: arith.addi %[[SLICE]], %[[SLICE]] : vector<16xi32>
@@ -1015,7 +1015,7 @@ def test_unary_lowerings():
     a = torch.randn(16, 16, dtype=torch.float16)
     b = torch.ones(16, 16, dtype=torch.int32)
     with codegen_test_context():
-        print(test(a, b).module_op)
+        print(test(a, b))
         # CHECK-LABEL: func @test
         # Testing Negate
         # CHECK: %[[NEG:.+]] = arith.negf
@@ -1085,7 +1085,7 @@ def test_reduce_sum():
         },
         canonicalize=True,
     ):
-        print(test(a, b, c).module_op)
+        print(test(a, b, c))
         # CHECK-LABEL: func @test
         # CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i32
         # CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i32
@@ -1162,7 +1162,7 @@ def test_mutliple_local_reduce_sum():
         },
         canonicalize=True,
     ):
-        print(test(a, b, c).module_op)
+        print(test(a, b, c))
         # CHECK-LABEL: func @test
         # CHECK: %[[LHS:.+]] = vector.load {{.*}} : memref<256x128xf16
         # CHECK: %[[RHS:.+]] = vector.load {{.*}} : memref<256x128xf16
@@ -1234,7 +1234,7 @@ def test_reduction_and_elemwise():
         },
         canonicalize=True,
     ):
-        print(test(a, c).module_op)
+        print(test(a, c))
         # CHECK-LABEL: func @test
         # CHECK-DAG: %[[C0_IDX:.+]] = arith.constant 0 : index
         # CHECK-DAG: %[[C4_IDX:.+]] = arith.constant 4 : index
@@ -1324,7 +1324,7 @@ def test_tiled_reduce_max():
         },
         canonicalize=True,
     ):
-        print(test(a, b, c).module_op)
+        print(test(a, b, c))
         # CHECK-LABEL: func @test
         # CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i32
         # CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i32
@@ -1420,7 +1420,7 @@ def test_tiled_reduce_min():
         },
         canonicalize=True,
     ):
-        print(test(a, b, c).module_op)
+        print(test(a, b, c))
         # CHECK-LABEL: func @test
         # CHECK-DAG: %[[C1:.+]] = arith.constant 1 : i32
         # CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i32
@@ -1520,7 +1520,7 @@ def test_multiple_reduction_iv():
         },
         canonicalize=True,
     ):
-        print(test(a, c).module_op)
+        print(test(a, c))
         # CHECK-LABEL: func @test
         # CHECK-DAG: %[[C0_IDX:.+]] = arith.constant 0 : index
         # CHECK-DAG: %[[C4_IDX:.+]] = arith.constant 4 : index
@@ -1621,7 +1621,7 @@ def test_reduce_propagate_broadcast():
         run=False,
         run_config=config,
     ):
-        print(test(a, c).module_op)
+        print(test(a, c))
         # CHECK-LABEL: func @test
         # CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
         # CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
@@ -1686,7 +1686,7 @@ def test_explicit_broadcast():
         run=False,
         run_config=config,
     ):
-        print(explicit_broadcast(a, b, c).module_op)
+        print(explicit_broadcast(a, b, c))
         # CHECK-LABEL: func.func @explicit_broadcast
         # CHECK-SAME: (%[[ARG0:.+]]: !stream.binding, %[[ARG1:.+]]: !stream.binding, %{{.+}}: !stream.binding)
         # CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
@@ -1761,7 +1761,7 @@ def test_broadcast_add():
         run=False,
         run_config=config,
     ):
-        print(broadcast_add(a, b, c).module_op)
+        print(broadcast_add(a, b, c))
         # CHECK-LABEL: func.func @broadcast_add
         # CHECK-SAME: (%[[ARG0:.+]]: !stream.binding, %[[ARG1:.+]]: !stream.binding, %{{.+}}: !stream.binding)
         # CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
@@ -1819,7 +1819,7 @@ def test_binary_lowerings():
     a = torch.randn(16, 16, dtype=torch.float16)
     b = torch.randn(16, 16, dtype=torch.float16)
     with codegen_test_context():
-        print(binary_lowerings(a, b).module_op)
+        print(binary_lowerings(a, b))
         # CHECK-LABEL: func @binary_lowerings
         # CHECK: %[[SUB:.+]] = arith.subf
         # CHECK: %[[MUL:.+]] = arith.mulf %[[SUB]]
@@ -1860,7 +1860,7 @@ def test_int_comparisons():
     a = torch.randint(42, (16, 16), dtype=torch.int32)
     b = torch.randint(42, (16, 16), dtype=torch.int32)
     with codegen_test_context():
-        print(cmp_lowerings(a, b).module_op)
+        print(cmp_lowerings(a, b))
         # CHECK-LABEL: @cmp_lowerings
         # CHECK: arith.cmpi sgt
         # CHECK: arith.select
@@ -1903,7 +1903,7 @@ def test_verbose_int_comparisons():
     a = torch.randint(42, (16, 16), dtype=torch.int32)
     b = torch.randint(42, (16, 16), dtype=torch.int32)
     with codegen_test_context():
-        print(verbose_cmp_lowerings(a, b).module_op)
+        print(verbose_cmp_lowerings(a, b))
         # CHECK-LABEL: @verbose_cmp_lowerings
         # CHECK: arith.cmpi sgt
         # CHECK: arith.select

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -101,7 +101,7 @@ def test_gemm():
         a = torch.randn(64, 32, dtype=torch.float16)
         b = torch.randn(128, 32, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(gemm(a, b, c).module_op)
+        print(gemm(a, b, c))
 
         # CHECK-LABEL:    func.func @gemm
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
@@ -249,7 +249,7 @@ def test_cdna2_int_gemm():
         a = torch.ones(64, 32, dtype=torch.int8)
         b = torch.ones(128, 32, dtype=torch.int8)
         c = torch.zeros(64, 128, dtype=torch.int32)
-        print(cdna2_int_gemm(a, b, c).module_op)
+        print(cdna2_int_gemm(a, b, c))
 
         # CHECK-LABEL:    func.func @cdna2_int_gemm
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
@@ -325,7 +325,7 @@ def test_cdna3_int_gemm():
         a = torch.ones(64, 32, dtype=torch.int8)
         b = torch.ones(128, 32, dtype=torch.int8)
         c = torch.zeros(64, 128, dtype=torch.int32)
-        print(cdna3_int_gemm(a, b, c).module_op)
+        print(cdna3_int_gemm(a, b, c))
 
         # CHECK-LABEL:    func.func @cdna3_int_gemm
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
@@ -406,7 +406,7 @@ def test_batched_gemm():
         a = torch.randn(12, 64, 32, dtype=torch.float16)
         b = torch.randn(12, 128, 32, dtype=torch.float16)
         c = torch.zeros(12, 64, 128, dtype=torch.float32)
-        print(batched_gemm(a, b, c).module_op)
+        print(batched_gemm(a, b, c))
 
         # CHECK-LABEL:    func.func @batched_gemm
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]:
@@ -575,7 +575,7 @@ def test_chained_gemm():
         k = torch.randn(8, 256, 64, dtype=torch.float16)
         v = torch.zeros(8, 128, 256, dtype=torch.float16)
         output = torch.zeros(8, 64, 128, dtype=torch.float32)
-        print(chained_gemm(q, k, v, output).module_op)
+        print(chained_gemm(q, k, v, output))
 
         # CHECK-LABEL:     func.func @chained_gemm
         # CHECK-SAME:        (%[[ARG0:.*]]: !stream.binding, %{{.+}}: !stream.binding, %{{.+}}: !stream.binding, %{{.+}}: !stream.binding)
@@ -660,7 +660,7 @@ def test_chained_gemm_32x32x8():
         k = torch.randn(8, 256, 64, dtype=torch.float16)
         v = torch.zeros(8, 128, 256, dtype=torch.float16)
         output = torch.zeros(8, 64, 128, dtype=torch.float32)
-        print(chained_gemm_32x32x8(q, k, v, output).module_op)
+        print(chained_gemm_32x32x8(q, k, v, output))
 
         # CHECK-LABEL:     func.func @chained_gemm_32x32x8
         # CHECK-SAME:        (%[[ARG0:.*]]: !stream.binding, %{{.+}}: !stream.binding, %{{.+}}: !stream.binding, %{{.+}}: !stream.binding)
@@ -750,7 +750,7 @@ def test_chained_gemm_32x32x16():
         k = torch.randn(8, 256, 64, dtype=torch.float16)
         v = torch.zeros(8, 128, 256, dtype=torch.float16)
         output = torch.zeros(8, 64, 128, dtype=torch.float32)
-        print(chained_gemm_32x32x16(q, k, v, output).module_op)
+        print(chained_gemm_32x32x16(q, k, v, output))
 
         # CHECK-LABEL:     func.func @chained_gemm_32x32x16(
         # CHECK:             %[[V_SHARED:.+]] = memref.alloc() : memref<1x64x36xf16, #gpu.address_space<workgroup>>
@@ -845,7 +845,7 @@ def test_chained_gemm_16x16x32():
         k = torch.randn(8, 256, 64, dtype=torch.float16)
         v = torch.zeros(8, 128, 256, dtype=torch.float16)
         output = torch.zeros(8, 64, 128, dtype=torch.float32)
-        print(chained_gemm_16x16x32(q, k, v, output).module_op)
+        print(chained_gemm_16x16x32(q, k, v, output))
 
         # CHECK-LABEL:     func.func @chained_gemm_16x16x32(
         # CHECK:             %[[V_SHARED:.+]] = memref.alloc() : memref<1x64x36xf16, #gpu.address_space<workgroup>>
@@ -932,7 +932,7 @@ def test_gemm_pipelined():
         a = torch.randn(64, 32, dtype=torch.float16)
         b = torch.randn(128, 32, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(gemm_pipelined(a, b, c).module_op)
+        print(gemm_pipelined(a, b, c))
 
         # CHECK-LABEL:    func.func @gemm_pipelined
         # CHECK-COUNT-2:    vector.load
@@ -1026,7 +1026,7 @@ def test_dynamic_gemm_pipelined():
         a = torch.randn(64, 256, dtype=torch.float16)
         b = torch.randn(128, 256, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(dynamic_gemm_pipelined(a, b, c).module_op)
+        print(dynamic_gemm_pipelined(a, b, c))
 
         # CHECK-LABEL:    func.func @dynamic_gemm_pipelined
         # CHECK-COUNT-2:    vector.maskedload
@@ -1119,7 +1119,7 @@ def test_gemm_with_gpr_offsets():
         a = torch.randn(64, 64, dtype=torch.float16)
         b = torch.randn(64, 64, dtype=torch.float16)
         c = torch.zeros(64, 64, dtype=torch.float32)
-        print(gemm_with_interleave_gpr(a, b, c).module_op)
+        print(gemm_with_interleave_gpr(a, b, c))
 
         # CHECK-LABEL:    func.func @gemm_with_interleave_gpr
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
@@ -1205,7 +1205,7 @@ def test_gemm_and_reduce():
         a = torch.randn(64, 32, dtype=torch.float16)
         b = torch.randn(128, 32, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(gemm(a, b, c).module_op)
+        print(gemm(a, b, c))
         # CHECK-LABEL: func.func @gemm
         # CHECK-DAG: %[[C0_IDX:.+]] = arith.constant 0 : index
         # CHECK-DAG: %[[C4_IDX:.+]] = arith.constant 4 : index
@@ -1291,7 +1291,7 @@ def test_gemm_with_maximized_shared_read_32x32x16():
         a = torch.randn(128, 64, dtype=torch.float16)
         b = torch.randn(128, 64, dtype=torch.float16)
         c = torch.zeros(128, 128, dtype=torch.float32)
-        print(gemm_with_maximized_shared_read_32x32x16(a, b, c).module_op)
+        print(gemm_with_maximized_shared_read_32x32x16(a, b, c))
 
         # CHECK-LABEL:    func.func @gemm_with_maximized_shared_read_32x32x16
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
@@ -1376,7 +1376,7 @@ def test_gemm_with_maximized_shared_read_16x16x32():
         a = torch.randn(64, 128, dtype=torch.float16)
         b = torch.randn(64, 128, dtype=torch.float16)
         c = torch.zeros(64, 64, dtype=torch.float32)
-        print(gemm_with_maximized_shared_read_16x16x32(a, b, c).module_op)
+        print(gemm_with_maximized_shared_read_16x16x32(a, b, c))
 
         # CHECK-LABEL:    func.func @gemm_with_maximized_shared_read_16x16x32
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
@@ -1466,7 +1466,7 @@ def test_broadcast_batched_gemm_with_vmma():
         a = torch.randn(1, 64, 64, dtype=torch.float16)
         b = torch.randn(6, 128, 64, dtype=torch.float16)
         c = torch.zeros(6, 64, 128, dtype=torch.float32)
-        print(broadcast_batched_gemm_with_vmma(a, b, c).module_op)
+        print(broadcast_batched_gemm_with_vmma(a, b, c))
         # CHECK-LABEL:    func.func @broadcast_batched_gemm_with_vmma
         # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
         # CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: !stream.binding) attributes {translation_info = #[[TRANSLATION:.+]]} {

--- a/lit_tests/kernel/wave/igemm.py
+++ b/lit_tests/kernel/wave/igemm.py
@@ -183,7 +183,7 @@ def test_igemm():
         },
         canonicalize=True,
     ):
-        print(conv(x, we, out).module_op)
+        print(conv(x, we, out))
         # CHECK-LABEL: func @conv
         #  CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
 

--- a/lit_tests/kernel/wave/mma.py
+++ b/lit_tests/kernel/wave/mma.py
@@ -65,7 +65,7 @@ def test_mma():
         a = torch.randn(64, 32, dtype=torch.float16)
         b = torch.randn(128, 32, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(mma(a, b, c).module_op)
+        print(mma(a, b, c))
 
         # CHECK:          func.func @mma
         # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
@@ -145,7 +145,7 @@ def test_mma_32x32x8():
         a = torch.randn(64, 32, dtype=torch.float16)
         b = torch.randn(128, 32, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(mma_32x32x8(a, b, c).module_op)
+        print(mma_32x32x8(a, b, c))
 
         # CHECK:          func.func @mma_32x32x8
         # CHECK-DAG:        %[[C27:.+]] = arith.constant 27 : index
@@ -299,7 +299,7 @@ def test_mma_32x32x16():
         a = torch.randn(64, 32, dtype=torch.float16)
         b = torch.randn(128, 32, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(mma_32x32x16(a, b, c).module_op)
+        print(mma_32x32x16(a, b, c))
 
         # CHECK:          func.func @mma_32x32x16
         # CHECK-DAG:        %[[C27:.+]] = arith.constant 27 : index
@@ -453,7 +453,7 @@ def test_mma_16x16x32():
         a = torch.randn(64, 32, dtype=torch.float16)
         b = torch.randn(128, 32, dtype=torch.float16)
         c = torch.zeros(64, 128, dtype=torch.float32)
-        print(mma_16x16x32(a, b, c).module_op)
+        print(mma_16x16x32(a, b, c))
 
         # CHECK:          func.func @mma_16x16x32
         # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>

--- a/tests/kernel/wave/attention/chained_gemm_test.py
+++ b/tests/kernel/wave/attention/chained_gemm_test.py
@@ -156,12 +156,12 @@ def testChainedGemm(
         k = device_randn(batch, kv_seq_len, qk_head_dim, dtype=torch.float16)
         v = device_randn(batch, v_head_dim, kv_seq_len, dtype=torch.float16)
         output = device_zeros(batch, v_head_dim, q_seq_len, dtype=torch.float32)
-        mb = chained_gemm(q, k, v, output)
+        asm = chained_gemm(q, k, v, output)
 
         if dump_generated_mlir:
             filename = f"wave_cgemm_{'x'.join(map(str, shape))}.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
                 print(f"IR dumped to {filename}")
 
         iree_ref = torch.zeros(batch, v_head_dim, q_seq_len, dtype=torch.float32)
@@ -312,12 +312,12 @@ def testChainedGemmF8(
         k = device_randn(batch, kv_seq_len, qk_head_dim, dtype=torch.float16)
         v = device_randn(batch, v_head_dim, kv_seq_len, dtype=torch.float16)
         output = device_zeros(batch, v_head_dim, q_seq_len, dtype=torch.float32)
-        mb = chained_gemm_f8(q, k, v, output)
+        asm = chained_gemm_f8(q, k, v, output)
 
         if dump_generated_mlir:
             filename = f"wave_cgemm_{'x'.join(map(str, shape))}.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         iree_ref = torch.zeros(batch, v_head_dim, q_seq_len, dtype=torch.float32)
         generate_iree_ref(

--- a/tests/kernel/wave/attention/decode_attention_test.py
+++ b/tests/kernel/wave/attention/decode_attention_test.py
@@ -99,7 +99,7 @@ def testFlashDecoding(
         dynamic_symbols_map=dynamic_symbols_map_0,
     ):
         # TODO: Add scaling of QK as part of kernel.
-        mb_qk = phase_0(
+        asm_qk = phase_0(
             q * dk_sqrt * log2e,
             k,
             v.permute([0, 2, 1]),
@@ -119,7 +119,7 @@ def testFlashDecoding(
         dynamic_symbols_map=dynamic_symbols_map_1,
     ):
         # TODO: Add variant of non-transposed V attention kernel.
-        mb_sv = phase_1(phase_0_output, phase_0_output_max, output)
+        asm_sv = phase_1(phase_0_output, phase_0_output_max, output)
 
     torch_ref = torch.nn.functional.scaled_dot_product_attention(
         q, k, v, attn_mask=None
@@ -128,9 +128,9 @@ def testFlashDecoding(
     if dump_generated_mlir:
         filename = f"wave_phase_0_kernel_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
-            f.write(mb_qk.module_op.get_asm())
+            f.write(asm_qk)
         filename = f"wave_phase_1_kernel_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
-            f.write(mb_sv.module_op.get_asm())
+            f.write(asm_sv)
 
     assert_close(output, torch_ref, check_dtype=False, atol=1e-3, rtol=1e-3)

--- a/tests/kernel/wave/attention/evoformer_test.py
+++ b/tests/kernel/wave/attention/evoformer_test.py
@@ -124,7 +124,7 @@ def testEvoformerAttentionForward(
         dk_sqrt = math.sqrt(1.0 / shape[4])
         # TODO: Add scaling of QK as part of kernel.
         # TODO: Add v-permute as part of kernel.
-        mb = evoformer_fwd(
+        asm = evoformer_fwd(
             q * dk_sqrt * log2e,
             k,
             v.permute([0, 1, 4, 3, 2]),
@@ -140,7 +140,7 @@ def testEvoformerAttentionForward(
         if dump_generated_mlir:
             filename = f"wave_evoformer_{'x'.join(map(str, shape))}.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         eps = 1e-2 if output.dtype == torch.float16 else 5e-2
         assert (

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -380,7 +380,7 @@ def testExtendAttention(
         use_buffer_load_ops=use_buffer_ops,
         use_buffer_store_ops=use_buffer_ops,
     ):
-        mb_qk = extend_attention(
+        asm_qk = extend_attention(
             q_extend,
             k_extend,
             v_extend,
@@ -397,7 +397,7 @@ def testExtendAttention(
     if dump_generated_mlir:
         filename = f"wave_extend_attention_kernel_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
-            f.write(mb_qk.module_op.get_asm())
+            f.write(asm_qk)
 
     # Run the reference implementation.
     ref_output = ref_extend_attn(
@@ -517,7 +517,7 @@ def testExtendRpeAttention(
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
     ):
-        mb_qk = extend_attention_rpe(
+        asm_qk = extend_attention_rpe(
             q_extend,
             k_extend,
             v_extend,
@@ -535,7 +535,7 @@ def testExtendRpeAttention(
     if dump_generated_mlir:
         filename = f"wave_extend_attention_kernel_rpe_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
-            f.write(mb_qk.module_op.get_asm())
+            f.write(asm_qk)
 
     # Run the reference implementation.
     ref_output = ref_extend_attn(

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -267,7 +267,7 @@ def testPagedFlashDecoding(
     ):
         # TODO: Add scaling of QK as part of kernel.
         # TODO: Add variant of non-transposed V attention kernel.
-        mb_qk = phase_0(
+        asm_qk = phase_0(
             query * dk_sqrt * log2e,
             key_cache_4d,
             value_cache_4d,
@@ -287,15 +287,15 @@ def testPagedFlashDecoding(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        mb_sv = phase_1(phase_0_output, phase_0_output_max, output)
+        asm_sv = phase_1(phase_0_output, phase_0_output_max, output)
 
     if dump_generated_mlir:
         filename = f"wave_paged_phase_0_kernel_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
-            f.write(mb_qk.module_op.get_asm())
+            f.write(asm_qk)
         filename = f"wave_paged_phase_1_kernel_{'x'.join(map(str, shape))}.mlir"
         with open(filename, "w") as f:
-            f.write(mb_sv.module_op.get_asm())
+            f.write(asm_sv)
 
     if not artifact_directory:
         # Run the reference implementation.

--- a/tests/kernel/wave/runtime/cache_test.py
+++ b/tests/kernel/wave/runtime/cache_test.py
@@ -207,8 +207,8 @@ def testSameConfig(request):
         output = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
         mb = base_attention(q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output)
         assert_close(output, torch_ref, atol=1e-3, rtol=1e-3)
-        assert isinstance(
-            mb, tk.compiler.builder.ModuleBuilder
+        assert (
+            cache_manager.cache_misses == 1 and cache_manager.cache_hits == 0
         ), "Expected first call to not be cached."
         assert (
             len(cache_manager.session_cache) == 1
@@ -223,8 +223,8 @@ def testSameConfig(request):
         assert (
             len(cache_manager.session_cache) == 1
         ), "Expected to keep size of cache because we reuse same kernel."
-        assert isinstance(
-            cached_kernel, WaveCache
+        assert (
+            cache_manager.cache_misses == 1 and cache_manager.cache_hits == 1
         ), "Expected subsequent call to be cached."
 
 
@@ -331,8 +331,8 @@ def testDifferentDynamicSameBlock(request):
             output_shape_0,
         )
         assert_close(output_shape_0, torch_ref_shape_0, atol=1e-3, rtol=1e-3)
-        assert isinstance(
-            mb, tk.compiler.builder.ModuleBuilder
+        assert (
+            cache_manager.cache_misses == 1 and cache_manager.cache_hits == 0
         ), "Expected first call to not be cached."
         assert (
             len(cache_manager.session_cache) == 1
@@ -385,8 +385,8 @@ def testDifferentDynamicSameBlock(request):
         assert (
             len(cache_manager.session_cache) == 1
         ), "Expected to keep size of cache because we reuse same kernel."
-        assert isinstance(
-            cached_kernel, WaveCache
+        assert (
+            cache_manager.cache_misses == 1 and cache_manager.cache_hits == 1
         ), "Expected subsequent call to be cached."
 
 
@@ -479,8 +479,8 @@ def testSameSizeDifferentBlock(request):
             q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output
         )
         assert_close(output, torch_ref, atol=1e-3, rtol=1e-3)
-        assert isinstance(
-            mb_config_0, tk.compiler.builder.ModuleBuilder
+        assert (
+            cache_manager.cache_misses == 1 and cache_manager.cache_hits == 0
         ), "Expected first call to not be cached."
         assert (
             len(cache_manager.session_cache) == 1
@@ -508,9 +508,9 @@ def testSameSizeDifferentBlock(request):
         assert (
             len(cache_manager.session_cache) == 2
         ), "Expected cache size to increment, because we use different block size/config."
-        assert isinstance(
-            mb_config_1, tk.compiler.builder.ModuleBuilder
-        ), "Expected subsequent call to be cached."
+        assert (
+            cache_manager.cache_misses == 2 and cache_manager.cache_hits == 0
+        ), "Expected subsequent call to not be cached."
         assert len(kernel_hash) == 1, "Expected to have one kernel hash returned."
 
     # Subsequent run/call to kernel, this will not trigger a hash computation
@@ -534,8 +534,8 @@ def testSameSizeDifferentBlock(request):
         assert (
             len(cache_manager.session_cache) == 2
         ), "Expected cache size to increment, because we use different block size/config."
-        assert isinstance(
-            mb_config_2, WaveCache
+        assert (
+            cache_manager.cache_misses == 2 and cache_manager.cache_hits == 1
         ), "Expected subsequent call to be cached."
         assert len(kernel_hash) == 1, "Expected to still have only one kernel hash."
 
@@ -596,8 +596,8 @@ def testSameConfigDifferentFreeVar(request):
         non_causal_mb = base_attention(
             q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output
         )
-        assert isinstance(
-            non_causal_mb, tk.compiler.builder.ModuleBuilder
+        assert (
+            cache_manager.cache_misses == 1 and cache_manager.cache_hits == 0
         ), "Expected first call to not be cached."
         assert (
             len(cache_manager.session_cache) == 1
@@ -630,8 +630,8 @@ def testSameConfigDifferentFreeVar(request):
         causal_mb = causal_attention(
             q * dk_sqrt * log2e, k, v.permute([0, 2, 1]), output
         )
-        assert isinstance(
-            causal_mb, tk.compiler.builder.ModuleBuilder
+        assert (
+            cache_manager.cache_misses == 2 and cache_manager.cache_hits == 0
         ), "Expected to not be cached despite same config, since it has different values for is_causal."
         assert (
             len(cache_manager.session_cache) == 2

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -200,12 +200,12 @@ def testGemm(
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
-        mb = gemm(a, b, c)
+        asm = gemm(a, b, c)
 
         if test_dump_generated_mlir:
             filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         if run_bench:
             if dump_perf is not None:
@@ -347,12 +347,12 @@ def testVMFMAGemm(
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
-        mb = gemm(a, b, c)
+        asm = gemm(a, b, c)
 
         if test_dump_generated_mlir:
             filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         if run_bench:
             if dump_perf is not None:
@@ -496,12 +496,12 @@ def testCDNA2IntGemm(
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
         c = device_zeros(shape[0], shape[1], dtype=torch.int32)
-        mb = gemm(a, b, c)
+        asm = gemm(a, b, c)
 
         if test_dump_generated_mlir:
             filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         if run_bench:
             if dump_perf is not None:
@@ -613,12 +613,12 @@ def testCDNA3IntGemm(
         a = device_randint(randint_hi, (shape[0], shape[2]), dtype=torch.int8)
         b = device_randint(randint_hi, (shape[1], shape[2]), dtype=torch.int8)
         c = device_zeros(shape[0], shape[1], dtype=torch.int32)
-        mb = gemm(a, b, c)
+        asm = gemm(a, b, c)
 
         if test_dump_generated_mlir:
             filename = f"wave_gemm_{'x'.join(map(str, shape))}_f8.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         if run_bench:
             if dump_perf is not None:
@@ -728,12 +728,12 @@ def testF8Gemm(
         a = device_randn(shape[0], shape[2], dtype=torch.float16)
         b = device_randn(shape[1], shape[2], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], dtype=torch.float32)
-        mb = gemm(a, b, c)
+        asm = gemm(a, b, c)
 
         if test_dump_generated_mlir:
             filename = f"wave_gemm_{'x'.join(map(str, shape))}_f8.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         if run_bench:
             if dump_perf is not None:
@@ -837,12 +837,12 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: bool, request):
         a = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
         b = device_randn(shape[0], shape[2], shape[3], dtype=torch.float16)
         c = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-        mb = batched_gemm(a, b, c)
+        asm = batched_gemm(a, b, c)
 
         if test_dump_generated_mlir:
             filename = f"wave_batched_gemm_{'x'.join(map(str, shape))}.mlir"
             with open(filename, "w") as f:
-                f.write(mb.module_op.get_asm())
+                f.write(asm)
 
         if run_bench:
             if dump_perf is not None:

--- a/tests/tools/interpreter_test.py
+++ b/tests/tools/interpreter_test.py
@@ -77,7 +77,6 @@ def testGemm():
         a = torch.randn(2048, 1280, dtype=torch.float16)
         b = torch.randn(10240, 1280, dtype=torch.float16)
         c = torch.zeros(2048, 10240, dtype=torch.float32)
-        mb = gemm(a, b, c)
-        asm = mb.module_op.get_asm()
+        asm = gemm(a, b, c)
         interpreter = Interpreter([0, 0, 0], [0, 0, 0])
         interpreter.interpret(asm)


### PR DESCRIPTION
Cached kernels were returning the asm and uncached ones were returning the module builder.

I added cache statistics to the `WaveCacheManager` instead of the cache test using the returned type to distinguish a cache hit. I also renamed the `module_op` property on `WaveCache` to `asm as that's actually what it is (treating it like it was a module op was what was causing failures in the first place).

Another option would be to consistently return a dataclass that has the extra information present in `WaveCache`, but I didn't want to use a cache type the path where the cache is turned off and `WaveCache` also fetches asm lazily, which complicates things a bit. I think we'd want a `WaveKernel` type and two duck-typed implementations if we went that route.

Fixes https://github.com/iree-org/iree-turbine/issues/419
