### PR TITLE
[TKW] Paged decode attention rewrite

### DIFF
--- a/iree/turbine/kernel/lang/wave_types.py
+++ b/iree/turbine/kernel/lang/wave_types.py
@@ -215,7 +215,7 @@ class IndexMapping:
 
         assert all(
             i is not None for i in iter_shape
-        ), "Cannot determine iteration domain"
+        ), f"Cannot determine iteration domain: {iter_shape=}"
         self.iters = iters
         self.iteration_shape = iter_shape
         self.input_mapping = inputs

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -697,10 +697,13 @@ def handle_reduction(emitter: WaveEmitter, node: fx.Node):
 
     # For now, we assume that dimensions that have tiling constraints on them,
     # do not have any other constraints.
-    if isinstance(node.count, sympy.Expr):
-        end = gen_sympy_index(add_emitter_subs(emitter), node.count)
+    count = node.count
+    if dyn_count := emitter.dynamic_dims.get(axis, None):
+        end = dyn_count
+    elif isinstance(count, sympy.Expr):
+        end = gen_sympy_index(add_emitter_subs(emitter), count)
     else:
-        end = arith_d.constant(IndexType.get(), int(node.count))
+        end = arith_d.constant(IndexType.get(), int(count))
 
     # Since we divide the end by the tile size, we need to make sure that the
     # step is 1.

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -698,9 +698,7 @@ def handle_reduction(emitter: WaveEmitter, node: fx.Node):
     # For now, we assume that dimensions that have tiling constraints on them,
     # do not have any other constraints.
     count = node.count
-    if dyn_count := emitter.dynamic_dims.get(axis, None):
-        end = dyn_count
-    elif isinstance(count, sympy.Expr):
+    if isinstance(count, sympy.Expr):
         end = gen_sympy_index(add_emitter_subs(emitter), count)
     else:
         end = arith_d.constant(IndexType.get(), int(count))

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Callable
-from sympy import ceiling, Piecewise, floor
+from sympy import ceiling, Piecewise, floor, Integer
 
 from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence
 from .._support.dtype import DataType
@@ -441,6 +441,7 @@ class TilingConstraint(Constraint):
     tile_size: IndexExpr
     induction_var: Optional[IndexExpr] = None
     iters: Optional[IndexExpr] = None
+    start: IndexExpr = Integer(0)
 
     def __eq__(self, value):
         if not isinstance(value, TilingConstraint):
@@ -466,7 +467,7 @@ class TilingConstraint(Constraint):
             raise ValueError(
                 "Index is being computed without setting induction variable"
             )
-        return IndexSequence(self.induction_var * self.tile_size, 1)
+        return IndexSequence(self.start + self.induction_var * self.tile_size, 1)
 
 
 @dataclass

--- a/iree/turbine/kernel/wave/global_to_shared_gathers.py
+++ b/iree/turbine/kernel/wave/global_to_shared_gathers.py
@@ -172,18 +172,32 @@ def construct_shared_read_mapping(read: Read) -> IndexMapping:
     return new_mapping
 
 
-def update_read_mapping_dynamic_values(read: Read) -> list[fx.Node]:
+def update_read_mapping_dynamic_values(read: Read):
     """
     Since every thread is now only reading one element along the gather dimension,
     we need to modify the read of the dynamic value to read only one element
     and do it at the specified index.
     """
+    new_dyn_vals = []
     for dyn_val in read.mapping_dynamic_vals:
         custom = get_custom(dyn_val)
-        custom.update_arg("elements_per_thread", 1)
-        for dim in dyn_val.index:
-            if dim in read.index:
-                dyn_val.index[dim] = read.index[dim]
+        assert isinstance(custom, Read), f"Only read nodes are supported, got {custom}"
+        # We cannot just update dynamic val inplace, as it may be used by other nodes
+        with custom.graph.inserting_before(dyn_val):
+            new_read = Read(
+                custom.memory,
+                1,
+                custom.mapping,
+                custom.mapping_dynamic_vals,
+            ).add_to_graph(custom.graph)
+            new_dyn_vals.append(new_read)
+
+            new_read.index = deepcopy(custom.index)
+            for dim in custom.index:
+                if dim in read.index:
+                    new_read.index[dim] = read.index[dim]
+
+    read.update_arg("mapping_dynamic_vals", new_dyn_vals)
 
 
 def add_optimized_nodes(

--- a/iree/turbine/kernel/wave/hoisting.py
+++ b/iree/turbine/kernel/wave/hoisting.py
@@ -11,6 +11,7 @@ from iree.turbine.kernel._support.tracing import CapturedTrace
 import torch.fx as fx
 from ..ops.wave_ops import *
 from ..lang.global_symbols import *
+import sympy
 
 logger = get_logger("turbine.wave.hoisting")
 
@@ -50,7 +51,8 @@ def get_hoistable_ops(
                 continue
             # Only hoist Read that is loop invariant.
             if any(
-                ind.start.has(induction_variable) for ind in custom_node.index.values()
+                sympy.sympify(ind.start).has(induction_variable)
+                for ind in custom_node.index.values()
             ):
                 continue
             hoistable_ops.append(custom_node)

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 def get_extend_attention_kernel(
     shape: AttentionShape,
-    mfma_variant: MMAType,
+    mfma_variant: tuple[MMAType, MMAType],
     q_shape: tuple[int],
     k_shape: tuple[int],
     v_shape: tuple[int],

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -122,7 +122,7 @@ def get_paged_decode_attention_kernels(
         constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 2)]
         # constraints += [tkw.WaveConstraint(S, BLOCK_S)]
 
-        vector_shapes = {BH: 0, T: 0, S: 0, U: 1}
+        vector_shapes = {BH: 0, S: 0, U: 1}
         waves_per_block = (1, B_WAVES, 1)
         constraints += [
             tkw.HardwareConstraint(
@@ -169,7 +169,6 @@ def get_paged_decode_attention_kernels(
     k = tkw.IndexMapping.iterator(2)
     l = tkw.IndexMapping.iterator(3)
     d0 = tkw.IndexMapping.dynamic_val(0)
-    d1 = tkw.IndexMapping.dynamic_val(1)
 
     mapping = tkw.IndexMapping(
         num_iterators=3,

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -85,7 +85,7 @@ def get_paged_decode_attention_kernels(
         constraints: list[tkw.Constraint] = []
         # U represents the number of splits of the key-value sequence.
         # U is parallelizable and is distributed across workgroups.
-        constraints += [tkw.WorkgroupConstraint(U, BLOCK_U, 2)]
+        constraints += [tkw.WorkgroupConstraint(U, BLOCK_U, 0)]
 
         wg_func = lambda wg: wg * sympy.floor(T / U) + sympy.Min(wg, sympy.Mod(T, U))
         constraints += [
@@ -112,7 +112,7 @@ def get_paged_decode_attention_kernels(
         constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 1, primary=False)]
         constraints += [tkw.WaveConstraint(B, BLOCK_B / B_WAVES)]
 
-        constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 0)]
+        constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 2)]
 
         vector_shapes = {BH: 0, T: 0, S: 0, U: 1}
         waves_per_block = (1, B_WAVES, 1)

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -231,7 +231,12 @@ def get_paged_decode_attention_kernels(
         new_acc = tkl.Register[S, N, B, tkl.f32](0.0)
 
         # The request index is used to load the appropriate entries from the block table.
-        req_index = tkw.read(request_indices, elements_per_thread=1)
+        req_index_v = tkw.read(
+            request_indices, elements_per_thread=LOAD_ELEMS_PER_THREAD_V
+        )
+        req_index_k = tkw.read(
+            request_indices, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK
+        )
         # The sequence length is used to control the bounds of the loop over T.
         seq_length = tkw.read(sequence_lengths, elements_per_thread=1)
         tkw.set_symbol(T, seq_length)
@@ -249,15 +254,15 @@ def get_paged_decode_attention_kernels(
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
             block_indices_v = tkw.read(
                 block_table,
-                elements_per_thread=1,
+                elements_per_thread=LOAD_ELEMS_PER_THREAD_V,
                 mapping=block_table_mapping,
-                mapping_dynamic_vals=(req_index,),
+                mapping_dynamic_vals=(req_index_v,),
             )
             block_indices_k = tkw.read(
                 block_table,
-                elements_per_thread=1,
+                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
                 mapping=block_table_mapping,
-                mapping_dynamic_vals=(req_index,),
+                mapping_dynamic_vals=(req_index_k,),
             )
             k_reg = tkw.read(
                 k,

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -87,12 +87,6 @@ def get_paged_decode_attention_kernels(
         # U represents the number of splits of the key-value sequence.
         # U is parallelizable and is distributed across workgroups.
         constraints += [tkw.WorkgroupConstraint(U, BLOCK_U, 0)]
-        # constraints += [tkw.WaveConstraint(U, BLOCK_U)]
-
-        # wg_func = lambda wg: wg * sympy.floor(T / U) + sympy.Min(wg, sympy.Mod(T, U))
-        # constraints += [
-        #     tkw.WorkgroupConstraint(T, 1, 0, apply_fn=wg_func, primary=False)
-        # ]
         constraints += [
             tkw.TilingConstraint(
                 K2, BLOCK_K2, iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2), start=SPLIT_OFF
@@ -119,7 +113,6 @@ def get_paged_decode_attention_kernels(
         constraints += [tkw.WaveConstraint(B, BLOCK_B / B_WAVES)]
 
         constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 2)]
-        # constraints += [tkw.WaveConstraint(S, BLOCK_S)]
 
         vector_shapes = {BH: 0, S: 0, U: 1}
         waves_per_block = (1, B_WAVES, 1)

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -286,7 +286,7 @@ def get_paged_decode_attention_kernels(
             inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
             x_j = tkw.permute(inner_acc, target_shape=[S, B, K2])
             k2_index = tkw.self_index(K2, tkl.i32)
-            mask = tkw.apply_expr(k2_index, lambda x: x < K2)
+            mask = tkw.apply_expr(k2_index, lambda x: x < (SPLIT_OFF + SPLIT_LEN))
             mask = tkw.broadcast(mask, target_shape=[B, K2])
             mask = tkw.cast(mask, tkw.i1)
             bias = tkw.select(mask, zero, neg_infinity)

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -250,7 +250,7 @@ def get_paged_decode_attention_kernels(
         tkw.set_symbol(SPLIT_OFF, split_offset)
 
         seq_length_per_split = tkw.apply_expr(
-            seq_length, lambda x: sympy.Min(x, sympy.Max(x - SPLIT_OFF, 0))
+            seq_length_per_split, lambda x: sympy.Min(x, sympy.Max(x - SPLIT_OFF, 0))
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -239,6 +239,7 @@ def get_paged_decode_attention_kernels(
         req_index = tkw.read(request_indices, elements_per_thread=1)
         # The sequence length is used to control the bounds of the loop over K2.
         seq_length = tkw.read(sequence_lengths, elements_per_thread=1)
+        tkw.set_symbol(SEQ_LEN, seq_length)
 
         seq_length_per_split = tkw.apply_expr(
             seq_length, lambda x: sympy.ceiling(x / U)
@@ -250,7 +251,8 @@ def get_paged_decode_attention_kernels(
         tkw.set_symbol(SPLIT_OFF, split_offset)
 
         seq_length_per_split = tkw.apply_expr(
-            seq_length_per_split, lambda x: sympy.Min(x, sympy.Max(x - SPLIT_OFF, 0))
+            seq_length_per_split,
+            lambda x: sympy.Min(x, sympy.Max(SEQ_LEN - SPLIT_OFF, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -50,7 +50,6 @@ def get_paged_decode_attention_kernels(
     SPLIT_OFF = tkl.sym.SPLIT_OFF
     SPLIT_LEN = tkl.sym.SPLIT_LEN
     SPLITS_ACTIVE = tkl.sym.SPLITS_ACTIVE
-    ZERO = tkl.sym.ZERO  # Hack
     U = tkl.sym.U  # Num splits
     BH = tkl.sym.BH
     # Workgroup tile sizes

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -356,7 +356,7 @@ def get_paged_decode_attention_kernels(
         M: 1,
         N: shape.head_size_kv,
         K1: shape.head_size,
-        K2: shape.block_size,
+        # K2: shape.block_size,
         BH: shape.num_kv_heads,
         S: shape.num_seqs,
         T: shape.kv_lens,
@@ -366,9 +366,16 @@ def get_paged_decode_attention_kernels(
     symbols_1[BLOCK_B] = PHASE_1_BLOCK_B
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
 
+    dynamic_symbols = [K2]
+    dynamic_symbols_map = {
+        K2: shape.block_size,
+    }
+
     return (
         phase_0,
         phase_1,
         symbols_0,
         symbols_1,
+        dynamic_symbols,
+        dynamic_symbols_map,
     )

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -94,7 +94,7 @@ def get_paged_decode_attention_kernels(
         ]
         constraints += [
             tkw.TilingConstraint(
-                K2, BLOCK_K2, iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2)
+                K2, BLOCK_K2, iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2), start=SPLIT_OFF
             )
         ]
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -231,12 +231,8 @@ def get_paged_decode_attention_kernels(
         new_acc = tkl.Register[S, N, B, tkl.f32](0.0)
 
         # The request index is used to load the appropriate entries from the block table.
-        req_index_v = tkw.read(
-            request_indices, elements_per_thread=LOAD_ELEMS_PER_THREAD_V
-        )
-        req_index_k = tkw.read(
-            request_indices, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK
-        )
+        req_index_v = tkw.read(request_indices, elements_per_thread=1)
+        req_index_k = tkw.read(request_indices, elements_per_thread=1)
         # The sequence length is used to control the bounds of the loop over T.
         seq_length = tkw.read(sequence_lengths, elements_per_thread=1)
         tkw.set_symbol(T, seq_length)
@@ -254,13 +250,13 @@ def get_paged_decode_attention_kernels(
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
             block_indices_v = tkw.read(
                 block_table,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_V,
+                elements_per_thread=1,
                 mapping=block_table_mapping,
                 mapping_dynamic_vals=(req_index_v,),
             )
             block_indices_k = tkw.read(
                 block_table,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
+                elements_per_thread=1,
                 mapping=block_table_mapping,
                 mapping_dynamic_vals=(req_index_k,),
             )

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -90,10 +90,10 @@ def get_paged_decode_attention_kernels(
         constraints += [tkw.WorkgroupConstraint(U, BLOCK_U, 0)]
         # constraints += [tkw.WaveConstraint(U, BLOCK_U)]
 
-        wg_func = lambda wg: wg * sympy.floor(T / U) + sympy.Min(wg, sympy.Mod(T, U))
-        constraints += [
-            tkw.WorkgroupConstraint(T, 1, 0, apply_fn=wg_func, primary=False)
-        ]
+        # wg_func = lambda wg: wg * sympy.floor(T / U) + sympy.Min(wg, sympy.Mod(T, U))
+        # constraints += [
+        #     tkw.WorkgroupConstraint(T, 1, 0, apply_fn=wg_func, primary=False)
+        # ]
         constraints += [
             tkw.TilingConstraint(
                 K2, BLOCK_K2, iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2), start=SPLIT_OFF

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -231,8 +231,7 @@ def get_paged_decode_attention_kernels(
         new_acc = tkl.Register[S, N, B, tkl.f32](0.0)
 
         # The request index is used to load the appropriate entries from the block table.
-        req_index_v = tkw.read(request_indices, elements_per_thread=1)
-        req_index_k = tkw.read(request_indices, elements_per_thread=1)
+        req_index = tkw.read(request_indices, elements_per_thread=1)
         # The sequence length is used to control the bounds of the loop over T.
         seq_length = tkw.read(sequence_lengths, elements_per_thread=1)
         tkw.set_symbol(T, seq_length)
@@ -250,15 +249,15 @@ def get_paged_decode_attention_kernels(
             q_reg = tkw.read(q, elements_per_thread=LOAD_ELEMS_PER_THREAD_QK)
             block_indices_v = tkw.read(
                 block_table,
-                elements_per_thread=1,
+                elements_per_thread=LOAD_ELEMS_PER_THREAD_V,
                 mapping=block_table_mapping,
-                mapping_dynamic_vals=(req_index_v,),
+                mapping_dynamic_vals=(req_index,),
             )
             block_indices_k = tkw.read(
                 block_table,
                 elements_per_thread=1,
                 mapping=block_table_mapping,
-                mapping_dynamic_vals=(req_index_k,),
+                mapping_dynamic_vals=(req_index,),
             )
             k_reg = tkw.read(
                 k,

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -243,7 +243,7 @@ def get_paged_decode_attention_kernels(
         tkw.set_symbol(SPLIT_OFF, split_offset)
 
         seq_length_per_split = tkw.apply_expr(
-            seq_length, lambda x: sympy.Min(x, SEQ_LEN - SPLIT_OFF)
+            seq_length, lambda x: sympy.Min(x, sympy.Max(SEQ_LEN - SPLIT_OFF, 0))
         )
         tkw.set_symbol(K2, seq_length_per_split)
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -381,7 +381,7 @@ def get_paged_decode_attention_kernels(
 
     dynamic_symbols = [K2]
     dynamic_symbols_map = {
-        K2: shape.block_size,
+        K2: shape.kv_lens,
     }
 
     return (

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -181,16 +181,16 @@ def get_paged_decode_attention_kernels(
     # Returns the key for the given token index.
     k_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={T: d0 // K2_dim, BH: j, K2: d0 % K2_dim, K1: l},
-        outputs={T: i, BH: j, K2: k, K1: l},
+        inputs={S: d0 // K2_dim, BH: j, K2: d0 % K2_dim, K1: l},
+        outputs={S: i, BH: j, K2: k, K1: l},
         dynamic_val_mappings={T: i},
     )
 
     # Returns the value for the given token index.
     v_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={T: d0 // K2_dim, BH: j, N: k, K2: d0 % K2_dim},
-        outputs={T: i, BH: j, N: k, K2: l},
+        inputs={S: d0 // K2_dim, BH: j, N: k, K2: d0 % K2_dim},
+        outputs={S: i, BH: j, N: k, K2: l},
         dynamic_val_mappings={T: i},
     )
 
@@ -210,8 +210,8 @@ def get_paged_decode_attention_kernels(
     @tkw.wave(get_constraints(Phase.PHASE_0))
     def phase_0(
         q: tkl.Memory[S, B, K1, GLOBAL_ADDRESS_SPACE, tkl.f16],
-        k: tkl.Memory[T, K2, BH, K1, ADDRESS_SPACE, tkl.f16, k_layout],
-        v: tkl.Memory[T, K2, BH, N, ADDRESS_SPACE, tkl.f16, v_layout],
+        k: tkl.Memory[S, K2, BH, K1, ADDRESS_SPACE, tkl.f16, k_layout],
+        v: tkl.Memory[S, K2, BH, N, ADDRESS_SPACE, tkl.f16, v_layout],
         request_indices: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32],
         sequence_lengths: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32],
         block_table: tkl.Memory[

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -484,7 +484,7 @@ def remove_global_indexing(
     for key in new_index:
         for constraint in tiling_constraints:
             new_dim = new_index[key]
-            if new_dim.start.has(constraint.induction_var):
+            if sympy.sympify(new_dim.start).has(constraint.induction_var):
                 new_dim = new_dim.subs({constraint.induction_var: 0})
                 new_dim.start = new_dim.start - constraint.start
                 new_index[key] = new_dim

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -483,7 +483,11 @@ def remove_global_indexing(
     new_index = {key: safe_subs(index[key], subs) for key in index}
     for key in new_index:
         for constraint in tiling_constraints:
-            new_index[key] = new_index[key].subs({constraint.induction_var: 0})
+            new_dim = new_index[key]
+            if new_dim.start.has(constraint.induction_var):
+                new_dim = new_dim.subs({constraint.induction_var: 0})
+                new_dim.start = new_dim.start - constraint.start
+                new_index[key] = new_dim
     return new_index
 
 

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -220,6 +220,8 @@ def testPagedFlashDecoding(
         phase_1,
         hyperparams_0,
         hyperparams_1,
+        dynamic_symbols,
+        dynamic_symbols_map,
     ) = get_paged_decode_attention_kernels(
         shape,
         mfma_variant,
@@ -266,6 +268,8 @@ def testPagedFlashDecoding(
         run_config=config,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
     ):
         # TODO: Add scaling of QK as part of kernel.
         # TODO: Add variant of non-transposed V attention kernel.

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -38,6 +38,7 @@ from typing import List, Optional
 # Reference paged attention implementation from vLLM and sglang.
 # (NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, BLOCK_SIZE, NUM_SEQS, SEQ_LEN)
 shapes = [(16, 1, 64, 64, 32, 2, 100)]
+shapes += [(16, 1, 64, 64, 32, 2, 3)]  # small SEQ_LEN test
 shapes += [(64, 1, 80, 80, 32, 2, 128)]
 shapes += [(128, 2, 80, 80, 32, 2, 500)]
 

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -149,7 +149,7 @@ def load_inputs(directory):
 @pytest.mark.parametrize(
     "mfma_variant",
     [
-        MMAType.F32_16x16x16_F16,
+        (MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16),
     ],
 )
 def testPagedFlashDecoding(

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -293,7 +293,7 @@ def testPagedFlashDecoding(
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
     ):
-        asm_sv = phase_1(phase_0_output, phase_0_output_max, output)
+        asm_sv = phase_1(phase_0_output, phase_0_output_max, kv_lens_tensor, output)
 
     if dump_generated_mlir:
         filename = f"wave_paged_phase_0_kernel_{'x'.join(map(str, shape))}.mlir"

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -220,8 +220,6 @@ def testPagedFlashDecoding(
         phase_1,
         hyperparams_0,
         hyperparams_1,
-        dynamic_symbols,
-        dynamic_symbols_map,
     ) = get_paged_decode_attention_kernels(
         shape,
         mfma_variant,
@@ -268,8 +266,6 @@ def testPagedFlashDecoding(
         run_config=config,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
-        dynamic_symbols=dynamic_symbols,
-        dynamic_symbols_map=dynamic_symbols_map,
     ):
         # TODO: Add scaling of QK as part of kernel.
         # TODO: Add variant of non-transposed V attention kernel.


### PR DESCRIPTION
Rewrite paged decode to get it closer to the triton kernel impl.

* Distribute K2 loop across splits, which requires custom `iters` and `start` on `TilingConstraint` as well as some custom masking code.
* Add `start` support to `TilingConstraint`
* `global_to_shared_gathers.py`: clone dependent read nodes instead of modifying exiting ones inplace, as they can be used by the other ops.