### PR TITLE
[Wave] Refactor LoopConstructor infra to prep for heuristic base strat

### DIFF
--- a/iree/turbine/kernel/wave/scheduling/loop_reconstruction_utils.py
+++ b/iree/turbine/kernel/wave/scheduling/loop_reconstruction_utils.py
@@ -10,7 +10,6 @@ from ...ops.wave_ops import (
     get_custom,
     Placeholder,
 )
-from .modulo_scheduling import ModuloScheduler
 from ..utils import graph_copy, erase_graph
 from ..utils import subs_idxc
 import torch.fx as fx
@@ -276,15 +275,15 @@ def liveness_analysis(graph: fx.Graph, reduction: Reduction) -> dict[fx.Node, in
 
 
 def partition_graph_by_stage(
-    graph: fx.Graph, scheduler: ModuloScheduler
+    graph: fx.Graph, num_stages: int
 ) -> list[dict[int, list[fx.Node]]]:
     """
     Partition the graph into stages based on the scheduling parameters.
     """
     partitioned_graph: list[dict[int, list[fx.Node]]] = [
-        defaultdict(list) for _ in range(scheduler.num_stages)
+        defaultdict(list) for _ in range(num_stages)
     ]
-    for stage in range(scheduler.num_stages):
+    for stage in range(num_stages):
         for node in graph.nodes:
             custom = get_custom(node)
             if custom.scheduling_parameters is None:

--- a/iree/turbine/kernel/wave/scheduling/schedule.py
+++ b/iree/turbine/kernel/wave/scheduling/schedule.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from enum import Enum
 from ..constraints import Constraint
 from ..._support.tracing import CapturedTrace
 from ...ops.wave_ops import Reduction, IterArg, get_custom, CustomOp
@@ -26,6 +27,27 @@ from ....support.logging import get_logger
 logger = get_logger("turbine.wave.scheduling.schedule")
 
 
+"""
+Formatting for different scheduling strategies:
+Values: 0xAB where:
+* A = Strategy types:
+  * 0 = None
+  * 1 = Solver Based
+  * 2 = Heuristic Based (to come)
+* B enumerates different strategy that share the same 0xA* bits.
+"""
+
+
+class SchedulingType(Enum):
+    NONE = 0x00
+    MODULO = 0x10
+
+
+def is_solver_based(scheduling_type: SchedulingType):
+    scheduling_ty_val = scheduling_type.value
+    return scheduling_ty_val >= 0x10 and scheduling_ty_val < 0x20
+
+
 def visualize_scheduling_graph(edges: list[Edge]):
     visualize_edges(edges, "reduction_graph.png")
 
@@ -35,6 +57,7 @@ def schedule_reduction(
     trace: CapturedTrace,
     constraints: list[Constraint],
     use_scheduling_barriers: bool = False,
+    scheduling_type: SchedulingType = SchedulingType.NONE,
 ):
     """
     Clones the reduction graph and does the following:
@@ -45,22 +68,30 @@ def schedule_reduction(
     to the original graph. Finally, erases the cloned graph.
 
     """
+    if scheduling_type == SchedulingType.NONE:
+        return {}
     reduction_graph = trace.get_subgraph(reduction.subgraph_name)
     graph, node_map = graph_copy(reduction_graph)
-    ignore_nodes, iter_args, output = annotate_resource_usage(graph)
-    edges = create_scheduling_edges(graph, ignore_nodes, iter_args, output)
+
+    if is_solver_based(scheduling_type):
+        ignore_nodes, iter_args, output = annotate_resource_usage(graph)
+        edges = create_scheduling_edges(graph, ignore_nodes, iter_args, output)
+        scheduler = ModuloScheduler(graph, edges, get_available_resources())
+        schedule, success = scheduler.schedule_graph()
+        initiation_interval = scheduler.initiation_interval
+        num_stages = scheduler.num_stages
+    else:
+        raise ValueError("Unknown scheduling type")
+
+    if not success:
+        raise ValueError("Scheduling failed.")
 
     visualize = False
     if visualize:
-        visualize_scheduling_graph(edges)
-        visualize_graph(graph, "scheduling_fx_graph.png")
-
-    scheduler = ModuloScheduler(graph, edges, get_available_resources())
-    schedule, success = scheduler.schedule_graph()
-    if not success:
-        raise ValueError("Scheduling failed.")
-    if visualize:
-        visualize_schedule(schedule, scheduler.initiation_interval, "schedule.html")
+        if is_solver_based(scheduling_type):
+            visualize_scheduling_graph(edges)
+            visualize_graph(graph, "scheduling_fx_graph.png")
+        visualize_schedule(schedule, initiation_interval, "schedule.html")
 
     # Apply schedule to original graph, specifying the stage
     # that each node is scheduled in as well as the cycle in
@@ -73,9 +104,9 @@ def schedule_reduction(
         custom = get_custom(inverse_node_map[node])
         custom.scheduling_parameters = {
             "absolute_cycle": cycle,
-            "cycle": cycle % scheduler.initiation_interval,
-            "stage": cycle // scheduler.initiation_interval,
-            "initiation_interval": scheduler.initiation_interval,
+            "cycle": cycle % initiation_interval,
+            "stage": cycle // initiation_interval,
+            "initiation_interval": initiation_interval,
         }
         # Erase edges between outputs and iter args.
         if isinstance(get_custom(node), IterArg):
@@ -86,9 +117,9 @@ def schedule_reduction(
         cycle = min([x.scheduling_parameters["absolute_cycle"] for x in custom.users])
         custom.scheduling_parameters = {
             "absolute_cycle": cycle,
-            "cycle": cycle % scheduler.initiation_interval,
-            "stage": cycle // scheduler.initiation_interval,
-            "initiation_interval": scheduler.initiation_interval,
+            "cycle": cycle % initiation_interval,
+            "stage": cycle // initiation_interval,
+            "initiation_interval": initiation_interval,
         }
 
     erase_graph(graph)
@@ -104,7 +135,7 @@ def schedule_reduction(
         # We can only do a compile-time check if the induction variable
         # is not dynamic.
         max_induction_variable = int(max_induction_variable)
-        if max_induction_variable <= scheduler.num_stages - 1:
+        if max_induction_variable <= num_stages - 1:
             logger.warning(
                 "Not enough iterations to pipeline the loop. Skipping pipelining."
             )
@@ -119,7 +150,7 @@ def schedule_reduction(
             return {}
 
         result = evaluate_with_assumptions(
-            constraints, max_induction_variable > scheduler.num_stages - 1
+            constraints, max_induction_variable > num_stages - 1
         )
         if not result:
             logger.warning(
@@ -132,7 +163,8 @@ def schedule_reduction(
         reduction,
         reduction_graph,
         constraints,
-        scheduler,
+        num_stages,
+        initiation_interval,
         node_map,
         max_induction_variable,
         visualize,
@@ -140,17 +172,21 @@ def schedule_reduction(
     )
 
     # Update new reduction count.
-    new_reduction.count = max_induction_variable - (scheduler.num_stages - 1)
+    new_reduction.count = max_induction_variable - (num_stages - 1)
 
 
 def schedule_graph(
     trace: CapturedTrace,
     constraints: list[Constraint],
     use_scheduling_barriers: bool = False,
+    scheduling_type: SchedulingType = SchedulingType.NONE,
 ):
     """
     Given a graph, pipelines the reductions in the graph.
     """
+
+    if scheduling_type == SchedulingType.NONE:
+        return
 
     def is_reduction(node: fx.Node) -> bool:
         return isinstance(get_custom(node), Reduction)
@@ -161,5 +197,9 @@ def schedule_graph(
 
     for reduction_node in reduction_nodes:
         schedule_reduction(
-            get_custom(reduction_node), trace, constraints, use_scheduling_barriers
+            get_custom(reduction_node),
+            trace,
+            constraints,
+            use_scheduling_barriers,
+            scheduling_type,
         )

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -49,7 +49,7 @@ from .hoisting import hoist_loop_invariant_ops
 from .minimize_global_loads import minimize_global_loads
 from .promotion import promote_placeholders
 from .reuse_shared_allocs import reuse_shared_allocs
-from .scheduling.schedule import schedule_graph
+from .scheduling.schedule import schedule_graph, SchedulingType
 from .type_inference import infer_types
 from .shared_memory_indexing import (
     apply_shared_memory_indexing_corrections,
@@ -547,13 +547,17 @@ class LaunchableWave(Launchable):
         # git fetch https://github.com/kerbowa/llvm-project.git ee52732cddae42deed2e3387a83b20ec05860b4e
         # git cherry-pick ee52732cddae42deed2e3387a83b20ec05860b4e
         # [Manually resolve conflicts consistent with the PR]
-        if kwargs.get("schedule", False):
-            use_scheduling_barriers = kwargs.get("use_scheduling_barriers", False)
-            graph_passes.append(
-                partial(
-                    schedule_graph, trace, self.constraints, use_scheduling_barriers
-                )
+        scheduling_type = kwargs.get("schedule", SchedulingType.NONE)
+        use_scheduling_barriers = kwargs.get("use_scheduling_barriers", False)
+        graph_passes.append(
+            partial(
+                schedule_graph,
+                trace,
+                self.constraints,
+                use_scheduling_barriers,
+                scheduling_type,
             )
+        )
 
         graph_passes += [
             # Align sizes to WG/Tile sizes

--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -15,6 +15,7 @@ from iree.turbine.kernel.wave.templates.vanilla_attention import (
 from iree.turbine.kernel.wave.templates.attention_common import (
     AttentionShape,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 # Input sizes
@@ -141,7 +142,7 @@ def test_attention_32x32x8():
         run=False,
         run_bench=False,
         compile_config=compile_config,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)
@@ -281,7 +282,7 @@ def test_dynamic_attention_32x32x8():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
         use_scheduling_barriers=False,
@@ -334,7 +335,7 @@ def test_attention():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)
@@ -391,7 +392,7 @@ def test_attention_causal():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)

--- a/lit_tests/kernel/wave/attention/attention_bias.py
+++ b/lit_tests/kernel/wave/attention/attention_bias.py
@@ -9,6 +9,7 @@ from iree.turbine.kernel.wave.utils import (
     get_mfma_load_elems_per_thread,
     get_mfma_store_elems_per_thread,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 # Input sizes
@@ -138,7 +139,7 @@ def test_attention_bias():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -13,6 +13,7 @@ from iree.turbine.kernel.wave.templates.paged_decode_attention import (
 from iree.turbine.kernel.wave.templates.decode_attention import (
     get_decode_attention_kernels,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 
@@ -58,7 +59,7 @@ def test_paged_flash_decoding():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         print(phase_0(q, k, v, logits, logits_max))
@@ -91,7 +92,7 @@ def test_paged_flash_decoding():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         print(phase_1(logits, logits_max, output))
@@ -141,7 +142,7 @@ def test_flash_decoding():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
         dynamic_symbols=dynamic_symbols_0,
         dynamic_symbols_map=dynamic_symbols_map_0,
@@ -170,7 +171,7 @@ def test_flash_decoding():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
         dynamic_symbols=dynamic_symbols_1,
         dynamic_symbols_map=dynamic_symbols_map_1,

--- a/lit_tests/kernel/wave/attention/evoformer.py
+++ b/lit_tests/kernel/wave/attention/evoformer.py
@@ -9,6 +9,7 @@ from iree.turbine.kernel.wave.utils import (
     get_mfma_load_elems_per_thread,
     get_mfma_store_elems_per_thread,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 # Input sizes
@@ -182,7 +183,7 @@ def test_evoformer():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -12,6 +12,7 @@ from iree.turbine.kernel.wave.templates.extend_attention import (
 from iree.turbine.kernel.wave.templates.attention_common import (
     AttentionShape,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 
@@ -58,7 +59,7 @@ def test_extend_attention():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
@@ -185,7 +186,7 @@ def test_causal_extend_attention():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,
@@ -331,7 +332,7 @@ def test_causal_extend_attention_32x32x8():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
         dynamic_symbols=dynamic_symbols,
         dynamic_symbols_map=dynamic_symbols_map,

--- a/lit_tests/kernel/wave/attention/pipelined_attention.py
+++ b/lit_tests/kernel/wave/attention/pipelined_attention.py
@@ -9,6 +9,7 @@ from iree.turbine.kernel.wave.utils import (
     get_mfma_load_elems_per_thread,
     get_mfma_store_elems_per_thread,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 # Input sizes
@@ -139,7 +140,7 @@ def test_dynamic_attention_pipelined():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=True,
+        schedule=SchedulingType.MODULO,
         use_scheduling_barriers=False,
         dynamic_symbols=(B, M, N, K2),
         dynamic_symbol_map={
@@ -281,7 +282,7 @@ def test_attention_pipelined():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=True,
+        schedule=SchedulingType.MODULO,
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)

--- a/lit_tests/kernel/wave/attention/prefill_attention.py
+++ b/lit_tests/kernel/wave/attention/prefill_attention.py
@@ -12,6 +12,7 @@ from iree.turbine.kernel.wave.templates.prefill_attention import (
 from iree.turbine.kernel.wave.templates.attention_common import (
     AttentionShape,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 
@@ -39,7 +40,7 @@ def test_prefill_attention():
         canonicalize=True,
         run=False,
         run_bench=False,
-        schedule=False,
+        schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
     ):
         torch.manual_seed(0)

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -12,6 +12,7 @@ from iree.turbine.kernel.wave.utils import (
     get_mfma_load_elems_per_thread,
     get_mfma_store_elems_per_thread,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import torch
 
 M = tkl.sym.M
@@ -926,7 +927,7 @@ def test_gemm_pipelined():
             SHUFFLE_UNITS: 8,
         },
         canonicalize=True,
-        schedule=True,
+        schedule=SchedulingType.MODULO,
         use_scheduling_barriers=True,
     ):
         a = torch.randn(64, 32, dtype=torch.float16)
@@ -1018,7 +1019,7 @@ def test_dynamic_gemm_pipelined():
             SHUFFLE_UNITS: 8,
         },
         canonicalize=True,
-        schedule=True,
+        schedule=SchedulingType.MODULO,
         use_scheduling_barriers=True,
         dynamic_symbols=(M, N, K),
         dynamic_symbols_map={M: 64, N: 128, K: 256},

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -8,6 +8,7 @@ from iree.turbine.kernel.wave.promotion import promote_placeholders
 from iree.turbine.kernel.wave.hoisting import hoist_loop_invariant_ops
 from iree.turbine.kernel.wave.expansion.expansion import expand_graph
 from iree.turbine.kernel.wave.type_inference import infer_types
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel._support.tracing import CapturedTrace
 from iree.turbine.kernel._support.indexing import IndexingContext
@@ -109,7 +110,7 @@ def test_gemm_pipelined():
         hoist_loop_invariant_ops(trace, constraints)
         minimize_global_loads(trace, constraints)
         apply_shared_memory_indexing_corrections(trace, constraints)
-        schedule_graph(trace, constraints, True)
+        schedule_graph(trace, constraints, True, SchedulingType.MODULO)
 
         print_subgraph(trace, "pipelined_reduction", False)
         # CHECK: %acc_m_0_n_0_k_0

--- a/tests/kernel/wave/attention/decode_attention_test.py
+++ b/tests/kernel/wave/attention/decode_attention_test.py
@@ -19,6 +19,7 @@ from iree.turbine.kernel.wave.constraints import MMAType
 from iree.turbine.kernel.wave.templates.decode_attention import (
     get_decode_attention_kernels,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import os
 from torch.testing import assert_close
 from ..common.utils import (
@@ -32,7 +33,7 @@ from ..common.shapes import get_test_shapes
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("decode_attention"))
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -43,7 +44,7 @@ from ..common.shapes import get_test_shapes
 )
 def testFlashDecoding(
     shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
     request,

--- a/tests/kernel/wave/attention/evoformer_test.py
+++ b/tests/kernel/wave/attention/evoformer_test.py
@@ -21,6 +21,7 @@ from iree.turbine.kernel.wave.utils import (
 )
 from iree.turbine.kernel.wave.constraints import MMAType
 from iree.turbine.kernel.wave.templates.evoformer import get_evoformer_kernel
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 from iree.turbine.kernel.lang import DataType
 import os
 from ..common.utils import (
@@ -62,7 +63,7 @@ def attention_reference(
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("evoformer"))
 @pytest.mark.parametrize("tile_sizes", default_tile_sizes)
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @pytest.mark.parametrize(
     "mfma_variant",
     [

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -35,6 +35,7 @@ from iree.turbine.kernel.wave.templates.prefill_attention import (
 from iree.turbine.kernel.wave.templates.attention_common import (
     AttentionShape,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import os
 from enum import Enum
 from torch.testing import assert_close
@@ -280,7 +281,7 @@ def create_inputs(
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("extend"))
 @pytest.mark.parametrize("dtype", [torch.float16])
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("is_causal", "causal")
 @param_bool("use_buffer_ops", "buf_ops")
 @pytest.mark.parametrize(
@@ -293,7 +294,7 @@ def create_inputs(
 def testExtendAttention(
     shape: AttentionShape,
     dtype: torch.dtype,
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     is_causal: bool,
     use_buffer_ops: bool,
     mfma_variant: MMAType,
@@ -424,7 +425,7 @@ def testExtendAttention(
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("extend"))
 @pytest.mark.parametrize("dtype", [torch.float16])
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("is_causal", "causal", [True])
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -436,7 +437,7 @@ def testExtendAttention(
 def testExtendRpeAttention(
     shape: AttentionShape,
     dtype: torch.dtype,
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     is_causal: bool,
     mfma_variant: MMAType,
     request,

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -22,6 +22,7 @@ from iree.turbine.kernel.wave.templates.paged_decode_attention import (
     get_paged_decode_attention_kernels,
     paged_decode_attention_shape,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import os
 from torch.testing import assert_close
 from ..common.utils import (
@@ -143,7 +144,7 @@ def load_inputs(directory):
 @require_cdna3
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("dtype", [torch.float16])
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @pytest.mark.parametrize("num_kv_splits", [8])
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -154,7 +155,7 @@ def load_inputs(directory):
 def testPagedFlashDecoding(
     shape: tuple[int],
     dtype: torch.dtype,
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     num_kv_splits: int,
     mfma_variant: MMAType,
     request,

--- a/tests/kernel/wave/attention/prefill_attention_test.py
+++ b/tests/kernel/wave/attention/prefill_attention_test.py
@@ -24,6 +24,7 @@ from iree.turbine.kernel.wave.templates.prefill_attention import (
 from iree.turbine.kernel.wave.templates.attention_common import (
     AttentionShape,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import os
 from torch.testing import assert_close
 from ..common.utils import (
@@ -96,7 +97,7 @@ def create_inputs(
 @require_cdna3
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("dtype", [torch.float16])
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @pytest.mark.parametrize(
     "mfma_variant",
     [(MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16)],
@@ -104,7 +105,7 @@ def create_inputs(
 def testPrefillAttention(
     shape: tuple[int],
     dtype: torch.dtype,
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     mfma_variant: MMAType,
     request,
 ):

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -35,11 +35,14 @@ from iree.turbine.kernel.wave.templates.vanilla_attention import (
     get_vanilla_attention_kernel,
 )
 from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 
 
 @require_e2e
 @pytest.mark.parametrize("input_shape", get_test_shapes("attention"))
-@param_bool("enable_scheduling", "sched")
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -52,7 +55,7 @@ from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
 )
 def testAttentionPure(
     input_shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
     request,
@@ -124,7 +127,7 @@ def testAttentionPure(
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("all_attention"))
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("dynamic_dims", "dyn", [False])
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -135,7 +138,7 @@ def testAttentionPure(
 )
 def testAttentionCausal(
     shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: tuple[MMAType],
     request,
@@ -207,7 +210,7 @@ def testAttentionCausal(
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("attention"))
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -218,7 +221,7 @@ def testAttentionCausal(
 )
 def testAttentionBias(
     shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
     request,
@@ -411,7 +414,7 @@ def testAttentionBias(
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("attention"))
-@param_bool("enable_scheduling", "sched", [False])
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -422,7 +425,7 @@ def testAttentionBias(
 )
 def testAttentionSoftCap(
     shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
     request,
@@ -618,7 +621,9 @@ def testAttentionSoftCap(
 @require_e2e
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("attention"))
-@param_bool("enable_scheduling", "sched")
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
 @pytest.mark.parametrize(
     "mfma_variant",
     [
@@ -627,7 +632,10 @@ def testAttentionSoftCap(
     ],
 )
 def testAttentionF8(
-    shape: tuple[int], enable_scheduling: bool, mfma_variant: tuple[MMAType], request
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    mfma_variant: tuple[MMAType],
+    request,
 ):
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1521,7 +1521,6 @@ def test_igemm_conv(
         run=True,
         run_bench=run_bench,
         run_config=config,
-        schedule=False,
         use_buffer_load_ops=use_buffer_ops,
         use_buffer_store_ops=use_buffer_ops,
     ):

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -23,6 +23,7 @@ from iree.turbine.kernel.wave.utils import (
     device_randint,
     device_zeros,
 )
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 from .common.utils import (
     require_e2e,
     require_cdna2,
@@ -68,7 +69,9 @@ def get_test_shapes(test_name: str) -> list[tuple[int]]:
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
-@param_bool("enable_scheduling", "sched")
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -79,7 +82,7 @@ def get_test_shapes(test_name: str) -> list[tuple[int]]:
 )
 def testGemm(
     shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
     request,
@@ -215,7 +218,9 @@ def testGemm(
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
-@param_bool("enable_scheduling", "sched")
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -226,7 +231,7 @@ def testGemm(
 )
 def testVMFMAGemm(
     shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
     request,
@@ -363,7 +368,9 @@ def testVMFMAGemm(
 @require_e2e
 @require_cdna2
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
-@param_bool("enable_scheduling", "sched")
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
     "mfma_variant",
@@ -374,7 +381,7 @@ def testVMFMAGemm(
 )
 def testCDNA2IntGemm(
     shape: tuple[int],
-    enable_scheduling: bool,
+    enable_scheduling: SchedulingType,
     dynamic_dims: bool,
     mfma_variant: MMAType,
     request,
@@ -512,7 +519,9 @@ def testCDNA2IntGemm(
 @require_e2e
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
-@param_bool("enable_scheduling", "sched")
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
 @pytest.mark.parametrize(
     "mfma_variant",
     [
@@ -521,7 +530,7 @@ def testCDNA2IntGemm(
     ],
 )
 def testCDNA3IntGemm(
-    shape: tuple[int], enable_scheduling: bool, mfma_variant: MMAType, request
+    shape: tuple[int], enable_scheduling: SchedulingType, mfma_variant: MMAType, request
 ):
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")
@@ -629,7 +638,9 @@ def testCDNA3IntGemm(
 @require_e2e
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
-@param_bool("enable_scheduling", "sched")
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
 @pytest.mark.parametrize(
     "mfma_variant",
     [
@@ -640,7 +651,7 @@ def testCDNA3IntGemm(
     ],
 )
 def testF8Gemm(
-    shape: tuple[int], enable_scheduling: bool, mfma_variant: MMAType, request
+    shape: tuple[int], enable_scheduling: SchedulingType, mfma_variant: MMAType, request
 ):
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")
@@ -743,8 +754,10 @@ def testF8Gemm(
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_batched_gemm"))
-@param_bool("enable_scheduling", "sched")
-def testBatchedGemm(shape: tuple[int], enable_scheduling: bool, request):
+@pytest.mark.parametrize(
+    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+)
+def testBatchedGemm(shape: tuple[int], enable_scheduling: SchedulingType, request):
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes


### PR DESCRIPTION
- Set scheduling to be an enum option/param instead of bool S.T we can choose different strategies in the future
- Refactor loop_reconstruction to use num_stages and initiation_interval as opposed to scheduler to make it easy to pass heuristic based schedule in the future.