### PR TITLE
[TKW] Mask value op

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -154,7 +154,9 @@ def broadcast(
     ...
 
 
-def mask_value(arg: "Register", value: int | float) -> "Register":
+def mask_value(
+    arg: "Register", value: int | float, dim_bounds: dict[IndexExpr, IndexExpr] = None
+) -> "Register":
     ...
 
 
@@ -1815,6 +1817,7 @@ class Broadcast(CustomOp, ABC):
 class MaskValue(CustomOp):
     register_: fx.Proxy
     value: int | float
+    dim_bounds: dict[IndexExpr, IndexExpr] = field(default_factory=dict)
 
     @property
     def type(self) -> "Register":

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -154,6 +154,10 @@ def broadcast(
     ...
 
 
+def mask_value(arg: "Register", value: int | float) -> "Register":
+    ...
+
+
 def sum(
     src: "Register",
     acc: Optional["Register"] = None,
@@ -1804,6 +1808,21 @@ class Broadcast(CustomOp, ABC):
     def infer_type(self):
         src_dtype = get_custom(self.arg).type.dtype
         self.type = Register[(*self.target_shape, src_dtype)]
+
+
+@define_op("mask_value")
+@dataclass
+class MaskValue(CustomOp):
+    register_: fx.Proxy
+    value: int | float
+
+    @property
+    def type(self) -> "Register":
+        return get_custom(self.register_).type
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        return get_custom(self.register_).indexing_dims
 
 
 @define_interface_op("max")

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -563,9 +563,12 @@ def get_constant_attr(value: Any, element_type: IrType) -> Attribute:
 
 
 def build_mask(
-    emitter: WaveEmitter, index: Dict[IndexExpr, IndexExpr], elements_per_thread: int
+    emitter: WaveEmitter,
+    index: Dict[IndexExpr, IndexExpr],
+    elements_per_thread: int,
+    dim_bounds: dict[IndexExpr, IndexExpr] = {},
 ) -> Optional[OpResult]:
-    bounds = find_index_bounds(emitter.constraints, index)
+    bounds = find_index_bounds(emitter.constraints, index, dim_bounds)
     if bounds is None:
         return None
 
@@ -577,7 +580,7 @@ def build_mask(
     new_index[last_dim] = new_index[last_dim] + idxc.iota(elements_per_thread)
 
     mask_expr = functools.reduce(
-        lambda a, b: sympy.And(a, b), (new_index[dim] < dim for dim in bounds)
+        lambda a, b: sympy.And(a, b), (new_index[dim] < bound for dim, bound in bounds)
     )
     mask = gen_sympy_index(add_emitter_subs(emitter), mask_expr)
 

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -894,7 +894,7 @@ def handle_broadcast(emitter: WaveEmitter, node: fx.Node):
 @handle_op(mask_value)
 def handle_mask_value(emitter: WaveEmitter, node: fx.Node):
     try:
-        register, value = node.args
+        register, value, dim_bounds = node.args
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
 
@@ -902,8 +902,7 @@ def handle_mask_value(emitter: WaveEmitter, node: fx.Node):
     register = cast_py_value(emitter, register).ir_value
     vec_type = register.type
 
-    bounds = find_index_bounds(emitter.constraints, index)
-    if mask := build_mask(emitter, index, vec_type.shape[0]):
+    if mask := build_mask(emitter, index, vec_type.shape[0], dim_bounds):
         val = arith_d.constant(
             vec_type,
             DenseElementsAttr.get_splat(

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -225,9 +225,6 @@ def get_paged_decode_attention_kernels(
         init_sum = tkl.Register[S, B, tkl.f32](0.0)
         new_acc = tkl.Register[S, N, B, tkl.f32](0.0)
 
-        zero = tkl.Register[B, K2, tkl.f32](0.0)
-        neg_infinity = tkl.Register[B, K2, tkl.f32](-1e6)
-
         # The request index is used to load the appropriate entries from the block table.
         req_index = tkw.read(request_indices, elements_per_thread=1)
         # The sequence length is used to control the bounds of the loop over K2.
@@ -277,12 +274,7 @@ def get_paged_decode_attention_kernels(
             imm_reg = tkl.Register[S, K2, B, tkl.f32](0.0)
             inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
             x_j = tkw.permute(inner_acc, target_shape=[S, B, K2])
-            k2_index = tkw.self_index(K2, tkl.i32)
-            mask = tkw.apply_expr(k2_index, lambda x: x < (SPLIT_OFF + SPLIT_LEN))
-            mask = tkw.broadcast(mask, target_shape=[B, K2])
-            mask = tkw.cast(mask, tkw.i1)
-            bias = tkw.select(mask, zero, neg_infinity)
-            x_j = x_j + bias
+            x_j = tkw.mask_value(x_j, -1e6)
             m_j = tkw.max(x_j, partial_max, dim=K2)
             e_delta_max = tkw.exp2(partial_max - m_j)
             e_delta = tkw.exp2(x_j - m_j)

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -274,7 +274,7 @@ def get_paged_decode_attention_kernels(
             imm_reg = tkl.Register[S, K2, B, tkl.f32](0.0)
             inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
             x_j = tkw.permute(inner_acc, target_shape=[S, B, K2])
-            x_j = tkw.mask_value(x_j, -1e6)
+            x_j = tkw.mask_value(x_j, -1e6, dim_bounds={K2: SPLIT_OFF + SPLIT_LEN})
             m_j = tkw.max(x_j, partial_max, dim=K2)
             e_delta_max = tkw.exp2(partial_max - m_j)
             e_delta = tkw.exp2(x_j - m_j)

--- a/iree/turbine/kernel/wave/utils.py
+++ b/iree/turbine/kernel/wave/utils.py
@@ -1229,19 +1229,19 @@ def evaluate_with_assumptions(constraints: list[Constraint], expr: IndexExpr) ->
     return True if any([result.equals(x) for x in facts]) else None
 
 
-def _get_start_index(i: IndexSequence | IndexExpr) -> IndexExpr:
+def get_start_index(i: IndexSequence | IndexExpr) -> IndexExpr:
     if isinstance(i, IndexSequence):
         i = i.start
 
     return i
 
 
-def _get_start_indices(
+def get_start_indices(
     src_indices: dict[IndexExpr, IndexSequence | IndexExpr],
 ) -> list[IndexExpr]:
     start_indices = []
     for dim_indexing in src_indices:
-        i = _get_start_index(src_indices[dim_indexing])
+        i = get_start_index(src_indices[dim_indexing])
         start_indices.append(i)
 
     return start_indices


### PR DESCRIPTION
Add `mask_value` which allows to override default masked value (0) with user provided val. Useful when op is expecting different neutral value (e.g. -inf for max).

Uses the same logic as read/write masking. Includes some refactoring and moving masking code around.