### PR TITLE
Feat: better scaling for fp8 quant

### DIFF
--- a/iree/turbine/kernel/wave/templates/quantized_attention.py
+++ b/iree/turbine/kernel/wave/templates/quantized_attention.py
@@ -113,7 +113,7 @@ def get_brevitas_pertensor_fp8_attention_kernel(
     # full fp8 range. We can do this with a offset as post `exp2` this equates
     # to multiplying by a static value. We are able to do this as `max` and
     # `sum` are scaled by the same value so the end result is the same.
-    FP8_OFFSET_VAL = math.log2(F8_MAX/ATTENTION_SOFTMAX_MAX)
+    FP8_OFFSET_VAL = math.log2(F8_MAX / ATTENTION_SOFTMAX_MAX)
 
     # Dequant Tensor Scaling
     DEQUANT_QK = q_scale * k_scale
@@ -128,7 +128,7 @@ def get_brevitas_pertensor_fp8_attention_kernel(
     def base_attention_core(q, k, v, c):
         qk_scaling = tkl.Register[B, N_Q, N_KV, tkl.f32](DK_SQRT * LOG2E * DEQUANT_QK)
         v_dequant = tkl.Register[B, D_KV, N_Q, tkl.f32](v_scale)
-        fp8_offset = tkl.Register[B, N_Q, N_KV, tkl.f32](1/FP8_OFFSET_VAL)
+        fp8_offset = tkl.Register[B, N_Q, N_KV, tkl.f32](1 / FP8_OFFSET_VAL)
         fp8_max = tkl.Register[B, N_Q, N_KV, tkl.f32](F8_MAX)
         c_reg = tkl.Register[B, D_KV, N_Q, tkl.f32](0.0)
         init_sum = tkl.Register[B, N_Q, tkl.f32](0.0)

--- a/iree/turbine/kernel/wave/templates/quantized_attention.py
+++ b/iree/turbine/kernel/wave/templates/quantized_attention.py
@@ -128,7 +128,7 @@ def get_brevitas_pertensor_fp8_attention_kernel(
     def base_attention_core(q, k, v, c):
         qk_scaling = tkl.Register[B, N_Q, N_KV, tkl.f32](DK_SQRT * LOG2E * DEQUANT_QK)
         v_dequant = tkl.Register[B, D_KV, N_Q, tkl.f32](v_scale)
-        fp8_offset = tkl.Register[B, N_Q, N_KV, tkl.f32](1 / FP8_OFFSET_VAL)
+        fp8_offset = tkl.Register[B, N_Q, N_KV, tkl.f32](FP8_OFFSET_VAL)
         fp8_max = tkl.Register[B, N_Q, N_KV, tkl.f32](F8_MAX)
         c_reg = tkl.Register[B, D_KV, N_Q, tkl.f32](0.0)
         init_sum = tkl.Register[B, N_Q, tkl.f32](0.0)

--- a/iree/turbine/kernel/wave/templates/quantized_attention.py
+++ b/iree/turbine/kernel/wave/templates/quantized_attention.py
@@ -169,7 +169,6 @@ def get_brevitas_pertensor_fp8_attention_kernel(
             bias = tkw.select(mask, ZEROF, MIN_INF)
             x_j = x_j + bias
             x_j *= qk_scaling
-            x_j += fp8_offset
             m_j = tkw.max(x_j, partial_max, dim=N_KV)
             e_delta_max = tkw.exp2(partial_max - m_j)
             e_delta = tkw.exp2(x_j - m_j)

--- a/lit_tests/kernel/wave/attention/quantized_attention.py
+++ b/lit_tests/kernel/wave/attention/quantized_attention.py
@@ -44,7 +44,7 @@ def test_fp8_pertensor_attention():
 
     # CHECK-LABEL:       func.func @base_attention
     # CHECK:                %[[F8_MAX:.+]] = arith.constant dense<2.400000e+02> : vector<4xf32>
-    # CHECK:                %[[F8_OFFSET:.+]] = arith.constant dense<0.00416666688> : vector<4xf32>
+    # CHECK:                %[[F8_OFFSET:.+]] = arith.constant dense<7.90689039> : vector<4xf32>
     # CHECK:                %[[FUSED_SCALE:.+]] = arith.constant dense<0.180336878> : vector<4xf32>
     # CHECK:                {{.*}} = scf.for
     # CHECK-COUNT-16:           {{.*}} = amdgpu.mfma
@@ -54,10 +54,13 @@ def test_fp8_pertensor_attention():
 
     # fused QK scaling + dequant scaling
     # CHECK-COUNT-8:            {{.*}} = arith.mulf %{{.*}}, %[[FUSED_SCALE]] : vector<4xf32>
+
+    # CHECK-COUNT-4:            {{.*}} = gpu.shuffle xor {{.*}}
+
     # FP8 Offset
     # CHECK-COUNT-8:            {{.*}} = arith.addf %{{.*}}, %[[F8_OFFSET]] : vector<4xf32>
 
-    # CHECK-COUNT-8:            {{.*}} = gpu.shuffle xor {{.*}}
+    # CHECK-COUNT-4:            {{.*}} = gpu.shuffle xor {{.*}}
     # CHECK-COUNT-8:            {{.*}} = arith.minimumf %{{.*}}, %[[F8_MAX]] : vector<4xf32>
     # CHECK-COUNT-8:            {{.*}} = arith.truncf %{{.+}}: vector<4xf32> to vector<4xf8E4M3FNUZ>
     # CHECK-COUNT-16:           {{.*}} = amdgpu.mfma


### PR DESCRIPTION
Currently, there is a line that shifts the tensors before softmax quantization, however that is effectively a no-op.

With this change, the value quantized to FP8 are correctly rescaled from the range [0, 1] to [0, 240] before quantization, thus using more the fp8 value range.

We need to undo the rescaling at the end before the output is returned.

cc @raikonenfnu @KyleHerndon 