### PR TITLE
[Wave] Add custom causal mask for Extend Attention

### DIFF
--- a/iree/turbine/kernel/wave/templates/attention_common.py
+++ b/iree/turbine/kernel/wave/templates/attention_common.py
@@ -31,6 +31,9 @@ class AttentionShape:
     # -----------------------
     # Decode specific
     block_size: Optional[int] = None
+    # -----------------------
+    # Extend specific
+    flattened_mask_len: Optional[int] = None
 
     def __iter__(self):
         for field in fields(AttentionShape):

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -20,7 +20,6 @@ import math
 import torch
 import sympy
 from typing import Optional
-import warnings
 
 
 def get_extend_attention_kernel(
@@ -425,7 +424,6 @@ def get_extend_attention_kernel(
         mask_offsets: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
         c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
     ):
-        warnings.warn("Custom mask with random values is untested, YMMV")
         extend_attention_core(
             q,
             k,

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -204,21 +204,18 @@ def get_extend_attention_kernel(
     num_seqs_layout = tkl.MemoryLayout(shape=[None])
     kv_indices_layout = tkl.MemoryLayout(shape=[None])
 
-    @tkw.wave(constraints)
-    def extend_attention(
-        q: tkl.Memory[N_Q, H, D_Q, GLOBAL_ADDRESS_SPACE, wave_input_dtype, q_layout],
-        k: tkl.Memory[N_KV, H_KV, D_Q, ADDRESS_SPACE, wave_input_dtype, k_layout],
-        v: tkl.Memory[N_KV, H_KV, D_KV, ADDRESS_SPACE, wave_input_dtype, v_layout],
-        k_cache: tkl.Memory[
-            N_KV, H_KV, D_Q, ADDRESS_SPACE, wave_input_dtype, k_cache_layout
-        ],
-        v_cache: tkl.Memory[
-            N_KV, H_KV, D_KV, ADDRESS_SPACE, wave_input_dtype, v_cache_layout
-        ],
-        qo_indptr: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
-        kv_indptr: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
-        kv_indices: tkl.Memory[N_KV, GLOBAL_ADDRESS_SPACE, tkl.i32, kv_indices_layout],
-        c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
+    def extend_attention_core(
+        q,
+        k,
+        v,
+        k_cache,
+        v_cache,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        custom_mask,
+        mask_offsets,
+        c,
     ):
         c_reg = tkl.Register[H, D_KV, N_Q, tkl.f32](0.0)
         init_sum = tkl.Register[H, N_Q, tkl.f32](0.0)
@@ -243,6 +240,11 @@ def get_extend_attention_kernel(
             - seq_kv_start_idx
         )
         tkw.set_symbol(N_KV, seq_len_prefix)
+        if use_custom_mask:
+            seq_len = seq_len_prefix + seq_len_extend
+            tkw.set_symbol(SEQ_LEN, seq_len)
+            seq_mask_start_idx = tkw.read(mask_offsets, elements_per_thread=1)
+            tkw.set_symbol(MASK_START_IDX, seq_mask_start_idx)
 
         @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
         def first_loop(
@@ -282,6 +284,14 @@ def get_extend_attention_kernel(
             mask = tkw.apply_expr(n_kv_index, lambda x: x < N_KV)
             mask = tkw.broadcast(mask, target_shape=[N_Q, N_KV])
             mask = tkw.cast(mask, tkw.i1)
+            if use_custom_mask:
+                c_mask = tkw.read(
+                    custom_mask,
+                    elements_per_thread=STORE_ELEMS_PER_THREAD,
+                    mapping=custom_mask_mapping_loop1,
+                )
+                c_mask = tkw.cast(c_mask, tkw.i1)
+                mask &= c_mask
             bias = tkw.select(mask, zero, neg_infinity)
             x_j = x_j + bias
             m_j = tkw.max(x_j, partial_max, dim=N_KV)
@@ -307,6 +317,8 @@ def get_extend_attention_kernel(
                 seq_len_extend, lambda x: sympy.Min(x, (WORKGROUP_0 + 1) * BLOCK_N_Q)
             )
         tkw.set_symbol(N_KV, seq_len_extend)
+        if use_custom_mask:
+            tkw.set_symbol(PREFIX_LEN, seq_len_prefix)
 
         @tkw.reduction(N_KV, init_args=[res_max, res_sum, res_mm])
         def second_loop(
@@ -339,6 +351,14 @@ def get_extend_attention_kernel(
                 n_q_index = tkw.broadcast(n_q_index, target_shape=[N_Q, N_KV])
                 mask = (n_q_index >= n_kv_index) & mask
             mask = tkw.cast(mask, tkw.i1)
+            if use_custom_mask:
+                c_mask = tkw.read(
+                    custom_mask,
+                    elements_per_thread=STORE_ELEMS_PER_THREAD,
+                    mapping=custom_mask_mapping_loop2,
+                )
+                c_mask = tkw.cast(c_mask, tkw.i1)
+                mask &= c_mask
             bias = tkw.select(mask, zero, neg_infinity)
             x_j = x_j + bias
             m_j = tkw.max(x_j, partial_max, dim=N_KV)
@@ -363,6 +383,26 @@ def get_extend_attention_kernel(
         if wave_output_dtype != tkl.f32:
             res = tkw.cast(res, wave_output_dtype)
         tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    @tkw.wave(constraints)
+    def extend_attention(
+        q: tkl.Memory[N_Q, H, D_Q, GLOBAL_ADDRESS_SPACE, wave_input_dtype, q_layout],
+        k: tkl.Memory[N_KV, H_KV, D_Q, ADDRESS_SPACE, wave_input_dtype, k_layout],
+        v: tkl.Memory[N_KV, H_KV, D_KV, ADDRESS_SPACE, wave_input_dtype, v_layout],
+        k_cache: tkl.Memory[
+            N_KV, H_KV, D_Q, ADDRESS_SPACE, wave_input_dtype, k_cache_layout
+        ],
+        v_cache: tkl.Memory[
+            N_KV, H_KV, D_KV, ADDRESS_SPACE, wave_input_dtype, v_cache_layout
+        ],
+        qo_indptr: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
+        kv_indptr: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
+        kv_indices: tkl.Memory[N_KV, GLOBAL_ADDRESS_SPACE, tkl.i32, kv_indices_layout],
+        c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
+    ):
+        extend_attention_core(
+            q, k, v, k_cache, v_cache, qo_indptr, kv_indptr, kv_indices, None, None, c
+        )
 
     @tkw.wave(constraints)
     def extend_attention_custom_mask(
@@ -384,166 +424,19 @@ def get_extend_attention_kernel(
         mask_offsets: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
         c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
     ):
-        c_reg = tkl.Register[H, D_KV, N_Q, tkl.f32](0.0)
-        init_sum = tkl.Register[H, N_Q, tkl.f32](0.0)
-        init_max = tkl.Register[H, N_Q, tkl.f32](-1e6)
-        zero = tkl.Register[N_Q, N_KV, tkl.f32](0.0)
-        neg_infinity = tkl.Register[N_Q, N_KV, tkl.f32](-1e6)
-        layer_scale_reg = tkl.Register[H, N_Q, N_KV, tkl.f32](layer_scaling)
-        if logit_cap > 0:
-            logit_cap_reg = tkl.Register[H, N_Q, N_KV, tkl.f32](logit_cap)
-
-        seq_extend_start_idx = tkw.read(qo_indptr, elements_per_thread=1)
-        tkw.set_symbol(EXT_IDX, seq_extend_start_idx)
-        seq_len_extend = (
-            tkw.read(qo_indptr, elements_per_thread=1, mapping=ind_ptr_mapping)
-            - seq_extend_start_idx
+        extend_attention_core(
+            q,
+            k,
+            v,
+            k_cache,
+            v_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            custom_mask,
+            mask_offsets,
+            c,
         )
-        tkw.set_symbol(N_Q, seq_len_extend)
-        seq_kv_start_idx = tkw.read(kv_indptr, elements_per_thread=1)
-        tkw.set_symbol(KV_START_IDX, seq_kv_start_idx)
-        seq_len_prefix = (
-            tkw.read(kv_indptr, elements_per_thread=1, mapping=ind_ptr_mapping)
-            - seq_kv_start_idx
-        )
-        tkw.set_symbol(N_KV, seq_len_prefix)
-        seq_len = seq_len_prefix + seq_len_extend
-        tkw.set_symbol(SEQ_LEN, seq_len)
-        seq_mask_start_idx = tkw.read(mask_offsets, elements_per_thread=1)
-        tkw.set_symbol(MASK_START_IDX, seq_mask_start_idx)
-
-        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
-        def first_loop(
-            partial_max: tkl.Register[H, N_Q, tkl.f32],
-            partial_sum: tkl.Register[H, N_Q, tkl.f32],
-            acc: tkl.Register[H, D_KV, N_Q, tkl.f32],
-        ):
-            q_reg = tkw.read(
-                q,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
-                mapping=q_mapping,
-            )
-            block_indices_v = tkw.read(
-                kv_indices,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_PV,
-                mapping=kv_indices_mapping,
-            )
-            block_indices_k = tkw.read(
-                kv_indices,
-                elements_per_thread=1,
-                mapping=kv_indices_mapping,
-            )
-            k_reg = tkw.read(
-                k_cache,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
-                mapping=k_cache_mapping,
-                mapping_dynamic_vals=(block_indices_k,),
-            )
-            imm_reg = tkl.Register[H, N_KV, N_Q, tkl.f32](0.0)
-            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
-            x_j = tkw.permute(inner_acc, target_shape=[H, N_Q, N_KV])
-            x_j = x_j * layer_scale_reg
-            if logit_cap > 0:
-                x_j = logit_cap_reg * tkw.tanh(x_j / logit_cap_reg)
-            n_kv_index = tkw.self_index(N_KV, tkl.i32)
-            mask = tkw.apply_expr(n_kv_index, lambda x: x < N_KV)
-            mask = tkw.broadcast(mask, target_shape=[N_Q, N_KV])
-            mask = tkw.cast(mask, tkw.i1)
-            c_mask = tkw.read(
-                custom_mask,
-                elements_per_thread=STORE_ELEMS_PER_THREAD,
-                mapping=custom_mask_mapping_loop1,
-            )
-            c_mask = tkw.cast(c_mask, tkw.i1)
-            mask &= c_mask
-            bias = tkw.select(mask, zero, neg_infinity)
-            x_j = x_j + bias
-            m_j = tkw.max(x_j, partial_max, dim=N_KV)
-            e_delta_max = tkw.exp2(partial_max - m_j)
-            e_delta = tkw.exp2(x_j - m_j)
-            e_init = partial_sum * e_delta_max
-            d_j = tkw.sum(e_delta, e_init, dim=N_KV)
-            imm_f16 = tkw.cast(e_delta, wave_input_dtype)
-            v_reg = tkw.read(
-                v_cache,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_PV,
-                mapping=v_cache_mapping,
-                mapping_dynamic_vals=(block_indices_v,),
-            )
-            new_acc = acc * e_delta_max
-            acc = tkw.mma(v_reg, imm_f16, new_acc)
-            return m_j, d_j, acc
-
-        res_max, res_sum, res_mm = first_loop
-
-        if is_causal:
-            seq_len_extend = tkw.apply_expr(
-                seq_len_extend, lambda x: sympy.Min(x, (WORKGROUP_0 + 1) * BLOCK_N_Q)
-            )
-        tkw.set_symbol(PREFIX_LEN, seq_len_prefix)
-        tkw.set_symbol(N_KV, seq_len_extend)
-
-        @tkw.reduction(N_KV, init_args=[res_max, res_sum, res_mm])
-        def second_loop(
-            partial_max: tkl.Register[H, N_Q, tkl.f32],
-            partial_sum: tkl.Register[H, N_Q, tkl.f32],
-            acc: tkl.Register[H, D_KV, N_Q, tkl.f32],
-        ):
-            imm_reg = tkl.Register[H, N_KV, N_Q, tkl.f32](0.0)
-            q_reg = tkw.read(
-                q,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
-                mapping=q_mapping,
-            )
-            k_reg = tkw.read(
-                k,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_QK,
-                mapping=k_mapping,
-            )
-            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
-            x_j = tkw.permute(inner_acc, target_shape=[H, N_Q, N_KV])
-            x_j = x_j * layer_scale_reg
-            if logit_cap > 0:
-                x_j = logit_cap_reg * tkw.tanh(x_j / logit_cap_reg)
-            n_kv_index = tkw.self_index(N_KV, tkl.i32)
-            mask = tkw.apply_expr(n_kv_index, lambda x: x < N_KV)
-            mask = tkw.broadcast(mask, target_shape=[N_Q, N_KV])
-            if is_causal:
-                n_q_index = tkw.self_index(N_Q, tkl.i32)
-                n_q_index = tkw.broadcast(n_q_index, target_shape=[N_Q, N_KV])
-                mask = (n_q_index >= n_kv_index) & mask
-            mask = tkw.cast(mask, tkw.i1)
-            c_mask = tkw.read(
-                custom_mask,
-                elements_per_thread=STORE_ELEMS_PER_THREAD,
-                mapping=custom_mask_mapping_loop2,
-            )
-            c_mask = tkw.cast(c_mask, tkw.i1)
-            mask &= c_mask
-            bias = tkw.select(mask, zero, neg_infinity)
-            x_j = x_j + bias
-            m_j = tkw.max(x_j, partial_max, dim=N_KV)
-            e_delta_max = tkw.exp2(partial_max - m_j)
-            e_delta = tkw.exp2(x_j - m_j)
-            e_init = partial_sum * e_delta_max
-            d_j = tkw.sum(e_delta, e_init, dim=N_KV)
-            imm_f16 = tkw.cast(e_delta, wave_input_dtype)
-            v_reg = tkw.read(
-                v,
-                elements_per_thread=LOAD_ELEMS_PER_THREAD_PV,
-                mapping=v_mapping,
-            )
-            new_acc = acc * e_delta_max
-            acc = tkw.mma(v_reg, imm_f16, new_acc)
-            return m_j, d_j, acc
-
-        # repeat represents the results of the loop
-        res_max, res_sum, res_mm = second_loop
-        reciprocal_sum = tkw.reciprocal(res_sum)
-        res = res_mm * reciprocal_sum
-        if wave_output_dtype != tkl.f32:
-            res = tkw.cast(res, wave_output_dtype)
-        tkw.write(res, c, mapping=mapping, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     hyperparams = {
         ADDRESS_SPACE: SHARED_ADDRESS_SPACE,

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -20,6 +20,7 @@ import math
 import torch
 import sympy
 from typing import Optional
+import warnings
 
 
 def get_extend_attention_kernel(
@@ -424,6 +425,7 @@ def get_extend_attention_kernel(
         mask_offsets: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
         c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
     ):
+        warnings.warn("Custom mask with random values is untested, YMMV")
         extend_attention_core(
             q,
             k,

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -400,18 +400,15 @@ def test_extend_attention_custom_mask():
     # CHECK-LABEL:       func.func @extend_attention_custom_mask
     # CHECK-COUNT-4:        vector.maskedload
     # CHECK:                scf.for
-    # CHECK-COUNT-3:            vector.maskedload
-    # CHECK-COUNT-2:            vector.maskedload
-    # CHECK-NEXT:               vector.store %{{.*}}, %{{.*}}
-    # CHECK-COUNT-1:            vector.maskedload
-    # CHECK-COUNT-1:            vector.store %{{.*}}, %{{.*}}
-    # CHECK-COUNT-32:           vector.load %{{.*}}
-    # CHECK-COUNT-8:            vector.load %{{.*}}
+    # load and apply custom mask
+    # CHECK:                    vector.maskedload
+    # CHECK:                    arith.trunci %{{.*}} : vector<4xi8> to vector<4xi1>
+    # CHECK:                    arith.andi %{{.*}}, %{{.*}} : vector<4xi1>
     # CHECK-COUNT-8:            amdgpu.mfma
 
     # CHECK:                scf.for
-    # CHECK-COUNT-1:            vector.maskedload
-    # CHECK-COUNT-1:            vector.store %{{.*}}, %{{.*}}
-    # CHECK-COUNT-32:           vector.load %{{.*}}
-    # CHECK-COUNT-8:            vector.load %{{.*}}
+    # load and apply custom mask
+    # CHECK:                    vector.maskedload
+    # CHECK:                    arith.trunci %{{.*}} : vector<4xi8> to vector<4xi1>
+    # CHECK:                    arith.andi %{{.*}}, %{{.*}} : vector<4xi1>
     # CHECK-COUNT-8:            amdgpu.mfma

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -70,7 +70,7 @@ def test_extend_attention():
     # CHECK-LABEL: test_extend_attention
     # CHECK-DAG:            #[[map0:.*]] = affine_map<()[s0] -> (s0 ceildiv 64)>
     # CHECK-DAG:            #[[map1:.*]] = affine_map<()[s0] -> (s0 * 16)>
-    # CHECK:              stream.executable.export public @extend_attention workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
+    # CHECK:              stream.executable.export public @extend_attention workgroups(%[[ARG0:.+]]: index, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index, %[[ARG4:.+]]: index)
     # CHECK-DAG:            %[[C1:.*]] = arith.constant 1 : index
     # CHECK:                %[[NQ_GRID:.+]] = affine.apply #[[map0]]()[%[[ARG3]]]
     # CHECK:                %[[NUM_SEQ:.+]] = affine.apply #[[map1]]()[%[[ARG2]]]

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -378,7 +378,7 @@ def test_extend_attention_custom_mask():
         k_cache_shape,
         v_cache_shape,
         o_shape,
-        use_custom_mask=True
+        use_custom_mask=True,
     )
 
     options = WaveCompileOptions(
@@ -393,7 +393,6 @@ def test_extend_attention_custom_mask():
     )
     extend_attention = wave_compile(options, extend_attention)
     print(extend_attention.asm)
-
 
     # CHECK-LABEL:       test_extend_attention_custom_mask
     # CHECK-DAG:            #[[map34:.*]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (s3 * 32 + s4 + s5 + (s0 + s1 * 64 - (s0 floordiv 16) * 16 + (s0 floordiv 64) * 16) * s2 + ((s0 mod 64) floordiv 16) * 4)>

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -25,6 +25,7 @@ from iree.turbine.kernel.wave.utils.torch_utils import (
     device_empty,
     device_arange,
     device_randint,
+    device_full,
 )
 from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
 from iree.turbine.kernel.wave.constraints import MMAType
@@ -258,6 +259,30 @@ def create_inputs(
     qo_indptr[1 : B + 1] = torch.cumsum(b_seq_len_extend[:B], dim=0)
     logit_cap = 30.0
 
+    b_seq_mask_len = b_seq_len_extend * b_seq_len
+    custom_mask = device_full(
+        (b_seq_mask_len.sum().item(),), fill_value=1, dtype=torch.int8
+    )
+    mask_offsets = device_zeros((B + 1,), dtype=torch.int32)
+    mask_offsets[1 : B + 1] = torch.cumsum(b_seq_mask_len[:B], dim=0)
+    for i in range(B):
+        causal_mask = (
+            torch.tril(
+                device_full(
+                    (b_seq_len_extend[i], b_seq_len_extend[i]),
+                    fill_value=1,
+                    dtype=torch.int8,
+                ),
+                diagonal=0,
+            )
+            == 1
+        )
+        prefix_mask = device_full(
+            (b_seq_len_extend[i], b_seq_len_prefix[i]), fill_value=1, dtype=torch.int8
+        )
+        mask_flatten = torch.cat([prefix_mask, causal_mask], dim=1).flatten()
+        custom_mask[mask_offsets[i] : mask_offsets[i + 1]] = mask_flatten
+
     max_rpe_context_length = 10
     rpe_bias = device_zeros(max_rpe_context_length + 1, dtype=torch.float32)
     rpe_bias.copy_(device_randn(max_rpe_context_length + 1, dtype=torch.float32))
@@ -274,6 +299,8 @@ def create_inputs(
         qo_indptr,
         kv_indptr,
         kv_indices,
+        custom_mask,
+        mask_offsets,
         b_start_loc,
         b_seq_len_prefix,
         extend_token_num,
@@ -294,7 +321,8 @@ def create_inputs(
 @pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
 @param_bool("is_causal", "causal")
 @param_bool("use_buffer_ops", "buf_ops")
-@param_bool("use_wave_runtime", "wr", [True])
+@param_bool("use_wave_runtime", "wr", [False])
+@param_bool("use_custom_mask", "cmask")
 @pytest.mark.parametrize(
     "mfma_variant",
     [
@@ -309,10 +337,10 @@ def testExtendAttention(
     is_causal: bool,
     use_buffer_ops: bool,
     use_wave_runtime: bool,
+    use_custom_mask: bool,
     mfma_variant: MMAType,
     request,
 ):
-
     torch.manual_seed(0)
     assert shape.num_query_heads % shape.num_kv_heads == 0
     (
@@ -326,6 +354,8 @@ def testExtendAttention(
         qo_indptr,
         kv_indptr,
         kv_indices,
+        custom_mask,
+        mask_offsets,
         b_start_loc,
         b_seq_len_prefix,
         extend_token_num,
@@ -335,7 +365,7 @@ def testExtendAttention(
         _,
     ) = create_inputs(shape, dtype)
     shape = replace(shape, max_seq_len=max_len_extend)
-
+    shape = replace(shape, flattened_mask_len=custom_mask.shape[0])
     if mfma_variant[0] == MMAType.F32_16x16x16_F16:
         num_waves = 4
     if mfma_variant[1] == MMAType.F32_32x32x8_F16:
@@ -362,6 +392,7 @@ def testExtendAttention(
         is_causal=is_causal,
         logit_cap=logit_cap,
         num_waves=num_waves,
+        use_custom_mask=use_custom_mask,
     )
     hyperparams.update(get_default_scheduling_params())
     run_bench = request.config.getoption("--runperf")
@@ -369,7 +400,6 @@ def testExtendAttention(
     perf_filename = construct_test_name(
         "wave_extend_attention", mfma_variant, is_causal, shape
     )
-
     options = WaveCompileOptions(
         subs=hyperparams,
         canonicalize=True,
@@ -392,17 +422,32 @@ def testExtendAttention(
     options = set_default_run_config(options)
     extend_attention = wave_compile(options, extend_attention)
 
-    asm_qk = extend_attention(
-        q_extend,
-        k_extend,
-        v_extend,
-        k_buffer,
-        v_buffer,
-        qo_indptr,
-        kv_indptr,
-        kv_indices,
-        output,
-    )
+    if use_custom_mask:
+        asm_qk = extend_attention(
+            q_extend,
+            k_extend,
+            v_extend,
+            k_buffer,
+            v_buffer,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            custom_mask,
+            mask_offsets,
+            output,
+        )
+    else:
+        asm_qk = extend_attention(
+            q_extend,
+            k_extend,
+            v_extend,
+            k_buffer,
+            v_buffer,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            output,
+        )
 
     if dump_generated_mlir:
         filename = f"wave_extend_attention_kernel_{'x'.join(map(str, shape))}.mlir"

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -10,7 +10,6 @@ import torch
 from torch.nn import functional as F
 from dataclasses import replace
 
-
 import iree.turbine.kernel as tk
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel.wave.utils.general_utils import (

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -259,6 +259,8 @@ def create_inputs(
     logit_cap = 30.0
 
     b_seq_mask_len = b_seq_len_extend * b_seq_len
+    # NOTE: Custom mask is of causal nature in this test. Random mask numerics
+    # is not tested.
     custom_mask = device_full(
         (b_seq_mask_len.sum().item(),), fill_value=1, dtype=torch.int8
     )

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -103,7 +103,6 @@ def context_attention_fwd(
         V = V.expand(Q.shape[0], *V.shape[1:])
         dk_sqrt = math.sqrt(1.0 / Q.shape[-1])
         a = torch.bmm(Q * dk_sqrt, K.transpose(-1, -2))
-        # breakpoint()
         if score_mod == ScoreMod.SoftCap:
             a = a / logit_cap
             a = torch.tanh(a)
@@ -126,7 +125,6 @@ def context_attention_fwd(
             )
             # Apply the mask to set the upper triangular part to -infinity
             a[mask == 1] = float("-inf")
-            # breakpoint()
         reference = torch.bmm(F.softmax(a, dim=-1).to(dtype=V.dtype), V)
         reference = reference.squeeze(0).permute(1, 0, 2)
         o[start:end] = reference
@@ -517,6 +515,8 @@ def testExtendRpeAttention(
         qo_indptr,
         kv_indptr,
         kv_indices,
+        _,
+        _,
         b_start_loc,
         b_seq_len_prefix,
         extend_token_num,


### PR DESCRIPTION
Adds custom causal mask for Extend Attention. Mask has flattened bool values of `seq_len_extend, seq_len_prefix` for each sequence. Sequence demarcation is identified by the `mask_offsets`. 