### PR TITLE
[Wave][Cache] Add caching support for nested functions

### DIFF
--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -96,7 +96,7 @@ def get_nested_functions(root_fn: Callable):
     """Simple BFS search to get all sub functions inside a wave kernel."""
     workqueue = deque([root_fn])
     fn_list = set([root_fn])
-    while len(workqueue) > 0:
+    while workqueue:
         cur_fn = workqueue.pop()
         # Add var to workqueue and fn_list freevar that
         # we have not seen before and who's type is a function.

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -15,7 +15,7 @@ import shutil
 import threading
 import math
 
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from dataclasses import dataclass, asdict
 from pathlib import Path
 import functools
@@ -88,8 +88,26 @@ def extract_free_vars(kernel_fn: Callable):
     return [
         (k, v)
         for k, v in inspect.getclosurevars(kernel_fn).nonlocals.items()
-        if not isinstance(v, IndexMapping)
+        if not isinstance(v, (IndexMapping, Callable))
     ]
+
+
+def get_nested_functions(root_fn: Callable):
+    """Simple BFS search to get all sub functions inside a wave kernel."""
+    workqueue = deque([root_fn])
+    fn_list = set([root_fn])
+    while len(workqueue) > 0:
+        cur_fn = workqueue.pop()
+        # Add var to workqueue and fn_list freevar that
+        # we have not seen before and who's type is a function.
+        sub_fns = [
+            f
+            for f in inspect.getclosurevars(cur_fn).nonlocals.values()
+            if inspect.isfunction(f) and f not in fn_list
+        ]
+        fn_list.update(sub_fns)
+        workqueue.extend(sub_fns)
+    return fn_list
 
 
 def anonymize_constraints(input_constraints: list[Constraint]):
@@ -145,28 +163,31 @@ class WaveCacheManager(object):
         """
         Get a unique identifier for a given kernel.
         """
-        try:
-            kernel_src = inspect.getsource(kernel_fn)
-            index_mappings = extract_mappings(kernel_fn)
-            arg_dtypes = extract_arg_types(kernel_fn)
-            free_vars = extract_free_vars(kernel_fn)
-        except:
-            # sets kernel_hash as None if fail to inspect source.
-            # We also taught load_kernel and store_kernel to skip
-            # if kernel_hash is None.
-            return None
-        processed_constraints = anonymize_constraints(constraints)
-        key = [
-            kernel_src,
-            processed_constraints,
-            options.subs,
-            options.dynamic_symbols,
-            options.schedule,
-            options.use_scheduling_barriers,
-            index_mappings,
-            arg_dtypes,
-            free_vars,
-        ]
+        fns = get_nested_functions(kernel_fn)
+        key = []
+        for fn in fns:
+            try:
+                kernel_src = inspect.getsource(kernel_fn)
+                index_mappings = extract_mappings(kernel_fn)
+                arg_dtypes = extract_arg_types(kernel_fn)
+                free_vars = extract_free_vars(kernel_fn)
+            except:
+                # sets kernel_hash as None if fail to inspect source.
+                # We also taught load_kernel and store_kernel to skip
+                # if kernel_hash is None.
+                return None
+            processed_constraints = anonymize_constraints(constraints)
+            key += [
+                kernel_src,
+                processed_constraints,
+                options.subs,
+                options.dynamic_symbols,
+                options.schedule,
+                options.use_scheduling_barriers,
+                index_mappings,
+                arg_dtypes,
+                free_vars,
+            ]
 
         # Benchmark related hash
         if options.run_bench:

--- a/tests/kernel/wave/runtime/cache_test.py
+++ b/tests/kernel/wave/runtime/cache_test.py
@@ -18,6 +18,7 @@ import math
 import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
+import sympy
 
 from iree.turbine.kernel.wave.cache import (
     is_cache_enabled,
@@ -613,3 +614,89 @@ def testSameConfigDifferentFreeVar(request):
     assert (
         len(cache_manager.session_cache) == 2
     ), "Expected len == 2, after caching second kernel."
+
+
+# This test is important to check two things:
+# 1. We can cache nested functions
+# 2. We do not cache if function signature is different even though
+#    core is same.
+
+
+@require_e2e
+@require_cache
+def testDifferentSignatureSameCore():
+    reset_cache_manager()
+    shape = [256, 256]
+    M = tkl.sym.M
+    N = tkl.sym.N
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Each workgroup works on single row of input data, and rows are further
+    # split into blocks of size up to 256. We have single wave per WG,
+    # and with default wave size of 64, each thread is operating on up to 4
+    # elements.
+    wave_size = 64
+    BLOCK_M = 1
+    # Tile size cannot be dynamic, so we use a fixed value here.
+    BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
+    ELEMS_PER_THREAD = BLOCK_N // wave_size
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: BLOCK_M, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    def add(a, b):
+        return a + b
+
+    def core(a):
+        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+        double = add(res, res)
+        tkw.write(double, a, elements_per_thread=ELEMS_PER_THREAD)
+
+    @tkw.wave(constraints)
+    def double(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
+        core(a)
+
+    @tkw.wave(constraints)
+    def double_transpose(a: tkl.Memory[N, M, ADDRESS_SPACE, tkl.f16]):
+        core(a)
+
+    cache_manager = get_cache_manager()
+    options = WaveCompileOptions(
+        subs={
+            M: shape[0],
+            N: shape[1],
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+    )
+    options = set_default_run_config(options)
+    assert (
+        len(cache_manager.session_cache) == 0
+    ), "Expected len == 0, before any compilation of kernel."
+
+    double0_fn = wave_compile(options, double)
+    assert (
+        len(cache_manager.session_cache) == 1
+    ), "Expected len == 1, after caching first kernel."
+
+    double1_fn = wave_compile(options, double)
+    # This used to break because in nested function,
+    # the nested fn pointer become a freevar, making us
+    # recompile every time.
+    assert (
+        len(cache_manager.session_cache) == 1
+    ), "Expected len == 1, since it's same kernel."
+
+    doubleT_0_fn = wave_compile(options, double_transpose)
+    assert (
+        len(cache_manager.session_cache) == 2
+    ), "Expected len == 2, since despite same core, it has different signature."


### PR DESCRIPTION
Currently, we are caching nested function as freevars which is detected in getclosurevars. However we are only caching it's function pointer which means every time we have a nested function inside wave kernel, it will recompile every single time since it has a different function pointer.

Even worse, the kernel defintion that we have cached for these nested functions are often just something like:
```
    @tkw.wave(constraints)
    def base_attention(
        q: tkl.Memory[B, N_Q, D_Q, GLOBAL_ADDRESS_SPACE, LOGIT_DTYPE],
        k: tkl.Memory[B, N_KV, D_Q, ADDRESS_SPACE, LOGIT_DTYPE],
        v: tkl.Memory[B, N_KV, D_KV, ADDRESS_SPACE, LOGIT_DTYPE],
        c: tkl.Memory[B, N_Q, D_KV, GLOBAL_ADDRESS_SPACE, tkl.f32],
    ):
        base_attention_core(q, k, v, c)
```

Which is very incomplete since we do not know what is inside base_attention_core and could change between different functions.

To solve this, we added a simple BFS search that detects all subfunctions, and then we just accumulate all these function's generated key to compute the final key. This way we can solve/cache all sorts of nested function.