### PR TITLE
[Wave] Add wave runtime

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -59,10 +59,21 @@ jobs:
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
 
-      - name: Install GPU rocm and pip deps
-        if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && !cancelled()"
+      - name: Install GPU rocm and pip deps (mi300)
+        if: "(!contains(toJSON(matrix.os), 'amdgpu') && contains(toJSON(matrix.os), 'mi300')) && !cancelled()"
         run: |
           sudo apt install -y rocm
+          python -m pip install --no-compile --upgrade pip
+          # Note: We install in three steps in order to satisfy requirements
+          # from non default locations first. Installing the PyTorch CPU
+          # wheels saves multiple minutes and a lot of bandwidth on runner setup.
+          pip install --no-compile -r pytorch-rocm-requirements.txt
+          pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
+          pip install -r requirements.txt -e .
+
+      - name: Install pip deps (mi250)
+        if: "(contains(toJSON(matrix.os), 'amdgpu') && !contains(toJSON(matrix.os), 'mi300')) && !cancelled()"
+        run: |
           python -m pip install --no-compile --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU

--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -59,9 +59,10 @@ jobs:
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
 
-      - name: Install GPU pip deps
+      - name: Install GPU rocm and pip deps
         if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && !cancelled()"
         run: |
+          sudo apt install -y rocm
           python -m pip install --no-compile --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -6,6 +6,7 @@
 
 
 import copy
+import glob
 import hashlib
 import inspect
 import json
@@ -17,17 +18,25 @@ import threading
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
 import functools
+from typing import Any, Callable, Optional
 
 from .constraints import Constraint, TilingConstraint, WaveConstraint
 from ..compiler.kernel_codegen import KernelBufferUsage
 from ..lang.wave_types import IndexMapping
 from .._support.indexing import IndexExpr
-from .utils import invoke_vmfb, _read_file, _write_file
+from .utils import (
+    invoke_vmfb,
+    _read_file,
+    _write_file,
+    KernelLaunchInfo,
+    _write_pickle_file,
+    _read_pickle_file,
+)
 
 default_cache_base_dir = Path.home() / ".wave"
 CACHE_BASE_DIR = Path(os.environ.get("WAVE_CACHE_DIR", default_cache_base_dir))
+WAVE_RUNTIME_DIR = CACHE_BASE_DIR / "wave_runtime"
 WAVE_ALWAYS_COMPILE = int(os.environ.get("WAVE_ALWAYS_COMPILE", 0))
 WAVE_CACHE_ON = int(os.environ.get("WAVE_CACHE_ON", 1))
 WAVE_CACHE_LIMIT = int(os.environ.get("WAVE_CACHE_LIMIT", 16))
@@ -48,10 +57,15 @@ class WaveCache:
     cache_id: str
     kernel_sig: tuple[KernelBufferUsage]
     vmfb: bytes
+    kernel_launch_info: Optional[KernelLaunchInfo] = None
 
     @property
-    def asm(self):
-        filepath = (CACHE_BASE_DIR / self.cache_id / self.cache_id).with_suffix(".mlir")
+    def asm_filepath(self):
+        return (CACHE_BASE_DIR / self.cache_id / self.cache_id).with_suffix(".mlir")
+
+    @staticmethod
+    @functools.lru_cache
+    def asm(filepath: str):
         with open(filepath, "r") as f:
             module_str = f.read()
         return module_str
@@ -191,10 +205,13 @@ class WaveCacheManager(object):
         vmfb: bytes,
         kernel_sig: tuple[KernelBufferUsage],
         module_str: str,
+        kernel_launch_info: KernelLaunchInfo,
     ):
         """
         Stores/save compiled kernels into CACHE_BASE_DIR/kernel_hash
-        including it's MLIR, VMFB, and kernel signature.
+        including it's MLIR, VMFB, and kernel signature. If wave
+        runtime is enabled, also copies the hsaco binary and
+        stores the kernel launch information.
         """
         cur_cache_dir = CACHE_BASE_DIR / kernel_hash
         os.makedirs(cur_cache_dir, exist_ok=True)
@@ -206,6 +223,13 @@ class WaveCacheManager(object):
         _write_file(cur_module_path, "w", module_str)
         kernel_sig_str = json.dumps([usage.name for usage in kernel_sig])
         _write_file(cur_kernelsig_path, "w", kernel_sig_str)
+        cur_hsaco_path = glob.glob(str(WAVE_RUNTIME_DIR / "*.hsaco"))
+        # Copy the hsaco file to the cache directory only if it exists.
+        if cur_hsaco_path:
+            cur_hsaco_path = cur_hsaco_path[0]
+            shutil.copy(cur_hsaco_path, cur_cache_basefile.with_suffix(".hsaco"))
+        cur_pkl_path = cur_cache_basefile.with_suffix(".pkl")
+        _write_pickle_file(cur_pkl_path, "wb", kernel_launch_info)
 
     @staticmethod
     @functools.lru_cache
@@ -225,7 +249,9 @@ class WaveCacheManager(object):
         vmfb = _read_file(cur_vmfb_path, "rb")
         kernel_sig_str = json.loads(_read_file(cur_kernelsig_path, "r"))
         kernel_sig = [KernelBufferUsage[usage] for usage in kernel_sig_str]
-        return WaveCache(kernel_hash, kernel_sig, vmfb)
+        cur_pkl_path = cur_cache_basefile.with_suffix(".pkl")
+        kernel_launch_info = _read_pickle_file(cur_pkl_path, "rb")
+        return WaveCache(kernel_hash, kernel_sig, vmfb, kernel_launch_info)
 
     ###############################################################################
     # Session cache related helpers
@@ -246,6 +272,7 @@ class WaveCacheManager(object):
         kernel_sig: tuple[KernelBufferUsage],
         module_str: str,
         kernel_hash: str,
+        kernel_launch_info: KernelLaunchInfo,
     ):
         """
         Save given kernel(vmfb, kernel_sig, and MLIR) into session_cache and file/offline cache.
@@ -253,11 +280,14 @@ class WaveCacheManager(object):
         if not WAVE_CACHE_ON or not kernel_hash:
             return
         with self.lock:
-            self.store_kernel_to_file(kernel_hash, vmfb, kernel_sig, module_str)
+            self.store_kernel_to_file(
+                kernel_hash, vmfb, kernel_sig, module_str, kernel_launch_info
+            )
             if not WAVE_ALWAYS_COMPILE:
                 # Do not store in session cache if always compile to save memory.
                 self.store_kernel_to_session(
-                    kernel_hash, WaveCache(kernel_hash, kernel_sig, vmfb)
+                    kernel_hash,
+                    WaveCache(kernel_hash, kernel_sig, vmfb, kernel_launch_info),
                 )
 
     def load_kernel(self, kernel_hash: str):
@@ -335,4 +365,5 @@ def invoke_cached_kernel(
         run_bench,
         inplace=True,
         kernel_hash=kernel_hash,
+        kernel_launch_info=cached_kernel.kernel_launch_info,
     )

--- a/iree/turbine/kernel/wave/promotion.py
+++ b/iree/turbine/kernel/wave/promotion.py
@@ -70,9 +70,9 @@ def apply_promotion_pattern(
     ```
     """
     match custom_node:
-        case Read(memory, elements_per_thread) if get_custom(
-            memory
-        ).type.address_space != allocate_node.address_space:
+        case Read(memory, elements_per_thread) if (
+            get_custom(memory).type.address_space != allocate_node.address_space
+        ):
             # Moves memory to top of graph after allocate to avoid non-dominating operands.
             move_node_after(custom_node.memory, allocate_node.fx_node)
             # We move CustomOp/Read up to the last write_to_shared_mem S.T
@@ -160,4 +160,4 @@ def compute_shared_memory_usage(
         custom_alloc = get_custom(alloc)
         shape = subs_idxc(math.prod(custom_alloc.distributed_shape))
         bits = custom_alloc.type.dtype.bitwidth()
-        kernel_launch_info.shared_memory_bytes += (shape * bits) // 8
+        kernel_launch_info.shared_memory_bytes += int((shape * bits) // 8)

--- a/iree/turbine/kernel/wave/runtime/CMakeLists.txt
+++ b/iree/turbine/kernel/wave/runtime/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.15...3.27)
+project(wave_runtime)
+
+if (CMAKE_VERSION VERSION_LESS 3.18)
+  set(DEV_MODULE Development)
+else()
+  set(DEV_MODULE Development.Module)
+endif()
+
+find_package(Python 3.10 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Detect the installed nanobind package and import it into CMake
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+# Link against torch, using the libraries and include dirs in site-packages.
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c "import torch; print(torch.utils.cmake_prefix_path)"
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE torch_cmake_PATH)
+list(APPEND CMAKE_PREFIX_PATH ${torch_cmake_PATH})
+list(APPEND CMAKE_PREFIX_PATH "/opt/rocm")
+
+find_package(Torch REQUIRED)
+find_package(HIP REQUIRED)
+add_definitions(-D__HIP_PLATFORM_AMD__)
+
+# Build the core parts of nanobind once
+nanobind_build_library(nanobind SHARED)
+
+# Compile an extension library
+add_library(wave_runtime MODULE runtime.cpp)
+
+# .. and link it against the nanobind parts
+target_link_libraries(wave_runtime PRIVATE nanobind hip::host ${TORCH_LIBRARIES})
+include_directories(${TORCH_INCLUDE_DIRS})
+
+# .. enable size optimizations
+nanobind_opt_size(wave_runtime)
+
+# .. enable link time optimization
+nanobind_lto(wave_runtime)
+
+# .. set the default symbol visibility to 'hidden'
+nanobind_set_visibility(wave_runtime)
+
+# .. strip unneeded symbols and debug info from the binary (only active in release builds)
+nanobind_strip(wave_runtime)
+
+# .. disable the stack protector
+nanobind_disable_stack_protector(wave_runtime)
+
+# .. set the Python extension suffix
+nanobind_extension(wave_runtime)
+
+# .. set important compilation flags
+nanobind_compile_options(wave_runtime PRIVATE ${TORCH_CXX_FLAGS})
+
+# .. set important linker flags
+nanobind_link_options(wave_runtime)

--- a/iree/turbine/kernel/wave/runtime/runtime.cpp
+++ b/iree/turbine/kernel/wave/runtime/runtime.cpp
@@ -1,0 +1,118 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/string.h>
+#include <torch/torch.h>
+#include <torch/extension.h>
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#include <ATen/hip/HIPContext.h>
+#include <unordered_map>
+
+namespace nb = nanobind;
+
+#define HIP_CHECK_EXC(expr)                                                                       \
+    do                                                                                            \
+    {                                                                                             \
+        hipError_t e = (expr);                                                                    \
+        if (e)                                                                                    \
+        {                                                                                         \
+            const char *errName = hipGetErrorName(e);                                             \
+            const char *errMsg = hipGetErrorString(e);                                            \
+            std::ostringstream msg;                                                               \
+            msg << "Error " << e << "(" << errName << ") " << __FILE__ << ":" << __LINE__ << ": " \
+                << std::endl                                                                      \
+                << #expr << std::endl                                                             \
+                << errMsg << std::endl;                                                           \
+            throw std::runtime_error(msg.str());                                                  \
+        }                                                                                         \
+    } while (0)
+
+#define HIP_CHECK_RETURN(expr) \
+    do                         \
+    {                          \
+        hipError_t e = (expr); \
+        if (e)                 \
+            return e;          \
+    } while (0)
+
+struct KernelLaunchInfo
+{
+    std::string kernel, function, kernelHash;
+    int sharedMemoryBytes;
+    int gridX, gridY, gridZ;
+    int blockX, blockY, blockZ;
+};
+
+std::unordered_map<std::string, std::tuple<hipModule_t, hipFunction_t>> cache;
+using Int64Vector = std::vector<uint64_t>;
+using Int32Vector = std::vector<uint32_t>;
+
+int launch(const KernelLaunchInfo &info, const Int64Vector &tensors, const Int64Vector &dynamicDims)
+{
+    hipStream_t stream = at::hip::getCurrentHIPStream();
+    hipModule_t module;
+    hipFunction_t function;
+
+    if (cache.count(info.kernelHash))
+    {
+        std::tie(module, function) = cache.at(info.kernelHash);
+    }
+    else
+    {
+        HIP_CHECK_RETURN(hipModuleLoad(&module, info.kernel.c_str()));
+        HIP_CHECK_RETURN(hipModuleGetFunction(&function, module, info.function.c_str()));
+        if (!info.kernelHash.empty())
+            cache[info.kernelHash] = std::make_tuple(module, function);
+    }
+
+    // Since we always pass our dynamic dims as index type, iree converts them to i64
+    // and then splits them to two i32s, i64 = hi | lo where
+    // lo = trunc(i64) and hi = trunc(i64 >> 32).
+    size_t kernArgSize = tensors.size() * sizeof(uint64_t) + 2 * dynamicDims.size() * sizeof(uint32_t);
+    uint8_t kernelArguments[kernArgSize];
+    uint64_t *ptr = (uint64_t *)kernelArguments;
+    for (int i = 0; i < tensors.size(); i++, ptr++)
+        *ptr = tensors[i];
+    uint32_t *ptr2 = (uint32_t *)ptr;
+    for (int i = 0; i < dynamicDims.size(); i++, ptr2++)
+    {
+        *ptr2 = (uint32_t)dynamicDims[i];
+        ptr2++;
+        *ptr2 = (uint32_t)(dynamicDims[i] >> 32);
+    }
+
+    void *hipLaunchParams[] = {
+        HIP_LAUNCH_PARAM_BUFFER_POINTER,
+        kernelArguments,
+        HIP_LAUNCH_PARAM_BUFFER_SIZE,
+        &kernArgSize,
+        HIP_LAUNCH_PARAM_END};
+    HIP_CHECK_RETURN(hipModuleLaunchKernel(function, info.gridX, info.gridY, info.gridZ,
+                                           info.blockX, info.blockY, info.blockZ, info.sharedMemoryBytes,
+                                           stream, nullptr, (void **)&hipLaunchParams));
+
+    // Always unload the module if the kernel hash is empty.
+    if (info.kernelHash.empty())
+        HIP_CHECK_RETURN(hipModuleUnload(module));
+
+    return hipSuccess;
+}
+
+NB_MODULE(wave_runtime, m)
+{
+    nb::bind_vector<Int64Vector>(m, "Int64Vector");
+    nb::bind_vector<Int32Vector>(m, "Int32Vector");
+    nb::class_<KernelLaunchInfo>(m, "KernelLaunchInfo")
+        .def(nb::init<const std::string &, const std::string &, const std::string &, int, int, int, int, int, int, int>())
+        .def_rw("kernel", &KernelLaunchInfo::kernel)
+        .def_rw("function", &KernelLaunchInfo::function)
+        .def_rw("kernelHash", &KernelLaunchInfo::kernelHash)
+        .def_rw("sharedMemoryBytes", &KernelLaunchInfo::sharedMemoryBytes)
+        .def_rw("gridX", &KernelLaunchInfo::gridX)
+        .def_rw("gridY", &KernelLaunchInfo::gridY)
+        .def_rw("gridZ", &KernelLaunchInfo::gridZ)
+        .def_rw("blockX", &KernelLaunchInfo::blockX)
+        .def_rw("blockY", &KernelLaunchInfo::blockY)
+        .def_rw("blockZ", &KernelLaunchInfo::blockZ);
+    m.def("launch", &launch);
+}

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -68,6 +68,18 @@ import iree.runtime as rt
 # TODO: Monkey-patching f16 support, need to fix in iree.
 import numpy
 import ctypes
+from dataclasses import dataclass
+import glob
+import os
+import pickle
+
+
+@dataclass
+class KernelLaunchInfo:
+    grid: tuple[int] = None
+    blocks: tuple[int] = None
+    shared_memory_bytes: int = 0
+    func_name: str = ""
 
 
 def try_apply_pass(
@@ -591,9 +603,20 @@ def _read_file(name, mode):
     return data
 
 
+def _read_pickle_file(name, mode):
+    with open(name, mode) as file:
+        data = pickle.load(file)
+    return data
+
+
 def _write_file(name, mode, data):
     with open(name, mode) as file:
         file.write(data)
+
+
+def _write_pickle_file(name, mode, data):
+    with open(name, mode) as file:
+        pickle.dump(data, file)
 
 
 def _print_bench_result(result, filename):
@@ -659,6 +682,9 @@ def compile_to_vmfb(
             f"--iree-hal-dump-executable-intermediates-to={intermediates_path}"
         )
 
+    if binaries_path := config.get("dump_binaries", None):
+        flags.append(f"--iree-hal-dump-executable-binaries-to={binaries_path}")
+
     if run_bench:
         bench_batch_size = config.get("benchmark_batch_size", None)
         if bench_batch_size is not None:
@@ -674,6 +700,54 @@ def compile_to_vmfb(
 RUNTIME_CACHE: dict[str, tuple[rt.SystemContext, rt.VmFunction]] = {}
 
 
+def invoke_with_wave_runtime(
+    kernel_inputs: list[torch.Tensor],
+    kernel_outputs: list[torch.Tensor],
+    kernel_dynamic_dims: list[int],
+    kernel_hash: str,
+    kernel_info: KernelLaunchInfo,
+):
+    """
+    Invokes the kernel with the wave runtime.
+    """
+    import wave_runtime
+    from .cache import WAVE_RUNTIME_DIR, CACHE_BASE_DIR
+
+    # Get the path to the binary.
+    if kernel_hash:
+        binary = str(CACHE_BASE_DIR / kernel_hash / kernel_hash) + ".hsaco"
+    else:
+        bin_dir = WAVE_RUNTIME_DIR
+        binary = glob.glob(str(bin_dir / "*.hsaco"))[0]
+
+    # Populate all the information required to launch the kernel.
+    hash_str = "" if not kernel_hash else kernel_hash
+    kernel_launch_info = wave_runtime.KernelLaunchInfo(
+        binary,
+        kernel_info.func_name,
+        hash_str,
+        kernel_info.shared_memory_bytes,
+        kernel_info.grid[0],
+        kernel_info.grid[1],
+        kernel_info.grid[2],
+        kernel_info.blocks[0],
+        kernel_info.blocks[1],
+        kernel_info.blocks[2],
+    )
+
+    # Ensure that the tensors are contiguous.
+    kern_args = []
+    for arg_tensor in kernel_inputs + kernel_outputs:
+        if not arg_tensor.is_contiguous():
+            arg_tensor = arg_tensor.contiguous()
+        kern_args.append(arg_tensor.data_ptr())
+
+    kernel_args = wave_runtime.Int64Vector(kern_args)
+    dyn_dims = wave_runtime.Int64Vector(list(kernel_dynamic_dims))
+    # Launch the kernel.
+    wave_runtime.launch(kernel_launch_info, kernel_args, dyn_dims)
+
+
 def invoke_vmfb(
     vmfb: bytes,
     func_name: str,
@@ -685,7 +759,19 @@ def invoke_vmfb(
     run_bench: bool = False,
     inplace: bool = False,
     kernel_hash: Optional[str] = None,
+    kernel_launch_info: Optional[KernelLaunchInfo] = None,
 ):
+    wave_runtime_launcher = config.get("wave_runtime", None)
+    if wave_runtime_launcher:
+        invoke_with_wave_runtime(
+            kernel_inputs,
+            kernel_outputs,
+            kernel_dynamic_dims,
+            kernel_hash,
+            kernel_launch_info,
+        )
+        return
+
     device = config["device"]
     if run_bench:
         bench_batch_size = config.get("benchmark_batch_size", None)
@@ -1619,3 +1705,16 @@ def print_live_tensors():
         except:
             pass
     print("-----------------------------")
+
+
+def remove_files_with_extension(directory, extension):
+    pattern = os.path.join(directory, "*" + extension)
+    files_to_remove = glob.glob(pattern)
+
+    for file_path in files_to_remove:
+        try:
+            os.remove(file_path)
+        except FileNotFoundError:
+            print(f"File not found: {file_path}")
+        except Exception as e:
+            print(f"Error removing {file_path}: {e}")

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -603,20 +603,9 @@ def _read_file(name, mode):
     return data
 
 
-def _read_pickle_file(name, mode):
-    with open(name, mode) as file:
-        data = pickle.load(file)
-    return data
-
-
 def _write_file(name, mode, data):
     with open(name, mode) as file:
         file.write(data)
-
-
-def _write_pickle_file(name, mode, data):
-    with open(name, mode) as file:
-        pickle.dump(data, file)
 
 
 def _print_bench_result(result, filename):
@@ -717,8 +706,7 @@ def invoke_with_wave_runtime(
     if kernel_hash:
         binary = str(CACHE_BASE_DIR / kernel_hash / kernel_hash) + ".hsaco"
     else:
-        bin_dir = WAVE_RUNTIME_DIR
-        binary = glob.glob(str(bin_dir / "*.hsaco"))[0]
+        binary = glob.glob(str(WAVE_RUNTIME_DIR / "*.hsaco"))[0]
 
     # Populate all the information required to launch the kernel.
     hash_str = "" if not kernel_hash else kernel_hash

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -47,7 +47,7 @@ from .expansion.expansion import expand_graph
 from .global_to_shared_gathers import global_to_shared_gathers
 from .hoisting import hoist_loop_invariant_ops
 from .minimize_global_loads import minimize_global_loads
-from .promotion import promote_placeholders
+from .promotion import promote_placeholders, compute_shared_memory_usage
 from .reuse_shared_allocs import reuse_shared_allocs
 from .scheduling.schedule import schedule_graph, SchedulingType
 from .type_inference import infer_types
@@ -71,11 +71,15 @@ from .utils import (
     partial,
     print_trace,
     try_apply_pass,
+    KernelLaunchInfo,
+    get_hardware_constraint,
+    remove_files_with_extension,
 )
 from .cache import (
     is_cache_enabled,
     get_cache_manager,
     invoke_cached_kernel,
+    WAVE_RUNTIME_DIR,
 )
 
 # Others
@@ -84,9 +88,17 @@ import torch.fx as fx
 import inspect
 import sympy
 import warnings
+from pathlib import Path
+import sys
+import subprocess
+import os
+import shutil
+import glob
 
 __all__ = ["wave", "wave_trace_only"]
 
+# Add wave runtime directory to sys path.
+sys.path.append(str(WAVE_RUNTIME_DIR))
 
 # Warn only once
 _warned = False
@@ -134,6 +146,44 @@ def _warn_iree_is_too_old():
         warnings.warn(
             f"IREE version is too old: {iree_compiler_ver}, min version: {min_iree_version}"
         )
+
+
+def build_wave_runtime():
+    wave_runtime_lib = "wave_runtime*.so"
+    lib_path = glob.glob(str(WAVE_RUNTIME_DIR / wave_runtime_lib))
+    # Don't build if lib already exists.
+    if lib_path and Path(lib_path[0]).is_file():
+        return
+
+    # Run cmake command.
+    runtime_path = Path(__file__).resolve()
+    runtime_path = runtime_path.parent / "runtime"
+    runtime_build_path = runtime_path / "build"
+    args = [
+        "cmake",
+        f"-DPython_EXECUTABLE={sys.executable}",
+        "-S",
+        str(runtime_path),
+        "-B",
+        str(runtime_build_path),
+    ]
+    try:
+        subprocess.run(args, check=True)
+    except subprocess.CalledProcessError as e:
+        raise ValueError(f"CMake configuration failed: {e}")
+
+    # Run build command.
+    args = ["cmake", "--build", str(runtime_build_path)]
+    try:
+        subprocess.run(args, check=True)
+    except subprocess.CalledProcessError as e:
+        raise ValueError(f"Build failed: {e}")
+
+    # Copy lib to cache dir.
+    os.makedirs(WAVE_RUNTIME_DIR, exist_ok=True)
+    lib_path = glob.glob(str(runtime_build_path / wave_runtime_lib))[0]
+    shutil.copy(lib_path, WAVE_RUNTIME_DIR)
+    sys.path.append(str(runtime_build_path))
 
 
 def wave(constraints: Optional[list[Constraint]] = None):
@@ -442,6 +492,7 @@ class LaunchableWave(Launchable):
     def build_initial_pass_pipeline(
         self,
         trace: CapturedTrace,
+        kernel_launch_info: KernelLaunchInfo,
         print_ir_before: Sequence[str] = [],
         print_ir_after: Sequence[str] = [],
     ):
@@ -488,12 +539,23 @@ class LaunchableWave(Launchable):
         dispatch_codegen.StreamExecutable,
         kernel_codegen.KernelSignature,
         str,
+        KernelLaunchInfo,
     ]:
         # Issue a warning if IREE ver is too low.
         # Warning will only be issued if we are compiling the kernel and won't
         # if we are using cached kernel as we don't want to add any additional
         # overhead to 'happy' path.
         _warn_iree_is_too_old()
+
+        # Store kernel launch info for the wave runtime.
+        kernel_launch_info = KernelLaunchInfo()
+
+        # Build wave runtime, if specified.
+        run_config = kwargs.get("run_config", {})
+        if run_config.get("wave_runtime", None):
+            # Remove any existing hsaco files in this directory.
+            remove_files_with_extension(WAVE_RUNTIME_DIR, ".hsaco")
+            build_wave_runtime()
 
         compile_config = kwargs.get("compile_config", {})
         print_ir_after = compile_config.get("print_ir_after", [])
@@ -513,7 +575,7 @@ class LaunchableWave(Launchable):
 
         # Initial passes, pre-optimization.
         graph_passes = self.build_initial_pass_pipeline(
-            trace, print_ir_before, print_ir_after
+            trace, kernel_launch_info, print_ir_before, print_ir_after
         )
 
         # Optimizations.
@@ -565,6 +627,7 @@ class LaunchableWave(Launchable):
             # so it should be called close to the end of pipeline.
             partial(align_index_sizes, trace, self.constraints),
             partial(add_shared_memory_barriers, trace),
+            partial(compute_shared_memory_usage, trace, kernel_launch_info),
         ]
 
         for p in graph_passes:
@@ -580,7 +643,22 @@ class LaunchableWave(Launchable):
         if compile_config.get("print_grid", False):
             print(f"Grid: {self.grid_type}")
 
-        return self.compile_to_mlir(trace, context, module_op, *args, **kwargs)
+        # Add grid and block dims to kernel launch info.
+        dynamic_symbols_map = kwargs.get("dynamic_symbols_map", {})
+        try_convert_to_int = lambda x: int(x) if isinstance(x, sympy.Integer) else x
+        kernel_launch_info.grid = [
+            try_convert_to_int(safe_subs(x, dynamic_symbols_map))
+            for x in self.grid_type.dims
+        ]
+        kernel_launch_info.blocks = [
+            int(x) for x in get_hardware_constraint(self.constraints).threads_per_block
+        ]
+        kernel_launch_info.func_name = self._name
+
+        return (
+            *self.compile_to_mlir(trace, context, module_op, *args, **kwargs),
+            kernel_launch_info,
+        )
 
     def test_execute(self, args, kwargs):
         run = kwargs.get("run", False)
@@ -594,6 +672,11 @@ class LaunchableWave(Launchable):
         # When this is passed in from the user, we will populate it with the kernel hash.
         # It will always be returned with just one entry which is the hash of the kernel.
         cached_kernel_hash = kwargs.get("kernel_hash", [])
+        # For the wave runtime, we need the hsaco binary. So we turn on
+        # dumping of binaries and store in wave runtime directory. If we
+        # are caching, this will be moved to the appropriate directory.
+        if config and config.get("wave_runtime", None):
+            config["dump_binaries"] = str(WAVE_RUNTIME_DIR)
 
         # Get cached kernel when available.
         cache_enabled = is_cache_enabled()
@@ -630,7 +713,7 @@ class LaunchableWave(Launchable):
                     run_bench,
                     kernel_hash,
                 )
-                return cached_kernel.asm
+                return cached_kernel.asm(cached_kernel.asm_filepath)
 
         # Recompile kernel from scratch if not found in cache.
         (
@@ -639,6 +722,7 @@ class LaunchableWave(Launchable):
             exe,
             kernel_sig,
             entrypoint_name,
+            kernel_launch_info,
         ) = self._trace_and_get_kernel_signature(args, kwargs)
 
         if run or run_bench or create_vmfb_file:
@@ -685,6 +769,7 @@ class LaunchableWave(Launchable):
                     kernel_usages,
                     asm,
                     kernel_hash,
+                    kernel_launch_info,
                 )
 
             invoke_vmfb(
@@ -698,6 +783,7 @@ class LaunchableWave(Launchable):
                 run_bench,
                 inplace=True,
                 kernel_hash=kernel_hash,
+                kernel_launch_info=kernel_launch_info,
             )
 
         return mb.module_op.get_asm()

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -554,6 +554,9 @@ class LaunchableWave(Launchable):
         run_config = kwargs.get("run_config", {})
         if run_config.get("wave_runtime", None):
             # Remove any existing hsaco files in this directory.
+            # If the kernel is being cached, then it will be referenced from the
+            # cache directory. When kernels are not being cached, we remove them
+            # to ensure that at any time there is only one hsaco file in this directory.
             remove_files_with_extension(WAVE_RUNTIME_DIR, ".hsaco")
             build_wave_runtime()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 # Build/test requirements.
 Jinja2==3.1.4
+cmake==3.31.6
 filecheck==1.0.0
 lit==18.1.7
 ml_dtypes==0.5.0
 mypy==1.8.0
+nanobind==2.5.0
 numpy
 parameterized==0.9.0
 pytest-xdist==3.5.0

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -284,6 +284,7 @@ def create_inputs(
 @pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("is_causal", "causal")
 @param_bool("use_buffer_ops", "buf_ops")
+@param_bool("use_wave_runtime", "wr", [True])
 @pytest.mark.parametrize(
     "mfma_variant",
     [
@@ -297,6 +298,7 @@ def testExtendAttention(
     enable_scheduling: SchedulingType,
     is_causal: bool,
     use_buffer_ops: bool,
+    use_wave_runtime: bool,
     mfma_variant: MMAType,
     request,
 ):
@@ -368,6 +370,9 @@ def testExtendAttention(
             "wave_extend_attention", mfma_variant, is_causal, shape
         )
         config["benchmark_results_file"] = os.path.join(dump_perf, perf_filename)
+
+    if use_wave_runtime:
+        config["wave_runtime"] = True
 
     with tk.gen.TestLaunchContext(
         hyperparams,


### PR DESCRIPTION
This PR adds a custom wave runtime that can be used to launch kernels. The runtime uses nanobind to transfer the kernel arguments from Python to C++ and then launches the kernels using the hip API. In order to enable this, we add the C++ code for wave runtime and link against nanobind and torch to generate a shared library that can be loaded.

For this runtime, we need the hsaco binary instead of the vmfb. So we cache the hsaco and associated kernel launch info when the cache is enabled. Finally, we add a pass to compute the shared memory usage by summing up the bytes used by all the shared memory allocations.

This PR will require all old cache directories to be removed.