### PR TITLE
[TKW] Propagate index from reduce nodes

### DIFF
--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -307,24 +307,6 @@ def populate_mma_source_indices(
     ]
 
 
-def collect_parent_redutions(root: CustomOp) -> list[Reduction]:
-    """
-    Collect all the parent reductions of the given node, starting from the most nested one.
-    """
-    ret = []
-    while True:
-        parent = getattr(root.graph, "parent_op", None)
-        if not parent:
-            break
-
-        parent = get_custom(parent)
-        if isinstance(parent, Reduction):
-            ret.append(parent)
-
-        root = parent
-    return ret
-
-
 def populate_read_write_source_indices(
     node: Read | Write,
     hardware_constraint: HardwareConstraint,

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -23,7 +23,6 @@ from ...ops.wave_ops import (
 from ..constraints import (
     Constraint,
     HardwareConstraint,
-    ThreadConstraint,
     TilingConstraint,
     WorkgroupConstraint,
 )
@@ -545,7 +544,7 @@ def set_thread_dependent_index_from_read_write(
 
     visited = set()
     workgroup_constraints = [
-        c for c in constraints if isinstance(c, (WorkgroupConstraint, ThreadConstraint))
+        c for c in constraints if isinstance(c, WorkgroupConstraint)
     ]
     symbolic_constraints = [c for c in constraints if isinstance(c, SymbolicAlias)]
     for source in sources:
@@ -666,7 +665,7 @@ def set_thread_dependent_index_from_reduce(
 
     visited = set()
     workgroup_constraints = [
-        c for c in constraints if isinstance(c, (WorkgroupConstraint, ThreadConstraint))
+        c for c in constraints if isinstance(c, WorkgroupConstraint)
     ]
     symbolic_constraints = [c for c in constraints if isinstance(c, SymbolicAlias)]
     for source in sources:

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -34,6 +34,7 @@ from ...lang.global_symbols import *
 from ..utils.general_utils import (
     get_hardware_constraint,
     get_largest_index_and_size,
+    get_workgroup_constraints,
     partial,
 )
 from ..utils.mma_utils import (
@@ -526,9 +527,7 @@ def set_thread_dependent_index_from_read_write(
     assert sources, "No read nodes found in the graph."
 
     visited = set()
-    workgroup_constraints = [
-        c for c in constraints if isinstance(c, WorkgroupConstraint)
-    ]
+    workgroup_constraints = get_workgroup_constraints(constraints)
     symbolic_constraints = [c for c in constraints if isinstance(c, SymbolicAlias)]
     for source in sources:
         visited = visited.union(set([x for x in sources]))
@@ -569,9 +568,7 @@ def get_reduce_mapping(
     """
     sources = trace.walk(lambda node: isinstance(get_custom(node), ReduceOp))
     hardware_constraint = get_hardware_constraint(constraints)
-    workgroup_constraints = [
-        c for c in constraints if isinstance(c, WorkgroupConstraint)
-    ]
+    workgroup_constraints = get_workgroup_constraints(constraints)
 
     reduce_mapping = {}
     for source in sources:
@@ -660,9 +657,7 @@ def set_thread_dependent_index_from_reduce(
     assert sources, "No reduce nodes found in the graph."
 
     visited = set()
-    workgroup_constraints = [
-        c for c in constraints if isinstance(c, WorkgroupConstraint)
-    ]
+    workgroup_constraints = get_workgroup_constraints(constraints)
     symbolic_constraints = [c for c in constraints if isinstance(c, SymbolicAlias)]
     for source in sources:
         visited = visited.union(set([x for x in sources]))

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -631,13 +631,14 @@ def populate_reduce_source_indices(
     else:
         ret += [(get_custom(node.arg), index, vector_shapes)]
 
-    if node.init:
-        ret += [(get_custom(node.init), index, vector_shapes)]
-
     # Reduce args must contain index for the reduction dimension,
-    # but the reduction itself does not.
+    # but init and the reduction itself does not.
     res_index = copy(index)
     del res_index[node.dim]
+
+    if node.init:
+        ret += [(get_custom(node.init), res_index, vector_shapes)]
+
     ret += [(node, res_index, vector_shapes)]
 
     return ret

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -566,9 +566,10 @@ def get_reduce_mapping(
         # threads per wave and the vector size.
         threads_per_wave = hardware_constraint.threads_per_wave
         vector_size = hardware_constraint.vector_shapes[dim]
-        elements_per_thread = sympy.Max(
-            sympy.ceiling(vector_size / threads_per_wave), 1
-        )
+        assert (
+            vector_size % threads_per_wave == 0
+        ), f"Vector size {dim}={vector_size} must be divisible by threads per wave {threads_per_wave}"
+        elements_per_thread = vector_size // threads_per_wave
         stride = compute_stride(
             custom.indexing_dims, hardware_constraint.vector_shapes, dim
         )

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -129,6 +129,9 @@ def set_node_indices(
     print_ir_before: Sequence[str] = [],
     print_ir_after: Sequence[str] = [],
 ):
+    mma_mapping = get_mma_dimensional_mapping(
+        trace, get_hardware_constraint(constraints)
+    )
     trace.walk(partial(set_thread_independent_index, constraints))
 
     if (
@@ -143,9 +146,7 @@ def set_node_indices(
         print_trace(trace)
 
     graph_passes = []
-    if mma_mapping := get_mma_dimensional_mapping(
-        trace, get_hardware_constraint(constraints)
-    ):
+    if mma_mapping:
         graph_passes += [
             partial(
                 set_thread_dependent_index_from_mma, constraints, mma_mapping, trace

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -597,11 +597,13 @@ def get_reduce_mapping(
             assert (
                 len(wg_constraint) <= 1
             ), f"Multiple workgroup constraints for dimension {dim}"
-            if not wg_constraint:
-                continue
+            if wg_constraint:
+                workgroup_dim = wg_constraint[0].workgroup_dim
+            else:
+                workgroup_dim = 0
 
             index[dim] = hardware_constraint.apply_read_write_thread_mapping(
-                dim, wg_constraint[0].workgroup_dim, elements_per_thread, stride
+                dim, workgroup_dim, elements_per_thread, stride
             )
 
         reduce_mapping[custom] = index

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -22,6 +22,7 @@ from ...ops.wave_ops import (
 from ..constraints import (
     Constraint,
     HardwareConstraint,
+    ThreadConstraint,
     TilingConstraint,
     WorkgroupConstraint,
 )
@@ -517,7 +518,7 @@ def set_thread_dependent_index_from_read_write(
 
     visited = set()
     workgroup_constraints = [
-        c for c in constraints if isinstance(c, WorkgroupConstraint)
+        c for c in constraints if isinstance(c, (WorkgroupConstraint, ThreadConstraint))
     ]
     symbolic_constraints = [c for c in constraints if isinstance(c, SymbolicAlias)]
     for source in sources:

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -153,7 +153,6 @@ def set_node_indices(
             )
         ]
     elif reduce_mapping := get_reduce_mapping(trace, constraints):
-        print(reduce_mapping)
         graph_passes += [
             partial(
                 set_thread_dependent_index_from_reduce,

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -587,12 +587,6 @@ def get_reduce_mapping(
             ), f"Multiple workgroup constraints for dimension {dim}"
             if wg_constraint:
                 workgroup_dim = wg_constraint[0].workgroup_dim
-                if workgroup_dim == 0:
-                    # Skip the first dimension as it is the reduction dimension.
-                    # sometimes we want to distribute reduction across the threads, and
-                    # distribute something else across wg0 blocks but not threads.
-                    # There is no way to express this in the current constraint framework.
-                    continue
             else:
                 continue
 

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -460,23 +460,20 @@ class TilingConstraint(Constraint):
 
 @dataclass
 class ThreadConstraint(Constraint):
+    """
+    A constraint of the form `tkw.ThreadConstraint(M, 0)`
+    specifies that we want to distribute dimension M along thread dim 0.
+    This translates to an index constraint for all tensors of the
+    shape [M, ?] -> index += (thread_id_0, 0)
+    """
+
     dim: IndexExpr
-    workgroup_dim: int
+    workgroup_dim: int  # Used by `populate_read_write_source_indices`
 
     def apply(self) -> IndexSequence:
+        # `apply` is called during thread-independent index sequence
+        # initialization. We don't need to do anything here.
         return IndexSequence(0, 1)
-
-    def apply_read_write_thread_mapping(
-        self,
-        dim: IndexSymbol,
-        workgroup_dim: int,
-        elements_per_thread: int | IndexSymbol,
-        stride: int,
-    ) -> IndexSequence:
-        thread_id = [THREAD_0, THREAD_1, THREAD_2][self.workgroup_dim]
-        return IndexSequence(
-            thread_id * elements_per_thread, elements_per_thread, stride
-        )
 
 
 @dataclass

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -485,9 +485,6 @@ class TilingConstraint(DistributionConstraint):
         if self.hw_constraint is None:
             raise ValueError("Hardware constraint not set")
 
-        # Reduction loops are distributed across threads, so if tile size is
-        # less than threads_per_wave, we need to add padding to the work_bound to
-        # avoid threads from accessing OOB.
         threads_per_wave = self.hw_constraint.threads_per_wave
         tile_size = self.tile_size
         return (

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Callable
-from sympy import ceiling, Piecewise, floor, Integer, Max
+from sympy import ceiling, Piecewise, floor, Integer
 
 from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence
 from .._support.dtype import DataType
@@ -452,7 +452,6 @@ class TilingConstraint(DistributionConstraint):
     induction_var: Optional[IndexExpr] = None
     iters: Optional[IndexExpr] = None
     start: IndexExpr = Integer(0)
-    hw_constraint: Optional[HardwareConstraint] = None
 
     def __eq__(self, value):
         if not isinstance(value, TilingConstraint):
@@ -482,14 +481,7 @@ class TilingConstraint(DistributionConstraint):
 
     @property
     def work_bound(self) -> IndexExpr:
-        if self.hw_constraint is None:
-            raise ValueError("Hardware constraint not set")
-
-        threads_per_wave = self.hw_constraint.threads_per_wave
-        tile_size = self.tile_size
-        return (
-            self.start + self.count * tile_size + Max(threads_per_wave - tile_size, 0)
-        )
+        return self.start + self.count * self.tile_size
 
 
 @dataclass

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -490,7 +490,10 @@ class ThreadConstraint(DistributionConstraint):
     A constraint of the form `tkw.ThreadConstraint(M, 0)`
     specifies that we want to distribute dimension M along thread dim 0.
     This translates to an index constraint for all tensors of the
-    shape [M, ?] -> index += (thread_id_0, 0)
+    shape [M, ?] -> index += (thread_id_0, 0).
+
+    This is useful when we want to distribute tiled reduction loop without
+    mma across threads.
     """
 
     dim: IndexExpr

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -485,6 +485,9 @@ class TilingConstraint(DistributionConstraint):
         if self.hw_constraint is None:
             raise ValueError("Hardware constraint not set")
 
+        # Reduction loops are distributed across threads, so if tile size is
+        # less than threads_per_wave, we need to add padding to the work_bound to
+        # avoid threads from accessing OOB.
         threads_per_wave = self.hw_constraint.threads_per_wave
         tile_size = self.tile_size
         return (

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -263,18 +263,6 @@ class HardwareConstraint(Constraint):
             if isinstance(vector_size, IndexExpr):
                 self.vector_shapes[vector_dim] = vector_size.subs(index_map)
 
-    def compute_access_pattern_using_vector_shapes(
-        self,
-        dim: IndexSymbol,
-        workgroup_dim: int,
-        elements_per_thread: int | IndexSymbol,
-        stride: int,
-    ) -> IndexSequence:
-        thread_id = self.get_thread_id_from_workgroup_dim(workgroup_dim)
-        return IndexSequence(
-            thread_id * elements_per_thread, elements_per_thread, stride
-        )
-
     def apply(self):
         assert False, "Call either apply_read_write_thread_mapping or apply_mma_mapping"
 
@@ -476,8 +464,19 @@ class ThreadConstraint(Constraint):
     workgroup_dim: int
 
     def apply(self) -> IndexSequence:
+        return IndexSequence(0, 1)
+
+    def apply_read_write_thread_mapping(
+        self,
+        dim: IndexSymbol,
+        workgroup_dim: int,
+        elements_per_thread: int | IndexSymbol,
+        stride: int,
+    ) -> IndexSequence:
         thread_id = [THREAD_0, THREAD_1, THREAD_2][self.workgroup_dim]
-        return IndexSequence(thread_id, 1)
+        return IndexSequence(
+            thread_id * elements_per_thread, elements_per_thread, stride
+        )
 
 
 @dataclass

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Callable
-from sympy import ceiling, Piecewise, floor, Integer
+from sympy import ceiling, Piecewise, floor, Integer, Max
 
 from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence
 from .._support.dtype import DataType
@@ -452,6 +452,7 @@ class TilingConstraint(DistributionConstraint):
     induction_var: Optional[IndexExpr] = None
     iters: Optional[IndexExpr] = None
     start: IndexExpr = Integer(0)
+    hw_constraint: Optional[HardwareConstraint] = None
 
     def __eq__(self, value):
         if not isinstance(value, TilingConstraint):
@@ -481,7 +482,14 @@ class TilingConstraint(DistributionConstraint):
 
     @property
     def work_bound(self) -> IndexExpr:
-        return self.start + self.count * self.tile_size
+        if self.hw_constraint is None:
+            raise ValueError("Hardware constraint not set")
+
+        threads_per_wave = self.hw_constraint.threads_per_wave
+        tile_size = self.tile_size
+        return (
+            self.start + self.count * tile_size + Max(threads_per_wave - tile_size, 0)
+        )
 
 
 @dataclass

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -471,6 +471,16 @@ class TilingConstraint(Constraint):
 
 
 @dataclass
+class ThreadConstraint(Constraint):
+    dim: IndexExpr
+    workgroup_dim: int
+
+    def apply(self) -> IndexSequence:
+        thread_id = [THREAD_0, THREAD_1, THREAD_2][self.workgroup_dim]
+        return IndexSequence(thread_id, 1)
+
+
+@dataclass
 class WaveConstraint(Constraint):
     """
     A constraint of the form `tkw.WaveConstraint(K, WAVE_K)` specifies
@@ -510,7 +520,7 @@ class WaveConstraint(Constraint):
     def set_wave_id_from_hardware_and_workgroup_constraint(
         self,
         hardware_constraint: HardwareConstraint,
-        workgroup_constraint: WorkgroupConstraint,
+        workgroup_constraint: WorkgroupConstraint | ThreadConstraint,
     ):
         """
         The wave_id is the same as the thread_id, with the exception of

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -145,10 +145,10 @@ def align_index_vars(
     need partial reads/writes.
     """
     key_subs = {
-        c.dim: (c.count * c.tile_size)
+        c.dim: (c.work_bound)
         for c in constraints
-        if isinstance(c, (TilingConstraint, WorkgroupConstraint))
-        and subs_idxc(c.dim) != subs_idxc(c.count * c.tile_size)
+        if isinstance(c, DistributionConstraint)
+        and subs_idxc(c.dim) != subs_idxc(c.work_bound)
     }
     return {safe_subs(key, key_subs): index[key] for key in index}
 

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -18,6 +18,7 @@ from ...ops.wave_ops import CustomOp, Read, Reduction, Write
 from ..assumptions import Assumption
 from ..constraints import (
     Constraint,
+    DistributionConstraint,
     HardwareConstraint,
     TilingConstraint,
     WorkgroupConstraint,
@@ -157,14 +158,14 @@ def find_index_bounds(
 ) -> Optional[list[IndexExpr]]:
     bounds = []
     for constraint in constraints:
-        if not isinstance(constraint, (WorkgroupConstraint, TilingConstraint)):
+        if not isinstance(constraint, DistributionConstraint):
             continue
 
         dim = constraint.dim
         if dim not in index:
             continue
 
-        work_size = constraint.count * constraint.tile_size
+        work_size = constraint.work_bound
         if subs_idxc(work_size) == subs_idxc(dim):
             continue
 

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -271,6 +271,9 @@ class LaunchableWave(Launchable):
         """
 
         hardware_constraint = self.hardware_constraints[0]
+        for thread_constraint in self.thread_constraints:
+            thread_constraint.hw_constraint = hardware_constraint
+
         for wave_constraint in self.wave_constraints:
             for workgroup_constraint in (
                 self.workgroup_constraints + self.thread_constraints

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -262,13 +262,8 @@ class LaunchableWave(Launchable):
         """
 
         hardware_constraint = self.hardware_constraints[0]
-        for thread_constraint in self.thread_constraints:
-            thread_constraint.hw_constraint = hardware_constraint
-
         for wave_constraint in self.wave_constraints:
-            for workgroup_constraint in (
-                self.workgroup_constraints + self.thread_constraints
-            ):
+            for workgroup_constraint in self.workgroup_constraints:
                 if wave_constraint.dim == workgroup_constraint.dim:
                     wave_constraint.set_wave_id_from_hardware_and_workgroup_constraint(
                         hardware_constraint, workgroup_constraint

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -262,9 +262,6 @@ class LaunchableWave(Launchable):
         """
 
         hardware_constraint = self.hardware_constraints[0]
-        for tiling_constraint in self.tiling_constraints:
-            tiling_constraint.hw_constraint = hardware_constraint
-
         for wave_constraint in self.wave_constraints:
             for workgroup_constraint in self.workgroup_constraints:
                 if wave_constraint.dim == workgroup_constraint.dim:

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -26,7 +26,6 @@ from .codegen import WaveEmitter
 from .constraints import (
     Constraint,
     HardwareConstraint,
-    ThreadConstraint,
     TilingConstraint,
     WaveConstraint,
     WorkgroupConstraint,
@@ -178,14 +177,6 @@ class LaunchableWave(Launchable):
             constraint
             for constraint in self.constraints
             if isinstance(constraint, WorkgroupConstraint)
-        ]
-
-    @property
-    def thread_constraints(self) -> list[ThreadConstraint]:
-        return [
-            constraint
-            for constraint in self.constraints
-            if isinstance(constraint, ThreadConstraint)
         ]
 
     @property

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -262,6 +262,9 @@ class LaunchableWave(Launchable):
         """
 
         hardware_constraint = self.hardware_constraints[0]
+        for tiling_constraint in self.tiling_constraints:
+            tiling_constraint.hw_constraint = hardware_constraint
+
         for wave_constraint in self.wave_constraints:
             for workgroup_constraint in self.workgroup_constraints:
                 if wave_constraint.dim == workgroup_constraint.dim:

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -26,6 +26,7 @@ from .codegen import WaveEmitter
 from .constraints import (
     Constraint,
     HardwareConstraint,
+    ThreadConstraint,
     TilingConstraint,
     WaveConstraint,
     WorkgroupConstraint,
@@ -180,6 +181,14 @@ class LaunchableWave(Launchable):
         ]
 
     @property
+    def thread_constraints(self) -> list[ThreadConstraint]:
+        return [
+            constraint
+            for constraint in self.constraints
+            if isinstance(constraint, ThreadConstraint)
+        ]
+
+    @property
     def tiling_constraints(self) -> list[TilingConstraint]:
         return [
             constraint
@@ -263,7 +272,9 @@ class LaunchableWave(Launchable):
 
         hardware_constraint = self.hardware_constraints[0]
         for wave_constraint in self.wave_constraints:
-            for workgroup_constraint in self.workgroup_constraints:
+            for workgroup_constraint in (
+                self.workgroup_constraints + self.thread_constraints
+            ):
                 if wave_constraint.dim == workgroup_constraint.dim:
                     wave_constraint.set_wave_id_from_hardware_and_workgroup_constraint(
                         hardware_constraint, workgroup_constraint

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1354,7 +1354,6 @@ def test_tiled_reduce_min():
     N = tkl.sym.N
     BLOCK_M = tkl.sym.BLOCK_M
     BLOCK_N = tkl.sym.BLOCK_N
-    ELEMS_PER_THREAD = tkl.sym.ELEMS_PER_THREAD
     ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
 
     constraints: list[tkw.Constraint] = [
@@ -1380,13 +1379,13 @@ def test_tiled_reduce_min():
         def repeat(
             partial_min: tkl.Register[M, tkl.f16],
         ) -> tkl.Register[M, tkl.f16]:
-            lhs = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
-            rhs = tkw.read(b, elements_per_thread=ELEMS_PER_THREAD)
+            lhs = tkw.read(a)
+            rhs = tkw.read(b)
             res = lhs * rhs
             partial_min = tkw.min(res, partial_min, dim=N)
             return partial_min
 
-        tkw.write(repeat, c, elements_per_thread=1)
+        tkw.write(repeat, c)
 
     shape = (256, 512)
     options = WaveCompileOptions(
@@ -1395,7 +1394,6 @@ def test_tiled_reduce_min():
             N: shape[1],
             BLOCK_M: 1,
             BLOCK_N: 128,
-            ELEMS_PER_THREAD: 2,
             ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
         },
         canonicalize=True,
@@ -1447,7 +1445,6 @@ def test_tiled_reduce_min_unaligned():
     N = tkl.sym.N
     BLOCK_M = tkl.sym.BLOCK_M
     BLOCK_N = tkl.sym.BLOCK_N
-    ELEMS_PER_THREAD = tkl.sym.ELEMS_PER_THREAD
     ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
 
     constraints: list[tkw.Constraint] = [
@@ -1473,13 +1470,13 @@ def test_tiled_reduce_min_unaligned():
         def repeat(
             partial_min: tkl.Register[M, tkl.f16],
         ) -> tkl.Register[M, tkl.f16]:
-            lhs = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
-            rhs = tkw.read(b, elements_per_thread=ELEMS_PER_THREAD)
+            lhs = tkw.read(a)
+            rhs = tkw.read(b)
             res = lhs * rhs
             partial_min = tkw.min(res, partial_min, dim=N)
             return partial_min
 
-        tkw.write(repeat, c, elements_per_thread=1)
+        tkw.write(repeat, c)
 
     shape = (256, 527)
     options = WaveCompileOptions(
@@ -1488,7 +1485,6 @@ def test_tiled_reduce_min_unaligned():
             N: shape[1],
             BLOCK_M: 1,
             BLOCK_N: 128,
-            ELEMS_PER_THREAD: 2,
             ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
         },
         canonicalize=True,

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1460,7 +1460,6 @@ def test_tiled_reduce_min_unaligned():
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
-    constraints += [tkw.ThreadConstraint(N, 0)]
     constraints += [tkw.TilingConstraint(N, BLOCK_N)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1099,7 +1099,7 @@ def test_toy_online_softmax(shape):
             M: shape[0],
             N: shape[1],
             BLOCK_N: min(128, shape[1]),
-            ELEMS_PER_THREAD: min(128, shape[1]) // wave_size,
+            ELEMS_PER_THREAD: ceildiv(min(128, shape[1]), wave_size),
             ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
         },
         canonicalize=True,

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1056,10 +1056,8 @@ def test_toy_online_softmax(shape):
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
-    constraints += [tkw.ThreadConstraint(N, 0)]
     constraints += [tkw.TilingConstraint(N, BLOCK_N)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]
-    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
 
     @tkw.wave(constraints)
     def test(

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1056,7 +1056,6 @@ def test_toy_online_softmax(shape):
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
-    # constraints += [tkw.WorkgroupConstraint(N, N, 0)]
     constraints += [tkw.ThreadConstraint(N, 0)]
     constraints += [tkw.TilingConstraint(N, BLOCK_N)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -71,15 +71,6 @@ def get_test_shapes(test_name: str) -> list[tuple[int]]:
     return default_test_shapes
 
 
-def xfail_unaligned(func):
-    def wrapper(shape):
-        if shape[-1] % 2 != 0:
-            pytest.xfail("Unaligned shape is not expected to work on this test yet.")
-        func(shape)
-
-    return wrapper
-
-
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_copy")[:1])
 def test_dump_vmfb(shape, tmp_path, request):
@@ -1048,7 +1039,6 @@ def test_reduce_sum(shape, request):
 
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_tiled_reduce_max"))
-@xfail_unaligned
 def test_toy_online_softmax(shape):
     M = tkl.sym.M
     N = tkl.sym.N

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1050,7 +1050,7 @@ def test_toy_online_softmax(shape):
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
-            threads_per_wave=64,
+            threads_per_wave=wave_size,
             waves_per_block=(1, 1, 1),
             vector_shapes={M: 1, N: BLOCK_N},
         )
@@ -1095,7 +1095,7 @@ def test_toy_online_softmax(shape):
         subs={
             M: shape[0],
             N: shape[1],
-            BLOCK_N: min(128, shape[1]),
+            BLOCK_N: max(min(128, shape[1]), wave_size),
             ELEMS_PER_THREAD: ceildiv(min(128, shape[1]), wave_size),
             ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
         },

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1066,7 +1066,8 @@ def test_toy_online_softmax(shape):
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
-    constraints += [tkw.WorkgroupConstraint(N, N, 0)]
+    # constraints += [tkw.WorkgroupConstraint(N, N, 0)]
+    constraints += [tkw.ThreadConstraint(N, 0)]
     constraints += [tkw.TilingConstraint(N, BLOCK_N)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]
     constraints += [tkw.WaveConstraint(N, BLOCK_N)]


### PR DESCRIPTION
* If we kernel doesnt have `mma`s but have reduce ops use them to determine ops indexing.
* `tkw.WorkgroupConstraint(N, N, 0)` hack is no longer needed as reduce nodes inside reduction loop will automatically distributed across threads.
* Fix `test_toy_online_softmax` for unaligned shapes.
* Refactor constraints and introduce `DistributionConstraint` base class.