### PR TITLE
[Wave] Restore benchmarking code

### DIFF
--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -41,6 +41,9 @@ class WaveCompileOptions:
     benchmark_batch_size: int = None
     benchmark_repetitions: int = None
     benchmark_results_file: str = None
+    capture_trace: bool = False
+    bench_with_constant_weights: bool = False
+    bench_file: str = None
 
     # === Cache options ===
     kernel_hash: list[str] = None


### PR DESCRIPTION
Recent refactors ignored the benchmarking code as it is not being captured by the builder. This PR updates the benchmarking code to reflect the new changes.