### PR TITLE
Capture location information from Python

### DIFF
--- a/iree/turbine/kernel/_support/location.py
+++ b/iree/turbine/kernel/_support/location.py
@@ -1,0 +1,55 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from iree.compiler.ir import Location, Context
+from typing import Union
+import sys
+import inspect
+from dataclasses import dataclass
+
+
+@dataclass
+class FileLineColInfo:
+    """
+    Location information containing the filename, line and column.
+    """
+
+    filename: str
+    line: Union[int, tuple[int, int]]
+    col: Union[int, tuple[int, int]]
+
+    def to_mlir(self):
+        assert Context.current is not None, "Must be called under MLIR context manager."
+
+        line_is_range = isinstance(self.line, tuple)
+        col_is_range = isinstance(self.col, tuple)
+        if not line_is_range and not col_is_range:
+            return Location.file(self.filename, self.line, self.col)
+        line_start = self.line[0] if line_is_range else self.line
+        line_end = self.line[1] if line_is_range else self.line
+        col_start = self.col[0] if col_is_range else self.col
+        col_end = self.col[1] if col_is_range else self.col
+        return Location.file(self.filename, line_start, col_start, line_end, col_end)
+
+    @staticmethod
+    def capture_current_location():
+        # Need to find a part of the call stack that doesn't belong to us.
+        for f in inspect.stack():
+            if "iree/turbine/kernel" not in f.filename:
+                break
+        if not f:
+            f = inspect.stack()[-1]
+
+        # Column information is only available for Python >= 3.11.
+        assert sys.version_info.major == 3, "Unexpected Python version"
+        if sys.version_info.minor < 11:
+            return FileLineColInfo(f.filename, f.lineno, 0)
+
+        return FileLineColInfo(
+            f.filename,
+            (f.positions.lineno, f.positions.end_lineno),
+            (f.positions.col_offset, f.positions.end_col_offset),
+        )

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -22,6 +22,7 @@ from .ir import (
 )
 
 from .._support.indexing import IndexSymbol
+from .._support.location import FileLineColInfo
 from .kernel_codegen import BindingDesc
 
 
@@ -73,8 +74,9 @@ def isolated_test_call(
 
         ftype = FunctionType.get(input_tensors, output_tensors)
         func_op = func_d.FuncOp("isolated_benchmark", ftype)
+        actual_loc = FileLineColInfo.capture_current_location().to_mlir()
         arg_locs = [
-            (Location.name(b.name) if b.name is not None else Location.unknown())
+            (Location.name(b.name, actual_loc) if b.name is not None else actual_loc)
             for b in sig.kernel_buffer_bindings + sig.dynamic_dim_bindings
         ]
         entry_block = func_op.add_entry_block(arg_locs)

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -91,7 +91,9 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     host_codegen.isolated_test_call(
         mb, exe, kernel_sig, entrypoint_name, options.dynamic_symbols
     )
-    asm = mb.module_op.get_asm()
+    asm = mb.module_op.get_asm(
+        enable_debug_info=options.debug_info, use_local_scope=options.use_local_scope
+    )
     if options.print_mlir:
         print(asm)
 

--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -54,6 +54,8 @@ class WaveCompileOptions:
     dump_binaries: str = None
     dump_intermediates: str = False
     compile_to_mlir: bool = False
+    debug_info: bool = False
+    use_local_scope: bool = False
 
     # === Performance options ===
     denorm_fp_math_f32: str = None

--- a/lit_tests/kernel/wave/location.py
+++ b/lit_tests/kernel/wave/location.py
@@ -1,0 +1,118 @@
+# RUN: python %s | FileCheck %s
+
+import pytest
+import iree.turbine.kernel as tk
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
+from iree.turbine.kernel.wave.utils.general_utils import (
+    run_test,
+)
+
+M = tkl.sym.M
+N = tkl.sym.N
+BLOCK_M = tkl.sym.BLOCK_M
+BLOCK_N = tkl.sym.BLOCK_N
+ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+
+def _make_constraints() -> list[tkw.Constraint]:
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), vector_shapes={M: 16, N: 16}
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+    return constraints
+
+
+def _make_options(
+    *, debug_info: bool, use_local_scope: bool = False
+) -> WaveCompileOptions:
+    subs = {
+        M: 16,
+        N: 16,
+        BLOCK_M: 16,
+        BLOCK_N: 16,
+        ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
+    }
+    options = WaveCompileOptions(
+        subs=subs,
+        compile_to_mlir=True,
+        debug_info=debug_info,
+        use_local_scope=use_local_scope,
+    )
+    return options
+
+
+@run_test
+def test_location_local_scope():
+    constraints = _make_constraints()
+    options = _make_options(debug_info=True, use_local_scope=True)
+
+    @tkw.wave(constraints)
+    def add_loc_local_scope(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        a_reg = tkw.read(a, elements_per_thread=16)
+        res = a_reg + a_reg
+
+    add_loc_local_scope = wave_compile(options, add_loc_local_scope)
+    print(add_loc_local_scope.asm)
+
+    # CHECK-LABEL: @add_loc_local_scope
+    # CHECK: vector.load {{.*}} loc("{{.*}}location.py":{{[0-9]+}}
+    # CHECK: arith.addf {{.*}} loc("{{.*}}location.py":{{[0-9]+}}
+    #
+    # CHECK: @isolated_benchmark(%{{.*}} loc("a"("{{.*}}location.py":{{[0-9]+}}{{.*}} loc("b"("{{.*}}location.py":{{[0-9]+}}
+
+
+@run_test
+def test_location_global_scope():
+    constraints = _make_constraints()
+    options = _make_options(debug_info=True, use_local_scope=False)
+
+    @tkw.wave(constraints)
+    def add_loc_global_scope(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        a_reg = tkw.read(a, elements_per_thread=16)
+        res = a_reg + a_reg
+
+    add_loc_global_scope = wave_compile(options, add_loc_global_scope)
+    print(add_loc_global_scope.asm)
+
+    # CHECK-DAG: #[[loc_arg:.+]] = loc("{{.*}}location.py":{{[0-9]+}}
+    # CHECK-DAG: #[[loc_a:.+]] = loc("a"(#[[loc_arg]])
+    # CHECK-DAG: #[[loc_b:.+]] = loc("b"(#[[loc_arg]])
+    # CHECK-LABEL: @add_loc_global_scope
+    # CHECK: vector.load {{.*}} loc(#[[loc_load:.+]])
+    # CHECK: arith.addf {{.*}} loc(#[[loc_addf:.+]])
+    # CHECK: @isolated_benchmark(%{{.*}} loc("a"(#[[loc_arg]])), %{{.*}} loc("b"(#[[loc_arg]])))
+    # CHECK-DAG: #[[loc_load]] = loc("{{.*}}location.py":{{[0-9]+}}
+    # CHECK-DAG: #[[loc_addf]] = loc("{{.*}}location.py":{{[0-9]+}}
+
+
+@run_test
+def test_no_location():
+    constraints = _make_constraints()
+    options = _make_options(debug_info=False)
+
+    @tkw.wave(constraints)
+    def add_no_loc_info(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        a_reg = tkw.read(a, elements_per_thread=16)
+        res = a_reg + a_reg
+
+    add_no_loc_info = wave_compile(options, add_no_loc_info)
+    print(add_no_loc_info.asm)
+
+    # CHECK-LABEL: @add_no_loc
+    # CHECK-NOT: loc(


### PR DESCRIPTION
Representing and propagating file/line location information from Python kernel source significantly improves debugging experience.

Note that column information is only available since Python 3.11 so additional logic is added to handle older versions.