### PR TITLE
[Wave] Add missing header

### DIFF
--- a/iree/turbine/kernel/wave/runtime/CMakeLists.txt
+++ b/iree/turbine/kernel/wave/runtime/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Copyright 2025 The IREE Authors
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 cmake_minimum_required(VERSION 3.15...3.27)
 project(wave_runtime)
 


### PR DESCRIPTION
This PR adds the copyright header to the wave runtime CMakeLists.txt.