### PR TITLE
[BOO] add an autograd function for conv launchables

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/conv.py
+++ b/iree/turbine/kernel/boo/conv_exports/conv.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from typing import (
+    Any,
     List,
     NamedTuple,
     Optional,
@@ -117,12 +118,18 @@ class ConvSignature:
                 return provided
             return default_layout
 
-        def listify(value: int | List[int]) -> List[int]:
-            if isinstance(value, int):
-                return [value] * num_spatial_dims
+        def listify(value: Any) -> List[int]:
             if isinstance(value, list):
                 assert len(value) == num_spatial_dims
                 return value
+            if isinstance(value, int):
+                return [value] * num_spatial_dims
+            try:
+                return list(value)
+            except TypeError as e:
+                raise TypeError(
+                    f"ConvSignature kwarg has value {value} with type {type(value).__name__}, but expected int or iterable."
+                ) from e
 
         if isinstance(mode, str):
             mode = Mode.parse(mode)

--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -3,7 +3,7 @@ import shutil
 import warnings
 
 from pathlib import Path
-from typing import Union
+from typing import Union, OrderedDict
 
 from iree.compiler.tools.core import compile_file, CompilerToolError
 
@@ -112,13 +112,48 @@ def _get_module_asm(signature: ConvSignature, func_name: str | None = None) -> s
     return module_asm
 
 
+class ConvLaunchableRuntimeCache:
+    def __init__(self, cache_limit: int | None = None):
+        self.cache_limit = cache_limit
+        self.session_cache: OrderedDict[str, Launchable] = OrderedDict()
+
+    def set_cache_limit(self, new_cache_limit: int | None):
+        self.cache_limit = new_cache_limit
+
+    def add_to_session_cache(self, func_name: str, launchable: Launchable):
+        self.session_cache[func_name] = launchable
+        self.session_cache.move_to_end(func_name)
+        if (
+            self.cache_limit is not None
+            and len(self.session_cache.keys) > self.cache_limit
+        ):
+            self.session_cache.popitem(last=False)
+
+    def get(self, func_name: str) -> Launchable | None:
+        return self.session_cache.get(func_name, None)
+
+    @staticmethod
+    def get_launchable_cache(cache_limit: int | None = None):
+        global _launchable_cache
+        if "_launchable_cache" in globals():
+            _launchable_cache.set_cache_limit(cache_limit)
+            return _launchable_cache
+        return ConvLaunchableRuntimeCache(cache_limit)
+
+
 def get_launchable(signature: ConvSignature) -> Launchable:
     func_name = signature.get_func_name()
+    launch_cache = ConvLaunchableRuntimeCache.get_launchable_cache()
+    launch = launch_cache.get(func_name)
+    if launch:
+        return launch
     module_asm = _get_module_asm(signature, func_name)
     cache_dir = CACHE_BASE_DIR / func_name if is_cache_enabled() else None
-    return Launchable.jit_compile(
+    launch = Launchable.jit_compile(
         module_asm,
         parameter_providers=(),
         entry_point=func_name,
         file_cache_dir=cache_dir,
     )
+    launch_cache.add_to_session_cache(func_name, launch)
+    return launch

--- a/iree/turbine/kernel/boo/examples/resnet_18_backward.py
+++ b/iree/turbine/kernel/boo/examples/resnet_18_backward.py
@@ -1,0 +1,70 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# NOTE: This script does not currently work because some bwd conv configs in the model fail compilation
+
+try:
+    import torchvision
+except ImportError as e:
+    raise ImportError(
+        "resnet 18 example requires torchvision package. E.g. pip install torchvision."
+    )
+
+import torch
+
+from iree.turbine.kernel.boo.modeling import replace_conv2d_with_boo_conv
+
+# load and modify the model:
+
+resnet_model = torchvision.models.resnet18(pretrained=False)
+resnet_model = replace_conv2d_with_boo_conv(resnet_model)
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+assert device == "cuda", f"device is {device}."
+
+resnet_model = resnet_model.to(device=device)
+
+import torch.optim as optim
+import torch.nn.functional as F
+import torchvision.transforms as transforms
+from torch.utils.data import DataLoader
+
+# get a training data loader
+transform = transforms.Compose(
+    [
+        transforms.RandomResizedCrop(32),
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+    ]  # Example normalization
+)
+train_dataset = torchvision.datasets.CIFAR10(
+    root="./data", train=True, download=True, transform=transform
+)
+train_loader = DataLoader(train_dataset, batch_size=4, shuffle=True, num_workers=2)
+
+# Define loss function and optimizer
+criterion = torch.nn.CrossEntropyLoss()
+optimizer = optim.SGD(resnet_model.parameters(), lr=0.001, momentum=0.9)
+
+# Training loop
+epochs = 10
+for epoch in range(epochs):
+    resnet_model.train()
+    running_loss = 0.0
+    for inputs, labels in train_loader:  # Assuming you have a train_loader
+        inputs, labels = inputs.to(device), labels.to(device)
+
+        optimizer.zero_grad()  # Zero the gradients
+
+        outputs = resnet_model(inputs)  # Forward pass
+        loss = criterion(outputs, labels)  # Calculate loss
+        loss.backward()  # Backpropagate
+        optimizer.step()  # Update weights
+
+        running_loss += loss.item()
+
+    print(f"Epoch {epoch+1}, Loss: {running_loss/len(train_loader)}")

--- a/iree/turbine/kernel/boo/modeling/__init__.py
+++ b/iree/turbine/kernel/boo/modeling/__init__.py
@@ -1,0 +1,1 @@
+from .replace import *

--- a/iree/turbine/kernel/boo/modeling/replace.py
+++ b/iree/turbine/kernel/boo/modeling/replace.py
@@ -1,0 +1,91 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+from ..ops.conv import boo_conv
+from ....support.logging import aot_logger as logger
+
+__all__ = [
+    "BooConv2d",
+    "replace_conv2d_with_boo_conv",
+]
+
+
+class BooConv2d(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        bias=True,
+    ):
+        super(BooConv2d, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+        self._bias = bias
+
+        self.weight = torch.nn.Parameter(
+            torch.randn(out_channels, in_channels // groups, *kernel_size)
+        )
+        if bias:
+            self.bias = torch.nn.Parameter(torch.randn(out_channels))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x):
+        if self._bias:
+            args = (x, self.weight, self.bias)
+        else:
+            args = (x, self.weight)
+        return boo_conv(
+            *args,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+            shared_layout="NCHW"
+        )
+
+
+def replace_conv2d_with_boo_conv(model):
+    for name, module in model.named_modules():
+        if isinstance(module, torch.nn.Conv2d):
+            logger.debug("Found Conv2d to replace with BooConv2d : %s", str(module))
+            custom_conv = BooConv2d(
+                module.in_channels,
+                module.out_channels,
+                module.kernel_size,
+                module.stride,
+                module.padding,
+                module.dilation,
+                module.groups,
+                module.bias is not None,
+            )
+
+            # Copy weights and bias if applicable
+            custom_conv.weight = torch.nn.Parameter(module.weight.data.clone())
+            if module.bias is not None:
+                custom_conv.bias = torch.nn.Parameter(module.bias.data.clone())
+
+            # Replace the module
+            parts = name.split(".")
+            if len(parts) > 1:
+                parent_name = ".".join(parts[:-1])
+                child_name = parts[-1]
+                parent_module = model.get_submodule(parent_name)
+                setattr(parent_module, child_name, custom_conv)
+            else:
+                setattr(model, name, custom_conv)
+    return model

--- a/iree/turbine/kernel/boo/ops/__init__.py
+++ b/iree/turbine/kernel/boo/ops/__init__.py
@@ -1,0 +1,1 @@
+from .conv import *

--- a/iree/turbine/kernel/boo/ops/conv.py
+++ b/iree/turbine/kernel/boo/ops/conv.py
@@ -86,4 +86,6 @@ def boo_conv(
 
     These layouts should be permutations of "NCH", "NCHW", or "NCDHW".
     """
-    return _BooConv.apply(input, weight, bias, kwargs)
+
+    filtered_kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    return _BooConv.apply(input, weight, bias, filtered_kwargs)

--- a/iree/turbine/kernel/boo/ops/conv.py
+++ b/iree/turbine/kernel/boo/ops/conv.py
@@ -1,0 +1,89 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+
+from ..conv_exports import ConvSignature, get_launchable
+
+__all__ = [
+    "boo_conv",
+]
+
+
+class _BooConv(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w, b=None, kwargs={}):
+        x = x.detach()
+        w = w.detach()
+        ctx.save_for_backward(x, w)
+        ctx.kwargs = kwargs
+        ctx.use_bias = b is not None
+        kwargs["mode"] = "fwd"
+        sig = ConvSignature.get(x, w, b, **kwargs)
+        ctx.output_layout = sig.output_layout
+        conv = get_launchable(sig)
+        args = (x, w) if b is None else (x, w, b.detach())
+        return conv(*args)
+
+    @staticmethod
+    @torch.autograd.function.once_differentiable
+    def backward(ctx, grad_output):
+        input_grad = weight_grad = bias_grad = None
+        x, w = ctx.saved_tensors
+        args = (x, w)
+        kwargs = ctx.kwargs
+
+        if ctx.needs_input_grad[0]:
+            kwargs["mode"] = "bwd"
+            bwd_sig = ConvSignature.get(*args, **kwargs)
+            bwd_conv = get_launchable(bwd_sig)
+            input_grad = bwd_conv(grad_output, w)
+
+        if ctx.needs_input_grad[1]:
+            kwargs["mode"] = "wrw"
+            wrw_conv = get_launchable(ConvSignature.get(*args, **kwargs))
+            weight_grad = wrw_conv(grad_output, x)
+
+        if ctx.needs_input_grad[2] and ctx.use_bias:
+            # TODO: use iree to perform the reduce sum?
+            output_layout = ctx.output_layout
+            reduce_dims = []
+            for i, char in enumerate(output_layout):
+                if char != "C":
+                    reduce_dims.append(i)
+            bias_grad = torch.sum(grad_output, reduce_dims)
+
+        return input_grad, weight_grad, bias_grad, None
+
+
+def boo_conv(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    **kwargs
+):
+    """
+    Applies a differentiable forward convolution kernel.
+
+    kwargs can include any of the following usual convolution options:
+
+        stride         : int or int[]
+        padding        : int or int[]
+        dilation       : int or int[]
+        groups         : int
+        output_padding : int or int[]
+        transposed     : bool
+
+    Users can also specify alternative layouts for each convolution:
+
+        shared_layout  : str
+        input_layout   : str
+        kernel_layout  : str
+        output_layout  : str
+
+    These layouts should be permutations of "NCH", "NCHW", or "NCDHW".
+    """
+    return _BooConv.apply(input, weight, bias, kwargs)

--- a/tests/kernel/boo/ops/boo_conv_test.py
+++ b/tests/kernel/boo/ops/boo_conv_test.py
@@ -1,0 +1,54 @@
+import unittest
+import tempfile
+
+from pathlib import Path
+
+import torch
+
+from iree.turbine.kernel.boo.conv_exports.launch import set_boo_cache
+from iree.turbine.kernel.boo.ops import boo_conv
+
+
+class BooConvTest(unittest.TestCase):
+    def testBooConvNonDefault(self):
+        with tempfile.TemporaryDirectory() as td:
+            set_boo_cache(Path(td))
+            device = "cuda:0" if torch.cuda.is_available() else None
+            x = torch.ones([2, 16, 16, 3], dtype=torch.float32, device=device)
+            w = torch.ones([4, 2, 2, 3], dtype=torch.float32, device=device)
+            y = boo_conv(x, w, shared_layout="NHWC", stride=2, dilation=2)
+            y_exp = torch.ones_like(y, device=device) * 12.0
+            self.assertAlmostEqual(
+                torch.abs(y - y_exp).sum().item(),
+                0.0,
+                msg=f"Expected output to be close to splat 12.0 tensor. Got {y}",
+            )
+
+    def testBooConvBackwardDefault(self):
+        with tempfile.TemporaryDirectory() as td:
+            set_boo_cache(Path(td))
+            device = "cuda:0" if torch.cuda.is_available() else None
+            x = torch.ones(
+                [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=True
+            )
+            w = torch.ones(
+                [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=True
+            )
+            torch.autograd.gradcheck(boo_conv, (x, w), atol=1e-5, eps=1e-3)
+
+    def testBooConvBackwardsWithBias(self):
+        with tempfile.TemporaryDirectory() as td:
+            set_boo_cache(Path(td))
+            device = "cuda:0" if torch.cuda.is_available() else None
+            x = torch.ones(
+                [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=True
+            )
+            w = torch.ones(
+                [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=True
+            )
+            b = torch.ones([1], dtype=torch.float32, device=device, requires_grad=True)
+            torch.autograd.gradcheck(boo_conv, (x, w, b), atol=1e-5, eps=1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is some initial work on being able to "plug-in" a boo conv launchable into a `torch.nn.Module` so that running the model backward will call into corresponding backward conv kernels. 

1. Adds a user-friendly `autograd.Function` called `boo_conv` which essentially acts like a regular forward torch convolution, but generates a launchable and invokes it.
2. Adds a runtime cache of conv launchables so that `boo_conv` can re-use the same launchable (if the configuration matches a previous use). 
3. Adds a `torch.nn.Module` variant of `Conv2d`, called `BooConv2d`, and a helper function which will replace each `Conv2d` named_module in a model into an equivalent `BooConv2d`. 
4. Adds a very basic training example for resnet-18 with the boo convs swapped in. This is not currently functional as the input_backward convolution IR does not currently compile (as a single dispatch) for some of the convolution configs present in the model, but this may be useful as a litmus test for basic functionality. 
5. Fixes a bug with non-list kwargs in `ConvSignature` getting removed.


Note: It may be better to eventually allow defining backward implementations for `CustomOp`s instead.