### PR TITLE
[runtime] Tier out internal Launchable caching and get hal device from uuid

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -246,6 +246,7 @@ class Device:
 
     def _recompute_target_keys(self):
         self.type_cache_key = f"{self.driver_id}:{';'.join(self.compile_target_flags)}"
+        self.instance_cache_key = f"{self.driver_id}:{self._s.enumerated_device_id}"
 
     @property
     def hal_device(self) -> HalDevice:

--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from functools import lru_cache
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 from threading import local, Lock
 import warnings
 
@@ -509,21 +509,21 @@ def _create_hip_device(torch_device: torch.device, props) -> Optional[Device]:
     return device
 
 
+@lru_cache(maxsize=None)
+def _get_uuid_to_info_mapping(driver) -> Dict[str, Dict[str, Any]]:
+    available_infos = driver.query_available_devices()
+    return {info["path"].removeprefix("GPU-"): info for info in available_infos}
+
+
 def _create_cuda_like_device(
     torch_device: torch.device, props, driver_name: str, dlpack_device_type_code: int
 ) -> Optional[Device]:
-    if torch.cuda.device_count() > 1:
-        warnings.warn(
-            f"Multiple {driver_name} devices detected: Turbine does not yet "
-            f"guarantee stable device mapping"
-        )
-
-    requested_index = torch_device.index
+    uuid = str(torch.cuda.get_device_properties(torch_device).uuid)
     driver = get_driver(driver_name)
-    available_infos = driver.query_available_devices()
-    if requested_index >= len(available_infos):
+    info_mapping = _get_uuid_to_info_mapping(driver)
+    device_info = info_mapping.get(uuid)
+    if device_info is None:
         return None
-    device_info = available_infos[requested_index]
     hal_device = driver.create_device(device_info)
     device_state = DeviceState(
         driver=driver,

--- a/iree/turbine/runtime/launch.py
+++ b/iree/turbine/runtime/launch.py
@@ -38,8 +38,10 @@ __all__ = [
     "Launchable",
 ]
 
+_NamedVmModule = Tuple[str, VmModule]
 _TargetBinary = Tuple[VmContext, VmFunction]
-_Loader = Callable[[Device], _TargetBinary]
+_Loader = Callable[[Device], _NamedVmModule]
+# _Loader = Callable[[Device], _TargetBinary]
 
 
 class Launchable:
@@ -55,10 +57,17 @@ class Launchable:
     This has various limitations.
     """
 
-    def __init__(self, loader: Optional[_Loader]):
+    def __init__(
+        self,
+        loader: Optional[_Loader],
+        parameter_providers: Sequence[ParameterProvider] = (),
+    ):
         self._loader = loader
-        # Map of Device.type_cache_key -> _TargetBinary for a resolved binary.
+        self._providers = parameter_providers
+        # Map of Device.instance_cache_key -> _TargetBinary for a resolved binary.
         self._target_binaries: dict[str, _TargetBinary] = {}
+        # Map of Device.type_cache_key -> VmModule for a device-type specific main VmModule
+        self._target_vm_modules: dict[str, _NamedVmModule] = {}
 
     @staticmethod
     def jit_compile(
@@ -67,54 +76,65 @@ class Launchable:
         parameter_providers: Sequence[ParameterProvider] = (),
         entry_point: str = "main",
     ) -> "Launchable":
-        return Launchable.from_vm_module(
-            _jit_callback(source),
+        return Launchable(
+            _jit_callback(source, entry_point),
             parameter_providers=parameter_providers,
-            entry_point=entry_point,
         )
-
-    @staticmethod
-    def from_vm_module(
-        vm_module_callback: Callable[[Device], VmModule],
-        *,
-        parameter_providers: Sequence[ParameterProvider] = (),
-        entry_point: str = "main",
-    ) -> "Launchable":
-        def loader(device: Device) -> _TargetBinary:
-            vm_instance = device.vm_instance
-            modules = [device.create_hal_module()]
-            if parameter_providers:
-                modules.append(
-                    create_io_parameters_module(vm_instance, *parameter_providers)
-                )
-            main_module = vm_module_callback(device)
-            modules.append(main_module)
-            vm_context = VmContext(vm_instance, modules)
-            main_function = main_module.lookup_function(entry_point)
-            return vm_context, main_function
-
-        return Launchable(loader)
 
     def preload(self, device: torch.device):
         """Pre-loads (or JIT compiles) for the given torch.device."""
         turbine_device = get_device_from_torch(device)
         self._resolve_target_binary(turbine_device)
 
+    def _assemble_target_binary_from_vm_module(
+        self, turbine_device: Device, entry_point: str, main_module: VmModule
+    ) -> _TargetBinary:
+        device_key = turbine_device.instance_cache_key
+        vm_instance = turbine_device.vm_instance
+        modules = [turbine_device.create_hal_module()]
+        if self._providers:
+            modules.append(create_io_parameters_module(vm_instance, *self._providers))
+        modules.append(main_module)
+        vm_context = VmContext(vm_instance, modules)
+        main_function = main_module.lookup_function(entry_point)
+        logger.debug("Cached new binary for %s", device_key)
+        self._target_binaries[device_key] = vm_context, main_function
+        return vm_context, main_function
+
     def _resolve_target_binary(self, turbine_device: Device) -> _TargetBinary:
-        device_key = turbine_device.type_cache_key
+
+        # Try binary cache for specific device:
+        device_key = turbine_device.instance_cache_key
         existing = self._target_binaries.get(device_key)
         if existing is not None:
             logger.debug("Launching cached binary for %s", device_key)
             return existing
 
+        # Try named module cache for device-type specific vm-module:
+        device_type_key = turbine_device.type_cache_key
+        _named_module = self._target_vm_modules.get(device_type_key)
+        if _named_module is not None:
+            entry_point, main_module = _named_module
+            logger.debug(
+                "Assembling binary for %s from cached module for %s",
+                device_key,
+                device_type_key,
+            )
+            return self._assemble_target_binary_from_vm_module(
+                turbine_device, entry_point, main_module
+            )
+
         # Try the user loader.
         loader = self._loader
         if loader is not None:
-            loaded = loader(turbine_device)
-            if loaded is not None:
-                logger.debug("Cached new binary for %s", device_key)
-                self._target_binaries[device_key] = loaded
-                return loaded
+            _named_module = loader(turbine_device)
+            if _named_module is not None:
+                logger.debug("Cached new module for %s", device_type_key)
+                self._target_vm_modules[device_type_key] = _named_module
+                entry_point, main_module = _named_module
+                return self._assemble_target_binary_from_vm_module(
+                    turbine_device, entry_point, main_module
+                )
         raise NotImplementedError(
             f"Could not load a target binary for device {turbine_device}"
         )
@@ -178,7 +198,7 @@ class Launchable:
             return torch_results
 
 
-def _jit_callback(program_source: Any) -> Callable[[Device], VmModule]:
+def _jit_callback(program_source: Any, entry_point: str) -> _Loader:
     session = Session()
     if isinstance(program_source, Source):
         ...
@@ -202,7 +222,7 @@ def _jit_callback(program_source: Any) -> Callable[[Device], VmModule]:
         # TODO: VmModule.wrap_buffer would be better here, but it is still
         # unreliable capturing mapped memory from the compiler.
         # See: https://github.com/iree-org/iree/issues/17403
-        return VmModule.copy_buffer(vm_instance, mapped_memory)
+        return entry_point, VmModule.copy_buffer(vm_instance, mapped_memory)
 
     return callback
 

--- a/iree/turbine/runtime/launch.py
+++ b/iree/turbine/runtime/launch.py
@@ -41,7 +41,6 @@ __all__ = [
 _NamedVmModule = Tuple[str, VmModule]
 _TargetBinary = Tuple[VmContext, VmFunction]
 _Loader = Callable[[Device], _NamedVmModule]
-# _Loader = Callable[[Device], _TargetBinary]
 
 
 class Launchable:

--- a/tests/runtime/launch_test.py
+++ b/tests/runtime/launch_test.py
@@ -87,7 +87,7 @@ class LaunchableTest(unittest.TestCase):
         torch.testing.assert_close(expected, result)
 
 
-class SameLaunchableDifferentDeviceTest(unittest.TestCase):
+class SameLaunchableDifferentDevicesTest(unittest.TestCase):
     def testLaunchJit(self):
         launch = Launchable.jit_compile(MLIR_NO_PARAMS_ASM)
         for d in devices:
@@ -98,34 +98,34 @@ class SameLaunchableDifferentDeviceTest(unittest.TestCase):
             expected = torch.tensor([10, 40, 90, 160], dtype=torch.int32).to(device)
             torch.testing.assert_close(expected, result)
 
-    # def testLaunchPreload(self):
-    #     launch = Launchable.jit_compile(MLIR_NO_PARAMS_ASM)
-    #     for d in devices:
-    #         device = d[0]
-    #         launch.preload(device)
-    #     launch._loader = None  # Don't let it load anything more.
-    #     for d in devices:
-    #         device = d[0]
-    #         t1 = torch.tensor([1, 2, 3, 4], dtype=torch.int32).to(device)
-    #         t2 = torch.tensor([10, 20, 30, 40], dtype=torch.int32).to(device)
-    #         result = launch(t1, t2)
-    #         expected = torch.tensor([10, 40, 90, 160], dtype=torch.int32).to(device)
-    #         torch.testing.assert_close(expected, result)
+    def testLaunchPreload(self):
+        launch = Launchable.jit_compile(MLIR_NO_PARAMS_ASM)
+        for d in devices:
+            device = d[0]
+            launch.preload(device)
+        launch._loader = None  # Don't let it load anything more.
+        for d in devices:
+            device = d[0]
+            t1 = torch.tensor([1, 2, 3, 4], dtype=torch.int32).to(device)
+            t2 = torch.tensor([10, 20, 30, 40], dtype=torch.int32).to(device)
+            result = launch(t1, t2)
+            expected = torch.tensor([10, 40, 90, 160], dtype=torch.int32).to(device)
+            torch.testing.assert_close(expected, result)
 
-    # def testLaunchParams(self):
-    #     param_archive = ParameterArchiveBuilder()
-    #     param_archive.add_tensor("param", torch.tensor([2, 4, 6, 8], dtype=torch.int32))
-    #     provider = param_archive.index.create_provider()
+    def testLaunchParams(self):
+        param_archive = ParameterArchiveBuilder()
+        param_archive.add_tensor("param", torch.tensor([2, 4, 6, 8], dtype=torch.int32))
+        provider = param_archive.index.create_provider()
 
-    #     launch = Launchable.jit_compile(MLIR_PARAMS_ASM, parameter_providers=[provider])
-    #     for d in devices:
-    #         device = d[0]
-    #         launch.preload(device)
-    #         t1 = torch.tensor([1, 2, 3, 4], dtype=torch.int32).to(device)
-    #         t2 = torch.tensor([10, 20, 30, 40], dtype=torch.int32).to(device)
-    #         result = launch(t1, t2)
-    #         expected = torch.tensor([12, 44, 96, 168], dtype=torch.int32).to(device)
-    #         torch.testing.assert_close(expected, result)
+        launch = Launchable.jit_compile(MLIR_PARAMS_ASM, parameter_providers=[provider])
+        for d in devices:
+            device = d[0]
+            launch.preload(device)
+            t1 = torch.tensor([1, 2, 3, 4], dtype=torch.int32).to(device)
+            t2 = torch.tensor([10, 20, 30, 40], dtype=torch.int32).to(device)
+            result = launch(t1, t2)
+            expected = torch.tensor([12, 44, 96, 168], dtype=torch.int32).to(device)
+            torch.testing.assert_close(expected, result)
 
 
 if __name__ == "__main__":

--- a/tests/runtime/launch_test.py
+++ b/tests/runtime/launch_test.py
@@ -40,7 +40,10 @@ func.func @main(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi32> {
 # TODO: Move this to a common utility controlled by project wide env vars.
 devices = [[torch.device("cpu")]]
 if torch.cuda.is_available():
+    num_gpus = torch.cuda.device_count()
     devices.append([torch.device("cuda:0")])
+    if num_gpus > 1:
+        devices.append([torch.device("cuda:1")])
 
 
 @parameterized_class(["device"], devices)
@@ -82,6 +85,47 @@ class LaunchableTest(unittest.TestCase):
         result = launch(t1, t2)
         expected = torch.tensor([12, 44, 96, 168], dtype=torch.int32).to(self.device)
         torch.testing.assert_close(expected, result)
+
+
+class SameLaunchableDifferentDeviceTest(unittest.TestCase):
+    def testLaunchJit(self):
+        launch = Launchable.jit_compile(MLIR_NO_PARAMS_ASM)
+        for d in devices:
+            device = d[0]
+            t1 = torch.tensor([1, 2, 3, 4], dtype=torch.int32).to(device)
+            t2 = torch.tensor([10, 20, 30, 40], dtype=torch.int32).to(device)
+            result = launch(t1, t2)
+            expected = torch.tensor([10, 40, 90, 160], dtype=torch.int32).to(device)
+            torch.testing.assert_close(expected, result)
+
+    # def testLaunchPreload(self):
+    #     launch = Launchable.jit_compile(MLIR_NO_PARAMS_ASM)
+    #     for d in devices:
+    #         device = d[0]
+    #         launch.preload(device)
+    #     launch._loader = None  # Don't let it load anything more.
+    #     for d in devices:
+    #         device = d[0]
+    #         t1 = torch.tensor([1, 2, 3, 4], dtype=torch.int32).to(device)
+    #         t2 = torch.tensor([10, 20, 30, 40], dtype=torch.int32).to(device)
+    #         result = launch(t1, t2)
+    #         expected = torch.tensor([10, 40, 90, 160], dtype=torch.int32).to(device)
+    #         torch.testing.assert_close(expected, result)
+
+    # def testLaunchParams(self):
+    #     param_archive = ParameterArchiveBuilder()
+    #     param_archive.add_tensor("param", torch.tensor([2, 4, 6, 8], dtype=torch.int32))
+    #     provider = param_archive.index.create_provider()
+
+    #     launch = Launchable.jit_compile(MLIR_PARAMS_ASM, parameter_providers=[provider])
+    #     for d in devices:
+    #         device = d[0]
+    #         launch.preload(device)
+    #         t1 = torch.tensor([1, 2, 3, 4], dtype=torch.int32).to(device)
+    #         t2 = torch.tensor([10, 20, 30, 40], dtype=torch.int32).to(device)
+    #         result = launch(t1, t2)
+    #         expected = torch.tensor([12, 44, 96, 168], dtype=torch.int32).to(device)
+    #         torch.testing.assert_close(expected, result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This breaks up the `Launchable`'s internal cache to store two mappings:

`device_type_key -> (entry_point, main_module)`
`device_instance_key -> (vm_context, main_function)`

And converts `_Loader` to be a callable returning tuples of the form `(entry_point, main_module)` for each device, essentially making `Launchable.__init__` roughly equivalent to the old `Launchable.from_vm_module` (which is removed). 

This PR also tries to infer the correct hal device from the `torch.device` by looking up the associated gpu uuid in the hal driver infos (although there may be runtime api I'm missing to do this directly).

Added tests to `launch_test.py` for validating that a single `Launchable` indeed can launch on multiple GPUs. 