### PR TITLE
[Wave] Tweak lit tests to support older lit 

### DIFF
--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -151,7 +151,7 @@ def test_attention_32x32x8():
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
         print(base_attention_32x32x8(q, k, v, output).module_op)
 
-        # CHECK-DAG:        #iree_codegen.translation_info
+        # CHECK:          #iree_codegen.translation_info
         # CHECK-SAME:       {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign"}
         # CHECK-LABEL:      func.func @base_attention_32x32x8
         # CHECK:                {{.*}} = scf.for

--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -151,7 +151,7 @@ def test_attention_32x32x8():
         output = torch.zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
         print(base_attention_32x32x8(q, k, v, output).module_op)
 
-        # CHECK:          #iree_codegen.translation_info
+        # CHECK:            #iree_codegen.translation_info
         # CHECK-SAME:       {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign"}
         # CHECK-LABEL:      func.func @base_attention_32x32x8
         # CHECK:                {{.*}} = scf.for

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -897,7 +897,8 @@ def test_dynamic_copy():
         a = torch.randn(16, 16, dtype=torch.float16)
         print(dynamic_copy(a).module_op)
 
-    # CHECK-LABEL:    func.func @dynamic_copy(%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index)
+    # CHECK-LABEL:    func.func @dynamic_copy
+    # CHECH-SAME:       %[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: index, %[[ARG2:.*]]: index
     # CHECK-SAME:       attributes {translation_info = #[[TRANSLATION:.+]]} {
     # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf16>
     # CHECK-DAG:        %[[CST_0:.+]] = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> :

--- a/tests/kernel/wave/common/utils.py
+++ b/tests/kernel/wave/common/utils.py
@@ -12,10 +12,16 @@ from iree.turbine.kernel.wave.utils import (
 
 require_e2e = pytest.mark.require_e2e
 require_cdna2 = pytest.mark.skipif(
-    "gfx90" not in get_default_arch(), reason="Default device is not CDNA2"
+    "gfx90" not in get_default_arch(),
+    reason="Default architecture is not CDNA2, default architecture is '{}'".format(
+        get_default_arch()
+    ),
 )
 require_cdna3 = pytest.mark.skipif(
-    "gfx94" not in get_default_arch(), reason="Default device is not CDNA3"
+    "gfx94" not in get_default_arch(),
+    reason="Default architecture is not CDNA3, default architecture is '{}'".format(
+        get_default_arch()
+    ),
 )
 # Whether to dump the generated MLIR module.
 dump_generated_mlir = int(os.environ.get("WAVE_DUMP_MLIR", 0))


### PR DESCRIPTION
2 minor changes:
1) Changes to lit checks required to run with my version of lit. I suspect older versions get confused by
    #CHECK-DAG immediately followed by #CHECK, and by CHECK-LABELS with variables to match. 
2) additional information when torch isn't installed with support for CDNA (FWIW: must install pytorch-rocm-requirements.txt)