### PR TITLE
[TKW] Add `ThreadConstraint`

### DIFF
--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -22,6 +22,7 @@ from ...ops.wave_ops import (
 from ..constraints import (
     Constraint,
     HardwareConstraint,
+    ThreadConstraint,
     TilingConstraint,
     WorkgroupConstraint,
 )
@@ -503,7 +504,7 @@ def set_thread_dependent_index_from_read_write(
 
     visited = set()
     workgroup_constraints = [
-        c for c in constraints if isinstance(c, WorkgroupConstraint)
+        c for c in constraints if isinstance(c, (WorkgroupConstraint, ThreadConstraint))
     ]
     symbolic_constraints = [c for c in constraints if isinstance(c, SymbolicAlias)]
     for source in sources:

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -460,23 +460,20 @@ class TilingConstraint(Constraint):
 
 @dataclass
 class ThreadConstraint(Constraint):
+    """
+    A constraint of the form `tkw.ThreadConstraint(M, 0)`
+    specifies that we want to distribute dimension M along thread dim 0.
+    This translates to an index constraint for all tensors of the
+    shape [M, ?] -> index += (thread_id_0, 0)
+    """
+
     dim: IndexExpr
-    workgroup_dim: int
+    workgroup_dim: int  # Used by `populate_read_write_source_indices`
 
     def apply(self) -> IndexSequence:
+        # `apply` is called during thread-independent index sequence
+        # initialization. We don't need to do anything here.
         return IndexSequence(0, 1)
-
-    def apply_read_write_thread_mapping(
-        self,
-        dim: IndexSymbol,
-        workgroup_dim: int,
-        elements_per_thread: int | IndexSymbol,
-        stride: int,
-    ) -> IndexSequence:
-        thread_id = [THREAD_0, THREAD_1, THREAD_2][self.workgroup_dim]
-        return IndexSequence(
-            thread_id * elements_per_thread, elements_per_thread, stride
-        )
 
 
 @dataclass

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -490,7 +490,10 @@ class ThreadConstraint(DistributionConstraint):
     A constraint of the form `tkw.ThreadConstraint(M, 0)`
     specifies that we want to distribute dimension M along thread dim 0.
     This translates to an index constraint for all tensors of the
-    shape [M, ?] -> index += (thread_id_0, 0)
+    shape [M, ?] -> index += (thread_id_0, 0).
+
+    This is useful when we want to distribute tiled reduction loop without
+    mma across threads.
     """
 
     dim: IndexExpr

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -263,18 +263,6 @@ class HardwareConstraint(Constraint):
             if isinstance(vector_size, IndexExpr):
                 self.vector_shapes[vector_dim] = vector_size.subs(index_map)
 
-    def compute_access_pattern_using_vector_shapes(
-        self,
-        dim: IndexSymbol,
-        workgroup_dim: int,
-        elements_per_thread: int | IndexSymbol,
-        stride: int,
-    ) -> IndexSequence:
-        thread_id = self.get_thread_id_from_workgroup_dim(workgroup_dim)
-        return IndexSequence(
-            thread_id * elements_per_thread, elements_per_thread, stride
-        )
-
     def apply(self):
         assert False, "Call either apply_read_write_thread_mapping or apply_mma_mapping"
 
@@ -476,8 +464,19 @@ class ThreadConstraint(Constraint):
     workgroup_dim: int
 
     def apply(self) -> IndexSequence:
+        return IndexSequence(0, 1)
+
+    def apply_read_write_thread_mapping(
+        self,
+        dim: IndexSymbol,
+        workgroup_dim: int,
+        elements_per_thread: int | IndexSymbol,
+        stride: int,
+    ) -> IndexSequence:
         thread_id = [THREAD_0, THREAD_1, THREAD_2][self.workgroup_dim]
-        return IndexSequence(thread_id, 1)
+        return IndexSequence(
+            thread_id * elements_per_thread, elements_per_thread, stride
+        )
 
 
 @dataclass

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -471,6 +471,16 @@ class TilingConstraint(Constraint):
 
 
 @dataclass
+class ThreadConstraint(Constraint):
+    dim: IndexExpr
+    workgroup_dim: int
+
+    def apply(self) -> IndexSequence:
+        thread_id = [THREAD_0, THREAD_1, THREAD_2][self.workgroup_dim]
+        return IndexSequence(thread_id, 1)
+
+
+@dataclass
 class WaveConstraint(Constraint):
     """
     A constraint of the form `tkw.WaveConstraint(K, WAVE_K)` specifies
@@ -510,7 +520,7 @@ class WaveConstraint(Constraint):
     def set_wave_id_from_hardware_and_workgroup_constraint(
         self,
         hardware_constraint: HardwareConstraint,
-        workgroup_constraint: WorkgroupConstraint,
+        workgroup_constraint: WorkgroupConstraint | ThreadConstraint,
     ):
         """
         The wave_id is the same as the thread_id, with the exception of

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -18,6 +18,7 @@ from ...ops.wave_ops import CustomOp, Read, Reduction, Write
 from ..assumptions import Assumption
 from ..constraints import (
     Constraint,
+    DistributionConstraint,
     HardwareConstraint,
     TilingConstraint,
     WorkgroupConstraint,
@@ -157,14 +158,14 @@ def find_index_bounds(
 ) -> Optional[list[IndexExpr]]:
     bounds = []
     for constraint in constraints:
-        if not isinstance(constraint, (WorkgroupConstraint, TilingConstraint)):
+        if not isinstance(constraint, DistributionConstraint):
             continue
 
         dim = constraint.dim
         if dim not in index:
             continue
 
-        work_size = constraint.count * constraint.tile_size
+        work_size = constraint.work_bound
         if subs_idxc(work_size) == subs_idxc(dim):
             continue
 

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -312,6 +312,9 @@ class LaunchableWave(Launchable):
         """
 
         hardware_constraint = self.hardware_constraints[0]
+        for thread_constraint in self.thread_constraints:
+            thread_constraint.hw_constraint = hardware_constraint
+
         for wave_constraint in self.wave_constraints:
             for workgroup_constraint in (
                 self.workgroup_constraints + self.thread_constraints

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -26,6 +26,7 @@ from .codegen import WaveEmitter
 from .constraints import (
     Constraint,
     HardwareConstraint,
+    ThreadConstraint,
     TilingConstraint,
     WaveConstraint,
     WorkgroupConstraint,
@@ -221,6 +222,14 @@ class LaunchableWave(Launchable):
         ]
 
     @property
+    def thread_constraints(self) -> list[ThreadConstraint]:
+        return [
+            constraint
+            for constraint in self.constraints
+            if isinstance(constraint, ThreadConstraint)
+        ]
+
+    @property
     def tiling_constraints(self) -> list[TilingConstraint]:
         return [
             constraint
@@ -304,7 +313,9 @@ class LaunchableWave(Launchable):
 
         hardware_constraint = self.hardware_constraints[0]
         for wave_constraint in self.wave_constraints:
-            for workgroup_constraint in self.workgroup_constraints:
+            for workgroup_constraint in (
+                self.workgroup_constraints + self.thread_constraints
+            ):
                 if wave_constraint.dim == workgroup_constraint.dim:
                     wave_constraint.set_wave_id_from_hardware_and_workgroup_constraint(
                         hardware_constraint, workgroup_constraint

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1449,6 +1449,85 @@ def test_tiled_reduce_min():
     # CHECK: scf.yield %[[ACC_REDUCE]] : vector<1xf16>
 
 
+@run_test
+def test_tiled_reduce_min_unaligned():
+    M = tkl.sym.M
+    N = tkl.sym.N
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    ELEMS_PER_THREAD = tkl.sym.ELEMS_PER_THREAD
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 1, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.ThreadConstraint(N, 0)]
+    constraints += [tkw.TilingConstraint(N, BLOCK_N)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+
+    @tkw.wave(constraints)
+    def tiled_reduce_min_unaligned(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, ADDRESS_SPACE, tkl.f16],
+    ):
+        init_min = tkl.Register[M, tkl.f16](1e6)
+
+        @tkw.reduction(N, init_args=[init_min])
+        def repeat(
+            partial_min: tkl.Register[M, tkl.f16],
+        ) -> tkl.Register[M, tkl.f16]:
+            lhs = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+            rhs = tkw.read(b, elements_per_thread=ELEMS_PER_THREAD)
+            res = lhs * rhs
+            partial_min = tkw.min(res, partial_min, dim=N)
+            return partial_min
+
+        tkw.write(repeat, c, elements_per_thread=1)
+
+    shape = (256, 527)
+    options = WaveCompileOptions(
+        subs={
+            M: shape[0],
+            N: shape[1],
+            BLOCK_M: 1,
+            BLOCK_N: 64,
+            ELEMS_PER_THREAD: 2,
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+        compile_to_mlir=True,
+    )
+    options = set_default_compile_config(options)
+    test = wave_compile(options, tiled_reduce_min_unaligned)
+    print(test.asm)
+
+    # CHECK-LABEL: func @tiled_reduce_min_unaligned
+    # CHECK-DAG: %[[C0_IDX:.+]] = arith.constant 0 : index
+    # CHECK-DAG: %[[C1_IDX:.+]] = arith.constant 1 : index
+    # CHECK-DAG: %[[C2_IDX:.+]] = arith.constant 2 : index
+    # CHECK-DAG: %[[C9_IDX:.+]] = arith.constant 9 : index
+    # CHECK-DAG: %[[C64_IDX:.+]] = arith.constant 64 : index
+    # CHECK-DAG: %[[CST_0:.+]] = arith.constant dense<527> : vector<2xindex>
+    # CHECK-DAG: %[[CST_1:.+]] = arith.constant dense<[0, 1]> : vector<2xindex>
+    # CHECK-DAG: %[[INIT:.+]] = arith.constant dense<0x7C00> : vector<1xf16>
+    # CHECK: %[[THREAD_ID_X:.+]] = gpu.thread_id  x
+    # CHECK: %[[MUL:.+]] = arith.muli %[[THREAD_ID_X]], %[[C2_IDX]] overflow<nsw, nuw> : index
+    # Tiled Reduction Loop
+    # CHECK: scf.for %[[ITER:.+]] = %[[C0_IDX]] to %[[C9_IDX]] step %[[C1_IDX]]
+    # CHECK: %[[D9:.*]] = arith.muli %[[ITER]], %[[C64_IDX]] overflow<nsw, nuw> : index
+    # CHECK: %[[D10:.*]] = arith.addi %[[D9]], %[[MUL]] overflow<nsw, nuw> : index
+    # CHECK: %[[D11:.*]] = vector.splat %[[D10]] : vector<2xindex>
+    # CHECK: %[[D12:.*]] = arith.addi %[[D11]], %[[CST_1]] overflow<nsw, nuw> : vector<2xindex>
+    # CHECK: %[[D13:.*]] = arith.cmpi slt, %[[D12]], %[[CST_0]] : vector<2xindex>
+    # CHECK-COUNT-2: vector.maskedload %{{.*}}[%{{.*}}, %[[D10]]], %[[D13]]
+
+
 # This test is to ensure that the we can handle multiple IV in reduction properly.
 @run_test
 def test_multiple_reduction_iv():

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1116,7 +1116,7 @@ def test_toy_online_softmax(shape):
             M: shape[0],
             N: shape[1],
             BLOCK_N: min(128, shape[1]),
-            ELEMS_PER_THREAD: min(128, shape[1]) // wave_size,
+            ELEMS_PER_THREAD: ceildiv(min(128, shape[1]), wave_size),
             ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
         },
         canonicalize=True,

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1073,7 +1073,6 @@ def test_toy_online_softmax(shape):
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
-    # constraints += [tkw.WorkgroupConstraint(N, N, 0)]
     constraints += [tkw.ThreadConstraint(N, 0)]
     constraints += [tkw.TilingConstraint(N, BLOCK_N)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -71,15 +71,6 @@ def get_test_shapes(test_name: str) -> list[tuple[int]]:
     return default_test_shapes
 
 
-def xfail_unaligned(func):
-    def wrapper(shape):
-        if shape[-1] % 2 != 0:
-            pytest.xfail("Unaligned shape is not expected to work on this test yet.")
-        func(shape)
-
-    return wrapper
-
-
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_copy")[:1])
 def test_dump_vmfb(shape, tmp_path, request):
@@ -1065,7 +1056,6 @@ def test_reduce_sum(shape, request):
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_tiled_reduce_max"))
-@xfail_unaligned
 def test_toy_online_softmax(shape):
     M = tkl.sym.M
     N = tkl.sym.N

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1083,7 +1083,8 @@ def test_toy_online_softmax(shape):
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
-    constraints += [tkw.WorkgroupConstraint(N, N, 0)]
+    # constraints += [tkw.WorkgroupConstraint(N, N, 0)]
+    constraints += [tkw.ThreadConstraint(N, 0)]
     constraints += [tkw.TilingConstraint(N, BLOCK_N)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]
     constraints += [tkw.WaveConstraint(N, BLOCK_N)]


### PR DESCRIPTION
* Add `ThreadConstraint`, allowing to distribute dim across threads inside workgroup, but not depend on wg index.
* `ThreadConstraint` can be combined with `WaveConstraint` in the same way as `WorkgroupConstraint`.
* Add `DistributionConstraint` base class and refactor masking generation.
* Refactor `test_toy_online_softmax` and fix it for unaligned shapes while we at here.