### PR TITLE
[TKW] Skip slow tests

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -95,15 +95,15 @@ jobs:
           rm -rf ./.wave
           WAVE_CACHE_ON=1 pytest --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/wave/runtime
 
-      - name: Run e2e tests on AMD GPU MI300
-        if: "contains(matrix.os, 'mi300') && !cancelled()"
+      - name: Run e2e tests on AMD GPU
+        if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && (github.event_name == 'pull_request') && !cancelled()"
         run: |
-          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --gpu-distribute 1 --durations=100 ./tests/kernel/wave/
+          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/wave/
 
-      - name: Run e2e tests on AMD GPU MI250
-        if: "contains(matrix.os, 'mi250') && !cancelled()"
+      - name: Run expensive e2e tests on AMD GPU
+        if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && (github.event_name != 'pull_request') && !cancelled()"
         run: |
-          WAVE_CACHE_ON=0 pytest -n 2 --capture=tee-sys --run-e2e -vv --durations=100 ./tests/kernel/wave/
+          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --run-expensive-tests --durations=100 ./tests/kernel/wave/
 
       - name: Run LIT tests
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -93,17 +93,17 @@ jobs:
         run: |
           export WAVE_CACHE_DIR=$PWD/.wave
           rm -rf ./.wave
-          WAVE_CACHE_ON=1 pytest --capture=tee-sys -vv --run-e2e --durations=0 ./tests/kernel/wave/runtime
+          WAVE_CACHE_ON=1 pytest --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/wave/runtime
 
       - name: Run e2e tests on AMD GPU MI300
         if: "contains(matrix.os, 'mi300') && !cancelled()"
         run: |
-          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --gpu-distribute 1 --durations=0 ./tests/kernel/wave/
+          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --gpu-distribute 1 --durations=100 ./tests/kernel/wave/
 
       - name: Run e2e tests on AMD GPU MI250
         if: "contains(matrix.os, 'mi250') && !cancelled()"
         run: |
-          WAVE_CACHE_ON=0 pytest -n 2 --capture=tee-sys --run-e2e -vv --durations=0 ./tests/kernel/wave/
+          WAVE_CACHE_ON=0 pytest -n 2 --capture=tee-sys --run-e2e -vv --durations=100 ./tests/kernel/wave/
 
       - name: Run LIT tests
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -93,17 +93,17 @@ jobs:
         run: |
           export WAVE_CACHE_DIR=$PWD/.wave
           rm -rf ./.wave
-          WAVE_CACHE_ON=1 pytest --capture=tee-sys -vv --run-e2e ./tests/kernel/wave/runtime
+          WAVE_CACHE_ON=1 pytest --capture=tee-sys -vv --run-e2e --durations=0 ./tests/kernel/wave/runtime
 
       - name: Run e2e tests on AMD GPU MI300
         if: "contains(matrix.os, 'mi300') && !cancelled()"
         run: |
-          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --gpu-distribute 1 ./tests/kernel/wave/
+          WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --gpu-distribute 1 --durations=0 ./tests/kernel/wave/
 
       - name: Run e2e tests on AMD GPU MI250
         if: "contains(matrix.os, 'mi250') && !cancelled()"
         run: |
-          WAVE_CACHE_ON=0 pytest -n 2 --capture=tee-sys --run-e2e -vv ./tests/kernel/wave/
+          WAVE_CACHE_ON=0 pytest -n 2 --capture=tee-sys --run-e2e -vv --durations=0 ./tests/kernel/wave/
 
       - name: Run LIT tests
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -93,6 +93,7 @@ jobs:
         run: |
           export WAVE_CACHE_DIR=$PWD/.wave
           rm -rf ./.wave
+          nproc
           WAVE_CACHE_ON=1 pytest --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/wave/runtime
 
       - name: Run e2e tests on AMD GPU

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,12 @@ def pytest_addoption(parser):
         "--run-e2e", action="store_true", default=False, help="run e2e tests"
     )
     parser.addoption(
+        "--run-expensive-tests",
+        action="store_true",
+        default=False,
+        help="run expensive tests",
+    )
+    parser.addoption(
         "--runperf", action="store_true", default=False, help="run performance tests"
     )
     parser.addoption(
@@ -30,6 +36,9 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "require_e2e: e2e test, runs with '--run-e2e'")
+    config.addinivalue_line(
+        "markers", "expensive_test: expensive test, runs with '--run-expensive-tests'"
+    )
     config.addinivalue_line(
         "markers", "perf_only: performance test, runs only with '--runperf'"
     )
@@ -64,10 +73,14 @@ def _has_marker(item, marker):
 def pytest_collection_modifyitems(config, items):
     _set_default_device(config)
     run_e2e = config.getoption("--run-e2e")
+    run_expensive = config.getoption("--run-expensive-tests")
     run_perf = config.getoption("--runperf")
     for item in items:
         if _has_marker(item, "require_e2e") and not run_e2e:
             item.add_marker(pytest.mark.skip("e2e tests are disabled"))
+
+        if _has_marker(item, "expensive_test") and not run_expensive:
+            item.add_marker(pytest.mark.skip("expensive tests are disabled"))
 
         is_validate_only = _has_marker(item, "validate_only")
         is_perf_only = _has_marker(item, "perf_only")

--- a/tests/kernel/wave/attention/backward_attention_test.py
+++ b/tests/kernel/wave/attention/backward_attention_test.py
@@ -29,9 +29,10 @@ from iree.turbine.kernel.wave.utils.torch_utils import (
 from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
 from iree.turbine.kernel.wave.constraints import MMAType
 from ..common.utils import (
-    require_e2e,
-    enable_scheduling_barriers,
     dump_generated_mlir,
+    enable_scheduling_barriers,
+    expensive_test,
+    require_e2e,
 )
 from torch.testing import assert_close
 
@@ -1177,6 +1178,7 @@ def testAttentionForward(mfma_variant: MMAType, shape: tuple[int, ...]):
 
 @require_e2e
 @param_mfma_shape
+@expensive_test
 def testAttentionBackward(mfma_variant: MMAType, shape: tuple[int, ...]):
     if mfma_variant == MMAType.F32_32x32x8_F16:
         pytest.skip("Asymmetric MFMA is broken")
@@ -1424,6 +1426,7 @@ def testAttentionBackward_dk(mfma_variant: MMAType, shape: tuple[int, ...]):
 
 @require_e2e
 @param_mfma_shape
+@expensive_test
 def testAttentionBackward_dq(mfma_variant: MMAType, shape: tuple[int, ...]):
     """This tests a kernel only for the gradient of q."""
     torch.manual_seed(0)

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -28,11 +28,12 @@ from iree.turbine.kernel.wave.constraints import MMAType
 import os
 from torch.testing import assert_close
 from ..common.utils import (
-    require_e2e,
-    require_cdna3,
-    enable_scheduling_barriers,
     dump_generated_mlir,
+    enable_scheduling_barriers,
+    expensive_test_param,
     param_bool,
+    require_cdna3,
+    require_e2e,
     scaled_dot_product_attention_bhsd,
 )
 from ..common.shapes import get_test_shapes
@@ -48,7 +49,8 @@ from iree.turbine.kernel.wave.compile import wave_compile, WaveCompileOptions
 @require_e2e
 @pytest.mark.parametrize("input_shape", get_test_shapes("attention"))
 @pytest.mark.parametrize(
-    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+    "enable_scheduling",
+    [SchedulingType.NONE, expensive_test_param(SchedulingType.MODULO)],
 )
 @param_bool("dynamic_dims", "dyn")
 @pytest.mark.parametrize(
@@ -833,7 +835,8 @@ def testAttentionSoftCap(
 @require_cdna3
 @pytest.mark.parametrize("shape", get_test_shapes("attention"))
 @pytest.mark.parametrize(
-    "enable_scheduling", [SchedulingType.NONE, SchedulingType.MODULO]
+    "enable_scheduling",
+    [SchedulingType.NONE, expensive_test_param(SchedulingType.MODULO)],
 )
 @pytest.mark.parametrize(
     "mfma_variant",

--- a/tests/kernel/wave/common/utils.py
+++ b/tests/kernel/wave/common/utils.py
@@ -33,6 +33,7 @@ enable_scheduling_barriers = int(os.environ.get("WAVE_USE_SCHED_BARRIERS", 0))
 
 # Add test shapes for validation and performance testing.
 perf_test = lambda *a: pytest.param(*a, marks=pytest.mark.perf_only)
+expensive_test_param = lambda *a: pytest.param(*a, marks=pytest.mark.expensive_test)
 
 
 def param_bool(name, shortname=None, values=None):

--- a/tests/kernel/wave/common/utils.py
+++ b/tests/kernel/wave/common/utils.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 from torch import Tensor
 
 require_e2e = pytest.mark.require_e2e
+expensive_test = pytest.mark.expensive_test
 require_cdna2 = pytest.mark.skipif(
     "gfx90" not in get_default_arch(),
     reason="Default architecture is not CDNA2, default architecture is '{}'".format(


### PR DESCRIPTION
* Print slowest tests on CI and skip the worst offenders (some of them were taking 300+sec).
* Reduced mi300 test time 18min -> 11min
* Let's keep individual tests on CI under 1min, everything else goes into `expensive_tests`