### PR TITLE
[BOO] Adds a function for getting a Launchable from a ConvSignature

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/__init__.py
+++ b/iree/turbine/kernel/boo/conv_exports/__init__.py
@@ -10,3 +10,4 @@ from .conv import *
 from .generate import *
 from .miopen_parser import *
 from .utils import *
+from .launch import *

--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -5,7 +5,7 @@ import warnings
 from pathlib import Path
 
 from .conv import ConvSignature
-from ....aot import CompiledModule, export
+from ....aot import export
 from ....importers.ir import Attribute, MLIRError
 from ....runtime import Launchable
 from ....support.logging import runtime_logger as logger
@@ -79,5 +79,10 @@ def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> s
 def get_launchable(signature: ConvSignature) -> Launchable:
     func_name = signature.get_func_name()
     module_asm = _get_module_asm(signature, func_name)
-    # TODO: cache vmfb per-device type
-    return Launchable.jit_compile(module_asm, entry_point=func_name)
+    cache_dir = CACHE_BASE_DIR / func_name if is_cache_enabled else None
+    return Launchable.jit_compile(
+        module_asm,
+        parameter_providers=(),
+        entry_point=func_name,
+        file_cache_dir=cache_dir,
+    )

--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -5,7 +5,7 @@ import warnings
 from pathlib import Path
 
 from .conv import ConvSignature
-from ....aot import export
+from ....aot import CompiledModule, export
 from ....importers.ir import Attribute, MLIRError
 from ....runtime import Launchable
 from ....support.logging import runtime_logger as logger
@@ -26,7 +26,7 @@ def is_cache_enabled() -> bool:
 
 
 def clear_cache_dir():
-    if CACHE_BASE_DIR.is_dir():
+    if not CACHE_BASE_DIR.is_dir():
         return
     shutil.rmtree(CACHE_BASE_DIR)
 
@@ -63,7 +63,8 @@ def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> s
             f"Failed to attach #util.preprocessing_pipeline attr to func op. Please try using a newer version of IREE."
         )
 
-    module_asm = str(mod)
+    e.import_to("full")
+    module_asm = str(e.mlir_module)
 
     if is_cache_enabled():
         logger.debug("Saving newly generated mlir file to %s", str(mlir_path))

--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -1,0 +1,82 @@
+import os
+import shutil
+import warnings
+
+from pathlib import Path
+
+from .conv import ConvSignature
+from ....aot import export
+from ....importers.ir import Attribute, MLIRError
+from ....runtime import Launchable
+from ....support.logging import runtime_logger as logger
+
+__all__ = [
+    "is_cache_enabled",
+    "clear_cache_dir",
+    "get_launchable",
+]
+
+_default_cache_base_dir = Path.home() / ".cache" / "turbine_kernels" / "boo"
+CACHE_BASE_DIR = Path(os.environ.get("BOO_CACHE_DIR", _default_cache_base_dir))
+BOO_CACHE_ON = os.environ.get("BOO_CACHE_ON", 1)
+
+
+def is_cache_enabled() -> bool:
+    return bool(BOO_CACHE_ON)
+
+
+def clear_cache_dir():
+    if CACHE_BASE_DIR.is_dir():
+        return
+    shutil.rmtree(CACHE_BASE_DIR)
+
+
+def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> str:
+    func_name = func_name or signature.get_func_name()
+    cache_dir = CACHE_BASE_DIR / func_name
+    mlir_path = cache_dir / f"{func_name}.mlir"
+
+    if is_cache_enabled() and mlir_path.is_file():
+        logger.debug("Loading cached mlir file at %s", str(mlir_path))
+        return mlir_path.read_text()
+
+    e = export(
+        signature.get_nn_module(),
+        args=signature.get_sample_conv_args(splat_value=0),
+        function_name=func_name,
+    )
+
+    e.import_to("import")
+
+    mod = e.mlir_module
+
+    ctx = mod.context
+    func_op = mod.regions[0].blocks[0].operations[0]
+    try:
+        with ctx:
+            pipeline_attr = Attribute.parse(
+                '#util.preprocessing_pipeline<"iree-preprocessing-make-single-dispatch">'
+            )
+            func_op.attributes["preprocessing_pipeline"] = pipeline_attr
+    except MLIRError as e:
+        warnings.warn(
+            f"Failed to attach #util.preprocessing_pipeline attr to func op. Please try using a newer version of IREE."
+        )
+
+    module_asm = str(mod)
+
+    if is_cache_enabled():
+        logger.debug("Saving newly generated mlir file to %s", str(mlir_path))
+        cache_dir = CACHE_BASE_DIR / func_name
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        mlir_path = cache_dir / f"{func_name}.mlir"
+        mlir_path.write_text(module_asm)
+
+    return module_asm
+
+
+def get_launchable(signature: ConvSignature) -> Launchable:
+    func_name = signature.get_func_name()
+    module_asm = _get_module_asm(signature, func_name)
+    # TODO: cache vmfb per-device type
+    return Launchable.jit_compile(module_asm, entry_point=func_name)

--- a/iree/turbine/kernel/boo/examples/conv_launchable.py
+++ b/iree/turbine/kernel/boo/examples/conv_launchable.py
@@ -9,60 +9,51 @@ from iree.turbine.support.logging import runtime_logger as logger
 
 # run this script with the env variable: TURBINE_DEBUG="log_level=DEBUG"
 
+devices = [torch.device("cpu")]
+if torch.cuda.is_available():
+    devices.append(torch.device("cuda:0"))
+    if torch.cuda.device_count() > 1:
+        devices.append(torch.device("cuda:1"))
 
-def main():
+
+def main(clear_cache: bool):
+    """Gets a launchable conv kernel and applies it twice on each device in devices."""
+
     # get a conv signature
-    sig = ConvSignature(input_shape=[1, 2, 16, 16], kernel_shape=[1, 2, 2, 2])
+    sig = ConvSignature(
+        input_shape=[1, 2, 16, 16], kernel_shape=[1, 2, 2, 2], dtype=torch.float32
+    )
 
     # get a launchable kernel
     conv = get_launchable(sig)
+    seed = 1
+    for torch_device in devices:
+        # get some random sample args on a specific device
+        args = sig.get_sample_conv_args(seed=seed, device=torch_device)
+        seed += 1
 
-    # set a device
-    torch_device = torch.device("cuda:0") if torch.cuda.is_available() else None
+        # Call the launchable (log the time). If we have a vmfb file in the cache, this should just load it.
+        t0 = time()
+        y = conv(*args)
+        run_time = (time() - t0) * 1000
+        logger.debug("first launchable call time : %fms", run_time)
 
-    # get some random sample args on a specific device
-    args_0 = sig.get_sample_conv_args(seed=10, device=torch_device)
+        # get some new inputs on the same device
+        args = sig.get_sample_conv_args(seed=seed, device=torch_device)
+        seed += 1
 
-    # call the launchable (log the time)
-    t0 = time()
-    y = conv(*args_0)
-    run_time_0 = (time() - t0) * 1000
-    logger.debug("first launchable call time : %fms", run_time_0)
-
-    # get some new inputs on the same device
-    args_1 = sig.get_sample_conv_args(seed=9, device=torch_device)
-
-    # run a second time. This should take significantly less time (no compilation)
-    t0 = time()
-    y = conv(*args_1)
-    run_time_1 = (time() - t0) * 1000
-    logger.debug("second launchable call time (same device) : %fms", run_time_1)
-
-    # run a third time, but on a new GPU. This should take a bit longer as we need to assemble a context from the vmfb.
-    torch_device = (
-        torch.device("cuda:1")
-        if torch.cuda.is_available() and torch.cuda.device_count() > 1
-        else None
-    )
-    other_args_0 = sig.get_sample_conv_args(seed=8, device=torch_device)
-    t0 = time()
-    y = conv(*other_args_0)
-    run_time_2 = (time() - t0) * 1000
-    logger.debug(
-        "third launchable call time (new gpu if multiple gpus available) : %fms",
-        run_time_2,
-    )
-
-    # run a fourth time. This should take about as long as the second run time.
-    other_args_1 = sig.get_sample_conv_args(seed=7, device=torch_device)
-    t0 = time()
-    y = conv(*other_args_1)
-    run_time_3 = (time() - t0) * 1000
-    logger.debug("fourth launchable call time : %fms", run_time_3)
+        # run a second time. This should launch from the cached (VmContext, VmFunction) used in the first call.
+        t0 = time()
+        y = conv(*args)
+        run_time = (time() - t0) * 1000
+        logger.debug("second launchable call time (same device) : %fms", run_time)
 
     # clear the mlir artifacts from the cache dir (cache is located at ~/.cache/turbine-kernels/boo/ by default)
-    clear_cache_dir()
+    if clear_cache:
+        clear_cache_dir()
 
 
 if __name__ == "__main__":
-    main()
+    # run main twice. The second run should be much faster since it loads vmfb/mlir from file cache.
+    main(clear_cache=False)
+    main(clear_cache=True)

--- a/iree/turbine/kernel/boo/examples/conv_launchable.py
+++ b/iree/turbine/kernel/boo/examples/conv_launchable.py
@@ -4,31 +4,48 @@ from iree.turbine.kernel.boo.conv_exports import (
     get_launchable,
     clear_cache_dir,
 )
+from time import time
+from iree.turbine.support.logging import runtime_logger as logger
 
 # run this script with the env variable: TURBINE_DEBUG="log_level=DEBUG"
 
-# get a conv signature
-sig = ConvSignature(input_shape=[1, 2, 16, 16], kernel_shape=[1, 2, 2, 2])
 
-# get a launchable kernel
-conv = get_launchable(sig)
+def main():
+    # get a conv signature
+    sig = ConvSignature(input_shape=[1, 2, 16, 16], kernel_shape=[1, 2, 2, 2])
 
-# get some sample args on a specific device
-torch_device = torch.device("cuda:0") if torch.cuda.is_available() else None
-args = sig.get_sample_conv_args(seed=10, device=torch_device)
+    # get a launchable kernel
+    conv = get_launchable(sig)
 
-# call the launchable
-y = conv(*args)
+    # set a device
+    torch_device = torch.device("cuda:0") if torch.cuda.is_available() else None
 
-# run on the same device:
-args = sig.get_sample_conv_args(seed=9, device=torch_device)
-y = conv(*args)
+    # get some random sample args on a specific device
+    args_0 = sig.get_sample_conv_args(seed=10, device=torch_device)
+
+    # call the launchable (log the time)
+    t0 = time()
+    y = conv(*args_0)
+    run_time_0 = (time() - t0) * 1000
+    logger.debug("first launchable call time : %fms", run_time_0)
+
+    # get some new inputs on the same device
+    args_1 = sig.get_sample_conv_args(seed=9, device=torch_device)
+
+    # run a second time. This should take significantly less time (no compilation)
+    t0 = time()
+    y = conv(*args_1)
+    run_time_1 = (time() - t0) * 1000
+    logger.debug("second launchable call time (same device) : %fms", run_time_1)
+
+    # Interestingly, launching on a different GPU results in a memory access fault:
+    # torch_device = torch.device("cuda:1") if torch.cuda.is_available() else None
+    # other_args = sig.get_sample_conv_args(seed=8, device=torch_device)
+    # y = conv(*other_args)
+
+    # clear the cache dir (cache is located at ~/.cache/turbine-kernels/boo/ by default)
+    # clear_cache_dir()
 
 
-# Interestingly, launching on a different GPU results in a memory access fault:
-# torch_device = torch.device("cuda:1") if torch.cuda.is_available() else None
-# other_args = sig.get_sample_conv_args(seed=8, device=torch_device)
-# y = conv(*other_args)
-
-# clear the cache dir
-# clear_cache_dir()
+if __name__ == "__main__":
+    main()

--- a/iree/turbine/kernel/boo/examples/conv_launchable.py
+++ b/iree/turbine/kernel/boo/examples/conv_launchable.py
@@ -1,5 +1,9 @@
 import torch
-from iree.turbine.kernel.boo.conv_exports import ConvSignature, get_launchable
+from iree.turbine.kernel.boo.conv_exports import (
+    ConvSignature,
+    get_launchable,
+    clear_cache_dir,
+)
 
 # run this script with the env variable: TURBINE_DEBUG="log_level=DEBUG"
 
@@ -25,3 +29,6 @@ y = conv(*args)
 # torch_device = torch.device("cuda:1") if torch.cuda.is_available() else None
 # other_args = sig.get_sample_conv_args(seed=8, device=torch_device)
 # y = conv(*other_args)
+
+# clear the cache dir
+# clear_cache_dir()

--- a/iree/turbine/kernel/boo/examples/conv_launchable.py
+++ b/iree/turbine/kernel/boo/examples/conv_launchable.py
@@ -1,0 +1,27 @@
+import torch
+from iree.turbine.kernel.boo.conv_exports import ConvSignature, get_launchable
+
+# run this script with the env variable: TURBINE_DEBUG="log_level=DEBUG"
+
+# get a conv signature
+sig = ConvSignature(input_shape=[1, 2, 16, 16], kernel_shape=[1, 2, 2, 2])
+
+# get a launchable kernel
+conv = get_launchable(sig)
+
+# get some sample args on a specific device
+torch_device = torch.device("cuda:0") if torch.cuda.is_available() else None
+args = sig.get_sample_conv_args(seed=10, device=torch_device)
+
+# call the launchable
+y = conv(*args)
+
+# run on the same device:
+args = sig.get_sample_conv_args(seed=9, device=torch_device)
+y = conv(*args)
+
+
+# Interestingly, launching on a different GPU results in a memory access fault:
+# torch_device = torch.device("cuda:1") if torch.cuda.is_available() else None
+# other_args = sig.get_sample_conv_args(seed=8, device=torch_device)
+# y = conv(*other_args)

--- a/iree/turbine/kernel/boo/examples/conv_launchable.py
+++ b/iree/turbine/kernel/boo/examples/conv_launchable.py
@@ -38,13 +38,30 @@ def main():
     run_time_1 = (time() - t0) * 1000
     logger.debug("second launchable call time (same device) : %fms", run_time_1)
 
-    # Interestingly, launching on a different GPU results in a memory access fault:
-    # torch_device = torch.device("cuda:1") if torch.cuda.is_available() else None
-    # other_args = sig.get_sample_conv_args(seed=8, device=torch_device)
-    # y = conv(*other_args)
+    # run a third time, but on a new GPU. This should take a bit longer as we need to assemble a context from the vmfb.
+    torch_device = (
+        torch.device("cuda:1")
+        if torch.cuda.is_available() and torch.cuda.device_count() > 1
+        else None
+    )
+    other_args_0 = sig.get_sample_conv_args(seed=8, device=torch_device)
+    t0 = time()
+    y = conv(*other_args_0)
+    run_time_2 = (time() - t0) * 1000
+    logger.debug(
+        "third launchable call time (new gpu if multiple gpus available) : %fms",
+        run_time_2,
+    )
 
-    # clear the cache dir (cache is located at ~/.cache/turbine-kernels/boo/ by default)
-    # clear_cache_dir()
+    # run a fourth time. This should take about as long as the second run time.
+    other_args_1 = sig.get_sample_conv_args(seed=7, device=torch_device)
+    t0 = time()
+    y = conv(*other_args_1)
+    run_time_3 = (time() - t0) * 1000
+    logger.debug("fourth launchable call time : %fms", run_time_3)
+
+    # clear the mlir artifacts from the cache dir (cache is located at ~/.cache/turbine-kernels/boo/ by default)
+    clear_cache_dir()
 
 
 if __name__ == "__main__":

--- a/tests/runtime/launch_test.py
+++ b/tests/runtime/launch_test.py
@@ -4,9 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from parameterized import parameterized_class
-import torch
+import tempfile
 import unittest
+import logging
+from io import StringIO
+
+from pathlib import Path
+from parameterized import parameterized_class
+
+import torch
 
 from iree.turbine.aot.params import (
     ParameterArchiveBuilder,
@@ -15,6 +21,8 @@ from iree.turbine.aot.params import (
 from iree.turbine.runtime import (
     Launchable,
 )
+
+from iree.turbine.support.logging import runtime_logger as logger
 
 MLIR_NO_PARAMS_ASM = r"""
 module @test_module {
@@ -85,6 +93,32 @@ class LaunchableTest(unittest.TestCase):
         result = launch(t1, t2)
         expected = torch.tensor([12, 44, 96, 168], dtype=torch.int32).to(self.device)
         torch.testing.assert_close(expected, result)
+
+    def testLaunchWithFileCache(self):
+        """Tests that vmfb files are getting stored to and loaded from a file_cache."""
+        with tempfile.TemporaryDirectory() as td:
+            temp_cache = Path(td)
+            launch_0 = Launchable.jit_compile(
+                MLIR_NO_PARAMS_ASM, file_cache_dir=temp_cache
+            )
+            launch_0.preload(self.device)
+            files = [f for f in temp_cache.glob("*.vmfb")]
+            self.assertTrue(len(files) == 1, "Expected a single cached vmfb.")
+            # Make a new launchable from the same source and verify it loads from the cache.
+            launch_1 = Launchable.jit_compile(
+                MLIR_NO_PARAMS_ASM, file_cache_dir=temp_cache
+            )
+            # This is a bit hacky: Intercept the logs to check for whether the vmfb gets loaded.
+            old_level = logger.level
+            logger.setLevel(logging.DEBUG)
+            intercept_stream = StringIO()
+            intercept_handler = logging.StreamHandler(intercept_stream)
+            logger.addHandler(intercept_handler)
+            launch_1.preload(self.device)
+            self.assertIn("Loading vmfb from cache:", intercept_stream.getvalue())
+            logger.removeHandler(intercept_handler)
+            intercept_stream.close()
+            logger.setLevel(old_level)
 
 
 @unittest.skipIf(


### PR DESCRIPTION
Adds a function to convert a `ConvSignature` into a `Launchable`, with added mlir and vmfb file caching/retrieval. 

Modifies `Launchable.jit_compile` to be able to optionally save and load jit-compiled artifacts within a directory.