### PR TITLE
[Wave] Make it possible for waves to be distributed in multiple dimensions

### DIFF
--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -115,8 +115,14 @@ class HardwareConstraint(Constraint):
             self.threads_per_block = (
                 self.waves_per_block[0] * self.threads_per_wave,
             ) + self.waves_per_block[1:]
-        assert math.prod(self.threads_per_block) == self.threads_per_wave * math.prod(
-            self.waves_per_block
+        total_threads_per_block = math.prod(self.threads_per_block)
+        total_waves_per_block = math.prod(self.waves_per_block)
+        expected_threads_per_block = self.threads_per_wave * total_waves_per_block
+        assert (
+            total_threads_per_block == self.threads_per_wave * total_waves_per_block
+        ), (
+            f"Invalid constraints: prod({self.threads_per_block}) = {total_threads_per_block} but must"
+            f" equal {self.threads_per_wave} * prod({self.waves_per_block}) = {expected_threads_per_block}"
         )
 
     def max_elems_per_load(self, element_type: DataType) -> int:

--- a/tests/kernel/wave/common/utils.py
+++ b/tests/kernel/wave/common/utils.py
@@ -4,8 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import pytest
 import os
+import pathlib
+
+import pytest
 from iree.turbine.kernel.wave.utils.run_utils import (
     get_default_arch,
 )
@@ -25,11 +27,29 @@ require_cdna3 = pytest.mark.skipif(
 )
 # Whether to dump the generated MLIR module.
 dump_generated_mlir = int(os.environ.get("WAVE_DUMP_MLIR", 0))
+
+
+def maybe_dump_mlir(asm, test_name):
+    if not dump_generated_mlir:
+        return
+
+    test_name = (
+        test_name.removeprefix("test_").strip("[]").replace("[", "_").replace("]", "_")
+    )
+    path = pathlib.Path(f"out/wave_{test_name}.mlir")
+    path.write_text(asm)
+    print(f"MLIR dumped to {path}")
+
+
 # Whether to use scheduling group barriers (needs LLVM fix).
 enable_scheduling_barriers = int(os.environ.get("WAVE_USE_SCHED_BARRIERS", 0))
 
 # Add test shapes for validation and performance testing.
 perf_test = lambda *a: pytest.param(*a, marks=pytest.mark.perf_only)
+
+
+def format_shape(shape: tuple[int, ...]):
+    return "x".join([str(dim) for dim in shape])
 
 
 def param_bool(name, shortname=None, values=None):


### PR DESCRIPTION
Right now, threads within a wave are always distributed so that there are 64 threads along the x dimension. This creates confusing behavior for kernels that are naturally multi-dimensional. I've removed this hardcoding and instead made that the *default* behavior with the ability for the user to specify other distributions. I've included tests of multi-dimensional copies that weren't possible otherwise.

Fixes https://github.com/iree-org/iree-turbine/issues/643