### PR TITLE
[Wave] Build wave runtime using torch pip package

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -70,6 +70,7 @@ jobs:
           pip install --no-compile -r pytorch-rocm-requirements.txt
           pip install --no-cache-dir -r requirements-iree-pinned.txt --upgrade
           pip install -r requirements.txt -e .
+          pip install -r requirements-wave-runtime.txt -e .
 
       - name: Install pip deps (mi250)
         if: "(contains(toJSON(matrix.os), 'amdgpu') && !contains(toJSON(matrix.os), 'mi300')) && !cancelled()"

--- a/docs/kernel/runtime.rst
+++ b/docs/kernel/runtime.rst
@@ -19,8 +19,14 @@ Wave Runtime
 In scenarios where the latencies associated with `torch.to_dlpack` are
 unacceptable, the Wave runtime can be used to launch kernels directly.
 The Wave runtime is a C++ extension that uses nanobind [3]_ to interface with
-inputs from Wave. In order to enable the wave runtime, modify the `run_config`
-as shown below.
+inputs from Wave. In order to enable the wave runtime, first install
+the `wave-runtime` pip package.
+
+.. code-block:: python
+
+     pip install -r requirements-wave-runtime.txt
+
+Then modify the `run_config` as shown below.
 
 .. code-block:: python
 

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -12,7 +12,6 @@ import inspect
 import json
 import os
 import shutil
-import torch
 import threading
 import math
 
@@ -26,10 +25,7 @@ from .constraints import Constraint, TilingConstraint, WaveConstraint
 from ..compiler.kernel_codegen import KernelBufferUsage
 from ..lang.wave_types import IndexMapping
 from .._support.indexing import IndexExpr
-from .utils.run_utils import (
-    _read_file,
-    _write_file,
-)
+from .utils.run_utils import _write_file, _read_file
 from .utils.classes import KernelLaunchInfo
 from .compile_options import WaveCompileOptions
 

--- a/iree/turbine/kernel/wave/runtime/CMakeLists.txt
+++ b/iree/turbine/kernel/wave/runtime/CMakeLists.txt
@@ -22,13 +22,26 @@ find_package(nanobind CONFIG REQUIRED)
 
 # Link against torch, using the libraries and include dirs in site-packages.
 execute_process(
-  COMMAND "${Python_EXECUTABLE}" -c "import torch; print(torch.utils.cmake_prefix_path)"
-  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE torch_cmake_PATH)
-list(APPEND CMAKE_PREFIX_PATH ${torch_cmake_PATH})
-list(APPEND CMAKE_PREFIX_PATH "/opt/rocm")
+  COMMAND "${Python_EXECUTABLE}" -c "import torch; print(torch.__path__[0])"
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE torch_PATH)
 
-find_package(Torch REQUIRED)
-find_package(HIP REQUIRED)
+# Add all directories in /opt/rocm/lib/cmake to CMAKE_PREFIX_PATH
+file(GLOB subdirectories "/opt/rocm/lib/cmake/*")
+foreach(subdir ${subdirectories})
+  if(IS_DIRECTORY ${subdir})
+    list(APPEND CMAKE_PREFIX_PATH "${subdir}")
+  endif()
+endforeach()
+
+include_directories(${torch_PATH}/include ${torch_PATH}/include/torch/csrc/api/include/)
+link_directories(${torch_PATH}/lib)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c "import torch; print(int(torch._C._GLIBCXX_USE_CXX11_ABI))"
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE torch_cxx_abi)
+set(TORCH_CXX_FLAGS -D_GLIBCXX_USE_CXX11_ABI=${torch_cxx_abi})
+
+find_package(hip REQUIRED)
 add_definitions(-D__HIP_PLATFORM_AMD__)
 
 # Build the core parts of nanobind once
@@ -38,8 +51,9 @@ nanobind_build_library(nanobind SHARED)
 add_library(wave_runtime MODULE runtime.cpp)
 
 # .. and link it against the nanobind parts
+set(TORCH_LIBRARIES ${torch_PATH}/lib/libtorch.so ${torch_PATH}/lib/libc10.so)
 target_link_libraries(wave_runtime PRIVATE nanobind hip::host ${TORCH_LIBRARIES})
-include_directories(${TORCH_INCLUDE_DIRS})
+set_target_properties(wave_runtime PROPERTIES LINK_WHAT_YOU_USE TRUE)
 
 # .. enable size optimizations
 nanobind_opt_size(wave_runtime)
@@ -64,3 +78,5 @@ nanobind_compile_options(wave_runtime PRIVATE ${TORCH_CXX_FLAGS})
 
 # .. set important linker flags
 nanobind_link_options(wave_runtime)
+
+install(TARGETS wave_runtime DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})

--- a/iree/turbine/kernel/wave/runtime/setup.py
+++ b/iree/turbine/kernel/wave/runtime/setup.py
@@ -1,0 +1,57 @@
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+import subprocess
+import os
+import sys
+from pathlib import Path
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        super().__init__(name, sources=[])
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        for ext in self.extensions:
+            self.build_cmake(ext)
+
+    def build_cmake(self, ext):
+
+        # Ensure CMake is available
+        try:
+            subprocess.check_output(["cmake", "--version"])
+        except OSError:
+            raise RuntimeError(
+                "CMake must be installed to build the following extensions: "
+                + ", ".join(e.name for e in self.extensions)
+            )
+
+        # Create build directory
+        build_dir = os.path.abspath(os.path.join(self.build_temp, ext.name))
+        os.makedirs(build_dir, exist_ok=True)
+
+        # Get extension directory
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
+        extdir = ext_fullpath.parent.resolve()
+
+        # Configure CMake
+        cmake_args = [
+            f"-DPython_EXECUTABLE={sys.executable}",
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-DCMAKE_BUILD_TYPE={'Debug' if self.debug else 'Release'}",
+        ]
+        subprocess.check_call(["cmake", ext.sourcedir, *cmake_args], cwd=build_dir)
+
+        # Build CMake project
+        subprocess.check_call(["cmake", "--build", "."], cwd=build_dir)
+
+
+setup(
+    name="wave_runtime",
+    version="0.1.0",
+    ext_modules=[CMakeExtension("wave_runtime")],
+    cmdclass={"build_ext": CMakeBuild},
+    zip_safe=False,
+)

--- a/requirements-wave-runtime.txt
+++ b/requirements-wave-runtime.txt
@@ -1,0 +1,2 @@
+# Wave runtime
+./iree/turbine/kernel/wave/runtime

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -294,7 +294,7 @@ def create_inputs(
 @pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("is_causal", "causal")
 @param_bool("use_buffer_ops", "buf_ops")
-@param_bool("use_wave_runtime", "wr", [False])
+@param_bool("use_wave_runtime", "wr", [True])
 @pytest.mark.parametrize(
     "mfma_variant",
     [


### PR DESCRIPTION
Previously, the runtime needed a system wide install of rocm. We remove this constraint and instead use the torch libraries inside the torch pip package. Also, rather than build the wave-runtime during execution, we provide an option to pip install wave-runtime.