### PR TITLE
[BOO] enable using `conv_2d_nhwc_fhwc` in conv exports

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/conv.py
+++ b/iree/turbine/kernel/boo/conv_exports/conv.py
@@ -263,6 +263,8 @@ class ConvSignature:
             str(self.dtype).removeprefix("torch."),
             str(self.mode).lower(),
         ]
+        if self.bias and self.mode == Mode.FORWARD:
+            name_items.append("_b_")
         l2s = lambda l: "x".join([str(i) for i in l])
         name_items.extend(
             [

--- a/iree/turbine/kernel/boo/conv_exports/conv.py
+++ b/iree/turbine/kernel/boo/conv_exports/conv.py
@@ -278,19 +278,17 @@ class ConvSignature:
         )
         return "_".join(name_items)
 
-    def get_nn_module(self) -> torch.nn.Module:
+    def get_nn_module(self, *, use_custom: bool = False) -> torch.nn.Module:
         """For a given ConvSignature, returns a torch.nn.Module implementation."""
         if self.mode == Mode.WEIGHT_BACKWARD:
             return ConvBackwardWeight(self)
         if self.mode == Mode.INPUT_BACKWARD:
             return ConvBackwardInput(self)
-        is_nhwc = (
-            self.input_layout == "NHWC"
+        is_supported_nhwc = (
+            use_custom
+            and self.input_layout == "NHWC"
             and self.kernel_layout == "NHWC"
             and self.output_layout == "NHWC"
-        )
-        is_supported_nhwc = (
-            is_nhwc
             and self.groups == 1
             and not self.transposed
             and self.dtype.is_floating_point

--- a/iree/turbine/kernel/boo/conv_exports/conv.py
+++ b/iree/turbine/kernel/boo/conv_exports/conv.py
@@ -264,7 +264,7 @@ class ConvSignature:
             str(self.mode).lower(),
         ]
         if self.bias and self.mode == Mode.FORWARD:
-            name_items.append("_b_")
+            name_items.append("b")
         l2s = lambda l: "x".join([str(i) for i in l])
         name_items.extend(
             [

--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -18,7 +18,7 @@ __all__ = [
 
 _default_cache_base_dir = Path.home() / ".cache" / "turbine_kernels" / "boo"
 CACHE_BASE_DIR = Path(os.environ.get("BOO_CACHE_DIR", _default_cache_base_dir))
-BOO_CACHE_ON = os.environ.get("BOO_CACHE_ON", 1)
+BOO_CACHE_ON = int(os.environ.get("BOO_CACHE_ON", 1))
 
 
 def is_cache_enabled() -> bool:
@@ -79,7 +79,7 @@ def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> s
 def get_launchable(signature: ConvSignature) -> Launchable:
     func_name = signature.get_func_name()
     module_asm = _get_module_asm(signature, func_name)
-    cache_dir = CACHE_BASE_DIR / func_name if is_cache_enabled else None
+    cache_dir = CACHE_BASE_DIR / func_name if is_cache_enabled() else None
     return Launchable.jit_compile(
         module_asm,
         parameter_providers=(),

--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -46,7 +46,7 @@ def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> s
         function_name=func_name,
     )
 
-    e.import_to("import")
+    e.import_to("full")
 
     mod = e.mlir_module
 
@@ -63,7 +63,6 @@ def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> s
             f"Failed to attach #util.preprocessing_pipeline attr to func op. Please try using a newer version of IREE."
         )
 
-    e.import_to("full")
     module_asm = str(e.mlir_module)
 
     if is_cache_enabled():

--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -41,7 +41,7 @@ def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> s
         return mlir_path.read_text()
 
     e = export(
-        signature.get_nn_module(),
+        signature.get_nn_module(use_custom=True),
         args=signature.get_sample_conv_args(splat_value=0),
         function_name=func_name,
     )

--- a/iree/turbine/ops/conv_fwd.py
+++ b/iree/turbine/ops/conv_fwd.py
@@ -140,6 +140,5 @@ class conv_2d_nhwc_fhwc(CustomOp):
             function_name,
             **kwargs,
         )
-        print(func_op)
         arg_bindings = kb.arg_bindings[0:2]
         kb.yield_results(*impl_helper.call_function(func_op, *arg_bindings))


### PR DESCRIPTION
This plugs in the `conv_2d_nhwc_fhwc` into a custom implementation for `ConvSignature.get_nn_module` to avoid generating unnecessary transposes. 

Some small additional fixes:

1. remove a debug print in the custom op generate method
2. fix an issue with disabling the boo_cache
3. adds the func op `preprocessing_pipeline` attr after lowering to iree-input (it appeared to be getting stripped).

Some examples of IR before vs. after these changes for the following signature (+/- `bias=True`) :

```python
ConvSignature(input_shape=[2,14,14,4], kernel_shape=[3,3,3,4], shared_layout="NHWC", dtype=torch.bfloat16)
```

are contained in this gist: <https://gist.github.com/zjgarvey/7d66d8ec6dc4470b22dd8329ed9e7e0a>