### PR TITLE
[Wave] Add 2-stage prefetch scheduling strategy for GEMM

### DIFF
--- a/iree/turbine/kernel/wave/scheduling/graph_utils.py
+++ b/iree/turbine/kernel/wave/scheduling/graph_utils.py
@@ -6,7 +6,7 @@
 
 import torch.fx as fx
 from random import Random
-from collections import defaultdict
+from collections import defaultdict, deque
 from ..._support.indexing import index_symbol, IndexExpr
 from .resources import *
 from dataclasses import dataclass
@@ -15,7 +15,7 @@ import math
 from functools import partial
 from ..utils.symbol_utils import safe_subs
 import multiprocessing as mp
-from typing import Optional
+from typing import Optional, Callable
 
 T = index_symbol("$INITIATION_INTERVAL")
 
@@ -362,3 +362,80 @@ def create_scheduling_edges(
             edges.append(edge)
     erase_placeholder_nodes(graph, ignore_nodes)
     return edges
+
+
+def get_root_nodes_from_edges(edges: list[Edge]) -> list[fx.Node]:
+    """
+    Given scheduling edges, returns a list of node that
+    do not have a ancestor, i.e are root nodes of the graph.
+    """
+    source_nodes = set()
+    dst_nodes = set()
+    for edge in edges:
+        source_nodes.add(edge._from)
+        dst_nodes.add(edge._to)
+    root_nodes = source_nodes.difference(dst_nodes)
+    return root_nodes
+
+
+def filter_edges(filter: Callable[[Edge], bool], edges) -> list[Edge]:
+    filtered = []
+    for edge in edges:
+        if filter(edge):
+            filtered.append(edge)
+    return filtered
+
+
+def sort_graph_by_edge_weight(nodes: list[fx.Node], edges: list[Edge]):
+    """
+    Sort nodes based on scheduling weight.
+
+    Where scheduling weight is defined as:
+    scheduling_weight[node] = sum(edge.weight + scheduling_weight[edge.source] for edge in edges)
+
+    scheduling weight is suppose to quantify how early or late a node should live in a graph.
+    Similar to topoological ordering but more robust.
+
+    This is achieved by setting up a workqueue which starts with root of graph.
+    we then explore successors of nodes in workqueue and compute it's scheduling
+    weight as defined in above formula. If ancestor/producer to current node has
+    no value yet, we move current node to end of queue to try again later.
+    """
+    schedule_weight = {}
+    root_nodes = get_root_nodes_from_edges(edges)
+    workqueue = deque(root_nodes)
+    non_solved_counter = 0
+    while len(workqueue) > 0:
+        node = workqueue.popleft()
+        is_producer_edge = lambda edge: edge._to == node
+        producers_edges = filter_edges(is_producer_edge, edges)
+        filter_producer_edge = [
+            edge for edge in producers_edges if edge.weight.iteration_difference == 0
+        ]
+
+        # Save for later if producer not registered yet.
+        if any([edge._from not in schedule_weight for edge in filter_producer_edge]):
+            # If we went over entire workqueue and still cannot find producer,
+            # means it is missing producer from the edges.
+            non_solved_counter += 1
+            if non_solved_counter > len(workqueue):
+                raise ValueError(
+                    "Cannot find producer(s) for remaining item in workqueue."
+                )
+            workqueue.append(node)
+            continue
+
+        non_solved_counter = 0
+        schedule_weight[node] = sum(
+            [
+                schedule_weight[edge._from] + edge.weight.delay
+                for edge in filter_producer_edge
+            ]
+        )
+        is_consumer_edge = lambda edge: edge._from == node
+        consumer_edges = filter_edges(is_consumer_edge, edges)
+        consumer_nodes = [
+            edge._to for edge in consumer_edges if edge.weight.iteration_difference == 0
+        ]
+        workqueue.extend(consumer_nodes)
+    return sorted(nodes, key=lambda x: schedule_weight[x])

--- a/iree/turbine/kernel/wave/scheduling/graph_utils.py
+++ b/iree/turbine/kernel/wave/scheduling/graph_utils.py
@@ -402,8 +402,7 @@ def sort_graph_by_edge_weight(nodes: list[fx.Node], edges: list[Edge]):
     no value yet, we move current node to end of queue to try again later.
     """
     schedule_weight = {}
-    root_nodes = get_root_nodes_from_edges(edges)
-    workqueue = deque(root_nodes)
+    workqueue = deque(nodes)
     non_solved_counter = 0
     while len(workqueue) > 0:
         node = workqueue.popleft()
@@ -432,10 +431,4 @@ def sort_graph_by_edge_weight(nodes: list[fx.Node], edges: list[Edge]):
                 for edge in filter_producer_edge
             ]
         )
-        is_consumer_edge = lambda edge: edge._from == node
-        consumer_edges = filter_edges(is_consumer_edge, edges)
-        consumer_nodes = [
-            edge._to for edge in consumer_edges if edge.weight.iteration_difference == 0
-        ]
-        workqueue.extend(consumer_nodes)
     return sorted(nodes, key=lambda x: schedule_weight[x])

--- a/iree/turbine/kernel/wave/scheduling/prefetch_scheduling.py
+++ b/iree/turbine/kernel/wave/scheduling/prefetch_scheduling.py
@@ -1,0 +1,132 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch.fx as fx
+from ...ops.wave_ops import get_custom
+from .graph_utils import Edge, sort_graph_by_edge_weight
+from .resources import Operation, get_custom_operation_type
+from enum import Enum
+import math
+
+
+class PrefetchStage(Enum):
+    GLOBAL_LOAD = 0
+    LOCAL_STORE = 1
+    LOCAL_LOAD = 2
+    COMPUTE = 3
+
+    def next(self):
+        if self.value == 3:
+            return PrefetchStage(3)
+        v = self.value + 1
+        return PrefetchStage(v)
+
+
+operation_stage_table = {
+    Operation.READ_SHARED: PrefetchStage.LOCAL_LOAD,
+    Operation.WRITE_SHARED: PrefetchStage.LOCAL_STORE,
+    Operation.READ_GLOBAL: PrefetchStage.GLOBAL_LOAD,
+    Operation.MMA: PrefetchStage.COMPUTE,
+    Operation.NOOP: PrefetchStage.COMPUTE,
+    Operation.VALU: PrefetchStage.COMPUTE,
+    Operation.SHUFFLE: PrefetchStage.COMPUTE,
+}
+
+
+def get_scheduling_stage(op: fx.Node) -> Operation:
+    op_ty = get_custom_operation_type(get_custom(op))
+    if op_ty not in operation_stage_table:
+        raise NotImplementedError(f"Cannot find {op_ty} in operation_stage_table")
+    return operation_stage_table[op_ty]
+
+
+class PrefetchScheduler:
+    """
+    Prefetch Scheduler
+
+    Convert vanilla schedule of:
+        for i = 0 to N:
+            a = READ_GLOBAL i
+            WRITE_SHARED a
+            barrier
+            b = READ_SHARED
+            COMPUTE b
+
+    into prefetch schedule:
+        a_0 = READ_GLOBAL 0
+        WRITE_SHARED a_0
+        for i = 0 to N - 1:
+            a_{i+1} = READ_GLOBAL i + 1
+            // a_{i+1} is NOT blocked by this barrier because barriers only block shared memory transfers
+            barrier
+            b_i = READ_SHARED
+            COMPUTE b_i
+            barrier
+            WRITE_SHARED a_{i+1}
+        barrier
+        b_N = READ_SHARED
+        COMPUTE b_N
+    """
+
+    def __init__(
+        self,
+        graph: fx.Graph,
+        edges: list[Edge],
+        resources: list[int],
+    ) -> None:
+        self.graph = graph
+        self.edges = edges
+        self.resources = resources
+        self.seed = 2024
+
+    def prefetch_scheduling(self, graph: fx.Graph, edges: list[Edge]):
+        """
+        Classify node to different stages. Based on it's stage,
+        program schedules clock for each node. This function also checks
+        that sorted node "contiguously" move between stages.
+        """
+        sorted_nodes = sort_graph_by_edge_weight(graph.nodes, edges)
+        schedule = {}
+        current_stage = PrefetchStage.GLOBAL_LOAD
+        for node in sorted_nodes:
+            node_stage = get_scheduling_stage(node)
+            next_stage = current_stage.next()
+            if node_stage == current_stage:
+                schedule[node] = current_stage.value
+            elif node_stage == next_stage:
+                schedule[node] = next_stage.value
+                current_stage = next_stage
+            else:
+                # Node do not move contigously through stages.
+                return {}, False
+        return schedule, True
+
+    def schedule_graph(self) -> tuple[dict[fx.Node, int], bool]:
+        """
+        1. Identify which nodes are part of the global_read/local_write/local_read/compute phase
+        2. Set nodes to clock (0,1,2,3) based on phase.
+        2. Set initiation interval to generate valid 2 stage prefetch.
+        """
+        self.schedule, success = self.prefetch_scheduling(self.graph, self.edges)
+        self._initiation_interval = 2
+        if self.num_stages != self._initiation_interval:
+            return {}, False
+        return self.schedule, success
+
+    @property
+    def initiation_interval(self) -> int:
+        """
+        Returns the initiation interval of the schedule.
+        """
+        return self._initiation_interval
+
+    @property
+    def num_stages(self) -> int:
+        """
+        Returns the number of stages in the kernel of the pipelined loop.
+        """
+        max_cycle = max([t for t in self.schedule.values()])
+        return math.ceil(max_cycle / self.initiation_interval)

--- a/iree/turbine/kernel/wave/scheduling/prefetch_scheduling.py
+++ b/iree/turbine/kernel/wave/scheduling/prefetch_scheduling.py
@@ -19,6 +19,9 @@ class PrefetchStage(Enum):
     COMPUTE = 3
 
     def next(self):
+        # Helper function to get next stage from the current.
+        # If at stage 3 returns itself to prevent crash
+        # since it is final stage.
         if self.value == 3:
             return PrefetchStage(3)
         v = self.value + 1

--- a/iree/turbine/kernel/wave/scheduling/resources.py
+++ b/iree/turbine/kernel/wave/scheduling/resources.py
@@ -87,15 +87,17 @@ resource_reservation_table = {
 def get_custom_operation_type(custom: CustomOp) -> Operation:
     if isinstance(custom, Read):
         return (
-            Operation.READ_GLOBAL
-            if custom.memory_type.address_space == GLOBAL_ADDRESS_SPACE
-            else Operation.READ_SHARED
+            Operation.READ_SHARED
+            if custom.memory
+            and custom.memory_type.address_space == SHARED_ADDRESS_SPACE
+            else Operation.READ_GLOBAL
         )
     elif isinstance(custom, Write):
         return (
-            Operation.WRITE_GLOBAL
-            if custom.memory_type.address_space == GLOBAL_ADDRESS_SPACE
-            else Operation.WRITE_SHARED
+            Operation.WRITE_SHARED
+            if custom.memory
+            and custom.memory_type.address_space == SHARED_ADDRESS_SPACE
+            else Operation.WRITE_GLOBAL
         )
     elif isinstance(custom, MMA):
         return Operation.MMA

--- a/iree/turbine/kernel/wave/scheduling/schedule_enums.py
+++ b/iree/turbine/kernel/wave/scheduling/schedule_enums.py
@@ -12,7 +12,7 @@ Values: 0xAB where:
 * A = Strategy types:
   * 0 = None
   * 1 = Solver Based
-  * 2 = Heuristic Based (to come)
+  * 2 = Heuristic Based
 * B enumerates different strategy that share the same 0xA* bits.
 """
 
@@ -20,3 +20,4 @@ Values: 0xAB where:
 class SchedulingType(Enum):
     NONE = 0x00
     MODULO = 0x10
+    PREFETCH = 0x20

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -76,7 +76,8 @@ def get_test_shapes(test_name: str) -> list[tuple[int]]:
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
-    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+    "enable_scheduling",
+    [SchedulingType.NONE, SchedulingType.PREFETCH, SchedulingType.MODULO],
 )
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is a MVP/first bring up for a heuristics based scheduling strategy into Wave. In this PR, we introduce 2-stage prefetch scheduling (strategy currently only tested for GEMM).  Just for a brief recap, what we mean by 2 stage prefetch strategy is as such:

```
    Convert vanilla schedule of:
        for i = 0 to N:
            a = READ_GLOBAL i
            WRITE_SHARED a
            barrier
            b = READ_SHARED
            COMPUTE b

    into prefetch schedule:
        a_0 = READ_GLOBAL 0
        WRITE_SHARED a_0
        for i = 0 to N - 1:
            a_{i+1} = READ_GLOBAL i + 1
            // a_{i+1} is NOT blocked by this barrier because barriers only block shared memory transfers
            barrier
            b_i = READ_SHARED
            COMPUTE b_i
            barrier
            WRITE_SHARED a_{i+1}
        barrier
        b_N = READ_SHARED
```

In order to do that we needed to bring these changes:

1. Implement a scheduler class that generate a schedule and initiation interval that generates a 2 stage prefetch strategy. The crux of this implementation is:
  a. we'd need to sort the nodes inside `reduction_graph` but it' accumulative scheduling weight (accumulative on it's predecessors), this should be rather similar to topological graph but more robust since it is based on scheduling edges weight. 
  b. After the nodes are sorted, we classify them to one of the 4 stages in prefetch strategy which is `GLOBAL_LOAD`, `LOCAL_STORE`, `LOCAL_LOAD`,  and `COMPUTE`, where each stage will correspond to a clock cycle. 
  c. Once this is done, we would simply set initiation interval to 2 which should let the loop reconstructor to generate a 2 stage prefetch strategy.
 
2. Modify scheduling/resources.py's implementation of `get_custom_operation_type` to index on shared reads, since global reads cannot be found in `reduction_graph`, which is the form used by prefetch scheduler (and other schedulers for that matter). 

3. General infra update and tests

Future work:
- Currently performance does not improve, but big hunch we'd just need to remove a redundant lds barrier to unlock perf.
- Another perf factor is to add set_prio instruction for better time slicing / resource overlap/use in a single SIMD.
- Apply to attention and extend attention