### PR TITLE
[TKW] Infer `elements_per_thread` for elementwise ops

### DIFF
--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -317,16 +317,19 @@ def populate_read_write_source_indices(
             else node.elements_per_thread
         )
 
-        stride = compute_stride(
-            node.indexing_dims, hardware_constraint.vector_shapes, dim
-        )
         wg_constraint = [x for x in workgroup_constraints if x.dim == dim]
 
         assert len(wg_constraint) <= 1, f"Multiple workgroup constraints for dim {dim}"
         if not wg_constraint:
             continue
 
+        stride = compute_stride(
+            node.indexing_dims, hardware_constraint.vector_shapes, dim
+        )
+
         wg_dim = wg_constraint[0].workgroup_dim
+        assert wg_dim <= 2, f"Only support up to 3 workgroups for now, got {wg_dim}"
+
         if elements_per_thread is None:
             tile_size = wg_constraint[0].tile_size
             threads_count = hardware_constraint.threads_per_block[wg_dim]

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -47,6 +47,7 @@ from ..utils.print_utils import (
     try_apply_pass,
 )
 import torch.fx as fx
+import sympy
 from typing import Sequence, Callable, Optional
 from ....support.logging import get_logger
 from copy import deepcopy, copy
@@ -316,19 +317,23 @@ def populate_read_write_source_indices(
             else node.elements_per_thread
         )
 
-        if elements_per_thread is None:
-            raise ValueError(
-                f"Elements per thread not set for {node} with indexing dim {dim}"
-            )
-
         stride = compute_stride(
             node.indexing_dims, hardware_constraint.vector_shapes, dim
         )
         wg_constraint = [x for x in workgroup_constraints if x.dim == dim]
+
+        assert len(wg_constraint) <= 1, f"Multiple workgroup constraints for dim {dim}"
         if not wg_constraint:
             continue
+
+        wg_dim = wg_constraint[0].workgroup_dim
+        if elements_per_thread is None:
+            tile_size = wg_constraint[0].tile_size
+            threads_count = hardware_constraint.threads_per_block[wg_dim]
+            elements_per_thread = sympy.Max(sympy.ceiling(tile_size / threads_count), 1)
+
         index[dim] = hardware_constraint.apply_read_write_thread_mapping(
-            dim, wg_constraint[0].workgroup_dim, elements_per_thread, stride
+            dim, wg_dim, elements_per_thread, stride
         )
     return [(node, index, hardware_constraint.vector_shapes)]
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -69,7 +69,7 @@ def test_read():
 
     @tkw.wave(constraints)
     def read(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
-        tkw.read(a, elements_per_thread=16)
+        tkw.read(a)
 
     read = wave_compile(get_wave_compile_options(), read)
     print(read.asm)
@@ -221,8 +221,8 @@ def test_read_write():
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=16)
-        tkw.write(res, b, elements_per_thread=16)
+        res = tkw.read(a)
+        tkw.write(res, b)
 
     read_write = wave_compile(get_wave_compile_options(canonicalize=True), read_write)
     print(read_write.asm)
@@ -279,7 +279,7 @@ def test_read_write_diagonal():
         m_index = tkw.broadcast(m_index, target_shape=[M, N])
         n_index = tkw.self_index(N, tkl.i64)
         res = tkw.select(m_index >= n_index, ZEROF, ONEF)
-        tkw.write(res, c, elements_per_thread=16)
+        tkw.write(res, c)
 
     read_write_diagonal = wave_compile(
         get_wave_compile_options(canonicalize=True), read_write_diagonal
@@ -337,8 +337,8 @@ def test_read_write_masked():
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=4)
-        tkw.write(res, b, elements_per_thread=4)
+        res = tkw.read(a)
+        tkw.write(res, b)
 
     options = WaveCompileOptions(
         subs={
@@ -409,8 +409,8 @@ def test_read_write_masked_shared():
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=4)
-        tkw.write(res, b, elements_per_thread=4)
+        res = tkw.read(a)
+        tkw.write(res, b)
 
     options = WaveCompileOptions(
         subs={
@@ -458,8 +458,8 @@ def test_read_write_mapping():
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[N, M, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=16)
-        tkw.write(res, b, mapping=mapping, elements_per_thread=16)
+        res = tkw.read(a)
+        tkw.write(res, b, mapping=mapping)
 
     read_write_mapping = wave_compile(
         get_wave_compile_options(canonicalize=True), read_write_mapping
@@ -521,14 +521,13 @@ def test_read_write_dynamic_mapping():
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=16)
+        offset = tkw.read(off)
         res = tkw.read(
             a,
             mapping=mapping,
             mapping_dynamic_vals=(offset,),
-            elements_per_thread=16,
         )
-        tkw.write(res, b, elements_per_thread=16)
+        tkw.write(res, b)
 
     read_write_dynamic_mapping = wave_compile(
         get_wave_compile_options(canonicalize=True), read_write_dynamic_mapping
@@ -589,14 +588,13 @@ def test_read_write_dynamic_mapping_broadcast():
         off: tkl.Memory[M, ONE, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=1)
+        offset = tkw.read(off)
         res = tkw.read(
             a,
             mapping=mapping,
             mapping_dynamic_vals=(offset,),
-            elements_per_thread=16,
         )
-        tkw.write(res, b, elements_per_thread=16)
+        tkw.write(res, b)
 
     read_write_dynamic_mapping_broadcast = wave_compile(
         get_wave_compile_options(canonicalize=True, additional_symbols={ONE: 1}),
@@ -651,20 +649,18 @@ def test_read_write_dynamic_mapping_chain():
         off2: tkl.Memory[M, SIZE2, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset1 = tkw.read(off1, elements_per_thread=1)
+        offset1 = tkw.read(off1)
         offset2 = tkw.read(
             off2,
             mapping=mapping1,
             mapping_dynamic_vals=(offset1,),
-            elements_per_thread=1,
         )
         res = tkw.read(
             a,
             mapping=mapping2,
             mapping_dynamic_vals=(offset2,),
-            elements_per_thread=4,
         )
-        tkw.write(res, b, elements_per_thread=4)
+        tkw.write(res, b)
 
     read_write_dynamic_mapping_chain = wave_compile(
         get_wave_compile_options(
@@ -720,14 +716,13 @@ def test_read_write_dynamic_symbol():
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=1)
+        offset = tkw.read(off)
         tkw.set_symbol(S, offset)
         res = tkw.read(
             a,
             mapping=mapping,
-            elements_per_thread=1,
         )
-        tkw.write(res, b, elements_per_thread=1)
+        tkw.write(res, b)
 
     test_dyn_symbol = wave_compile(
         get_wave_compile_options(
@@ -782,15 +777,14 @@ def test_read_write_dynamic_symbol_expr():
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=1)
+        offset = tkw.read(off)
         offset = tkw.apply_expr(offset, lambda a: M - a - 1)
         tkw.set_symbol(S, offset)
         res = tkw.read(
             a,
             mapping=mapping,
-            elements_per_thread=1,
         )
-        tkw.write(res, b, elements_per_thread=1)
+        tkw.write(res, b)
 
     test_dyn_expr = wave_compile(
         get_wave_compile_options(
@@ -943,7 +937,7 @@ def test_add_float():
 
     @tkw.wave(constraints)
     def add(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
-        a_reg = tkw.read(a, elements_per_thread=16)
+        a_reg = tkw.read(a)
         res = a_reg + a_reg
 
     add = wave_compile(get_wave_compile_options(), add)
@@ -968,7 +962,7 @@ def test_add_integer():
 
     @tkw.wave(constraints)
     def test(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32]):
-        a_reg = tkw.read(a, elements_per_thread=16)
+        a_reg = tkw.read(a)
         res = a_reg + a_reg
 
     test = wave_compile(get_wave_compile_options(), test)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -151,7 +151,6 @@ def test_copy(shape, use_buffer_ops, request):
     BLOCK_M = 1
     # Tile size cannot be dynamic, so we use a fixed value here.
     BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -170,8 +169,8 @@ def test_copy(shape, use_buffer_ops, request):
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        res = tkw.read(a)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape, dtype=torch.float16)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -95,7 +95,6 @@ def test_dump_vmfb(shape, tmp_path, request):
     BLOCK_M = 1
     # Tile size cannot be dynamic, so we use a fixed value here.
     BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -114,8 +113,8 @@ def test_dump_vmfb(shape, tmp_path, request):
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        res = tkw.read(a)
+        tkw.write(res, b)
 
     vmfb_file = tmp_path / "test.vmfb"
     options = WaveCompileOptions(
@@ -209,7 +208,6 @@ def test_dynamic_copy(shape, use_buffer_ops, request):
     BLOCK_M = 1
     # Tile size cannot be dynamic, so we use a fixed value here.
     BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -228,8 +226,8 @@ def test_dynamic_copy(shape, use_buffer_ops, request):
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        res = tkw.read(a)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape, dtype=torch.float16)
@@ -264,7 +262,6 @@ def test_transpose_read(shape, use_buffer_ops, request):
     wave_size = 64
     BLOCK_N = 1
     BLOCK_M = sympy.Max(sympy.Min(M, 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_M // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -289,8 +286,8 @@ def test_transpose_read(shape, use_buffer_ops, request):
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[N, M, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, mapping=mapping, elements_per_thread=ELEMS_PER_THREAD)
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        res = tkw.read(a, mapping=mapping)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape[::-1], dtype=torch.float16)
@@ -324,7 +321,6 @@ def test_transpose_write(shape, use_buffer_ops, request):
     wave_size = 64
     BLOCK_M = 1
     BLOCK_N = sympy.Max(sympy.Min(N, 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -349,8 +345,8 @@ def test_transpose_write(shape, use_buffer_ops, request):
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[N, M, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
-        tkw.write(res, b, mapping=mapping, elements_per_thread=ELEMS_PER_THREAD)
+        res = tkw.read(a)
+        tkw.write(res, b, mapping=mapping)
 
     a = device_randn(shape, dtype=torch.float16)
     b = device_zeros(shape[::-1], dtype=torch.float16)
@@ -389,7 +385,6 @@ def test_offset_read(shape, use_buffer_ops, request):
     BLOCK_M = 1
     # Tile size cannot be dynamic, so we use a fixed value here.
     BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -419,14 +414,13 @@ def test_offset_read(shape, use_buffer_ops, request):
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
+        offset = tkw.read(off)
         res = tkw.read(
             a,
             mapping=mapping,
             mapping_dynamic_vals=(offset,),
-            elements_per_thread=ELEMS_PER_THREAD,
         )
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     off = device_randint(shape[0], shape, dtype=torch.int32)
@@ -498,14 +492,13 @@ def test_offset_read_one(shape, use_buffer_ops, request):
         off: tkl.Memory[M, N1, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=1)
+        offset = tkw.read(off)
         res = tkw.read(
             a,
             mapping=mapping,
             mapping_dynamic_vals=(offset,),
-            elements_per_thread=ELEMS_PER_THREAD,
         )
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     count = int(ELEMS_PER_THREAD)
@@ -550,7 +543,6 @@ def test_read_write_same(shape, use_buffer_ops, request):
     BLOCK_M = 1
     # Tile size cannot be dynamic, so we use a fixed value here.
     BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -566,9 +558,9 @@ def test_read_write_same(shape, use_buffer_ops, request):
 
     @tkw.wave(constraints)
     def double(a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16]):
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+        res = tkw.read(a)
         double = res + res
-        tkw.write(double, a, elements_per_thread=ELEMS_PER_THREAD)
+        tkw.write(double, a)
 
     a = device_randn(shape, dtype=torch.float16)
     ref = a + a
@@ -610,7 +602,6 @@ def test_set_symbol(shape, request):
     # TODO: Only ELEMS_PER_THREAD == 1
     # BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
     BLOCK_N = wave_size
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -644,14 +635,13 @@ def test_set_symbol(shape, request):
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
+        offset = tkw.read(off)
         tkw.set_symbol(S, offset)
         res = tkw.read(
             a,
             mapping=mapping,
-            elements_per_thread=ELEMS_PER_THREAD,
         )
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     off = device_randint(shape[0], shape, dtype=torch.int32)
@@ -695,7 +685,6 @@ def test_apply_expr(shape, request):
     # TODO: Only ELEMS_PER_THREAD == 1
     # BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
     BLOCK_N = wave_size
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -729,15 +718,14 @@ def test_apply_expr(shape, request):
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
+        offset = tkw.read(off)
         offset = tkw.apply_expr(offset, lambda a: M - a - 1)
         tkw.set_symbol(S, offset)
         res = tkw.read(
             a,
             mapping=mapping,
-            elements_per_thread=ELEMS_PER_THREAD,
         )
-        tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+        tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     off = device_randint(shape[0], shape, dtype=torch.int32)
@@ -778,7 +766,6 @@ def test_conditional(shape, request):
     # TODO: Only ELEMS_PER_THREAD == 1
     # BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
     BLOCK_N = wave_size
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -798,14 +785,14 @@ def test_conditional(shape, request):
         mask: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
-        cond = tkw.read(mask, elements_per_thread=ELEMS_PER_THREAD)
+        res = tkw.read(a)
+        cond = tkw.read(mask)
 
         cond = tkw.apply_expr(cond, lambda a: a > 0)
 
         @tkw.conditional(cond)
         def then():
-            tkw.write(res, b, elements_per_thread=ELEMS_PER_THREAD)
+            tkw.write(res, b)
 
     a = device_randn(shape, dtype=torch.float16)
     mask = device_randint(2, shape, dtype=torch.int32)
@@ -843,7 +830,6 @@ def test_offset_write(shape, use_buffer_ops, request):
     BLOCK_M = 1
     # Tile size cannot be dynamic, so we use a fixed value here.
     BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
-    ELEMS_PER_THREAD = BLOCK_N // wave_size
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
@@ -873,14 +859,13 @@ def test_offset_write(shape, use_buffer_ops, request):
         off: tkl.Memory[M, N, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=ELEMS_PER_THREAD)
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+        offset = tkw.read(off)
+        res = tkw.read(a)
         tkw.write(
             res,
             b,
             mapping=mapping,
             mapping_dynamic_vals=(offset,),
-            elements_per_thread=ELEMS_PER_THREAD,
         )
 
     a = device_randn(shape, dtype=torch.float16)
@@ -960,14 +945,13 @@ def test_offset_write_one(shape, use_buffer_ops, request):
         off: tkl.Memory[M, N1, ADDRESS_SPACE, tkl.i32],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        offset = tkw.read(off, elements_per_thread=1)
-        res = tkw.read(a, elements_per_thread=ELEMS_PER_THREAD)
+        offset = tkw.read(off)
+        res = tkw.read(a)
         tkw.write(
             res,
             b,
             mapping=mapping,
             mapping_dynamic_vals=(offset,),
-            elements_per_thread=ELEMS_PER_THREAD,
         )
 
     a = device_randn(shape, dtype=torch.float16)


### PR DESCRIPTION
* Infer `elements_per_thread` for elementwise ops from tile size and num threads
* Some lit tests are not updated as they have suspicious `elements_per_thread` hardcoded