### PR TITLE
[boo_driver] Add `--csv` and `--splat-input-value` options

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/README.md
+++ b/iree/turbine/kernel/boo/conv_exports/README.md
@@ -150,6 +150,8 @@ convbfp16 -n 128 -c 35 -H 48 -W 32 -k 35 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1
 ```
 
 The `-t 1` option to collect timing is implemented by launching the kernel in a subprocess, which is then traced using `tracy`. Using this requires:
-- IREE runtime python bindings with tracy enabled. If using the pre-built `iree-base-runtime` package, this requires setting `IREE_PY_RUNTIME=tracy` in your environment
+- IREE runtime python bindings with tracy enabled.
+  If using the pre-built `iree-base-runtime` package, this requires setting `IREE_PY_RUNTIME=tracy` in your environment.
+  If using a local build of the python bindings, you may need to configure cmake with `-DTRACY_DELAYED_INIT=ON -DTRACY_MANUAL_LIFETIME=ON` to work around issues with the tracy client being closed before traces are captured.
 - `iree-tracy-capture`; see https://iree.dev/developers/performance/profiling-with-tracy/#building-the-tracy-capture-cli-tool
 - `tracy-csvexport`; see https://iree.dev/developers/performance/profiling-with-tracy/#building-the-tracy-csvexport-tool

--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -1,5 +1,6 @@
 import argparse
 from collections.abc import Callable, Sequence
+import os
 import shlex
 import statistics
 import torch
@@ -19,6 +20,12 @@ command-line arguments are appended to the arguments from the file.
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--commands-file", type=str, help="read commands from file")
+    parser.add_argument(
+        "--csv",
+        type=str,
+        default=None,
+        help="file to output timing information in csv format",
+    )
     args, extra_cli_args = parser.parse_known_args()
 
     if args.commands_file:
@@ -29,20 +36,30 @@ command-line arguments are appended to the arguments from the file.
     else:
         mio_file_args = [[]]  # use CLI arguments
 
+    csv_file = open(args.csv if args.csv is not None else os.devnull, "w")
+    csv_file.write("arguments,min_time (us)\n")
+
     runner_parser = argparse.ArgumentParser()
     runner_parser.add_argument("--timing", "-t", type=int, help="Enable timing")
     for file_args in mio_file_args:
-        args = file_args + extra_cli_args
-        timing_args, runner_args = runner_parser.parse_known_args(args)
+        driver_args = file_args + extra_cli_args
+        timing_args, runner_args = runner_parser.parse_known_args(driver_args)
         func = lambda: run(runner_args)
+        csv_file.write(shlex.join(driver_args) + ",")
         if not timing_args.timing:
             func()
             continue
 
-        zones, func_name = trace_gpu(func)
+        try:
+            zones, func_name = trace_gpu(func)
+        except Exception as exc:
+            print(f">>> ERROR: {exc}")
+            csv_file.write("N.A.\n")
+            continue
         dispatch_zone_names = [n for n in zones.keys() if n.startswith(func_name)]
         if len(dispatch_zone_names) == 0:
             print(">>> FAILED TO COLLECT TIMING INFO")
+            csv_file.write("failed to collect timing info\n")
             continue
         for zone_name in dispatch_zone_names:
             # Convert from nanoseconds to microseconds
@@ -55,6 +72,13 @@ command-line arguments are appended to the arguments from the file.
             if len(dispatch_zone_names) > 1:
                 s += f"\t({zone_name})"
             print(s)
+
+        if len(dispatch_zone_names) == 0:
+            csv_file.write("no timing info\n")
+        elif len(dispatch_zone_names) > 1:
+            csv_file.write("multiple dispatches\n")
+        else:
+            csv_file.write(f"{min(zones[dispatch_zone_names[0]]) / 1000:.2f}\n")
 
 
 def run(cli_args: Sequence[str]):
@@ -108,14 +132,18 @@ def trace_gpu(func: Callable[[], str]) -> tuple[dict[str, list[int]], str]:
 
             def proc_fn():
                 os.environ["TRACY_PORT"] = tracy_port
-                queue.put(func())
+                try:
+                    queue.put(func())
+                except Exception as exc:
+                    queue.put(str(exc))
+                    raise
 
             process = Process(target=proc_fn)
             process.start()
             process.join()
+            result = queue.get_nowait()
             if process.exitcode != 0:
-                sys.exit(process.exitcode)
-            result = queue.get()
+                raise ValueError(result)
             try:
                 # Tracy will never exit if it fails to connect, so kill the process after some time.
                 out, err = tracy.communicate(timeout=5)

--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -94,11 +94,19 @@ def run(cli_args: Sequence[str]):
     parser.add_argument(
         "--iter", type=int, help="Number of iterations to run", default=100
     )
+    parser.add_argument(
+        "--splat-input-value",
+        default=None,
+        type=int,
+        help="use a splat value for inputs (defaults to random values)",
+    )
     args = parser.parse_args(cli_args)
     sig = mio.get_signature(args)
     conv = get_launchable(sig)
 
-    conv_args = sig.get_sample_conv_args(seed=10, device="cuda")
+    conv_args = sig.get_sample_conv_args(
+        seed=10, device="cuda", splat_value=args.splat_input_value
+    )
 
     result = None
     for _ in range(args.iter):


### PR DESCRIPTION
This adds some extra options to `boo_driver.py`:
- `--csv <file>`: this outputs timing info in csv format to the specified file
- `--splat-input-value <val>`: this uses splat inputs instead of the default random values

Additionally the script now continues if the traced invocation fails, so that all specified configurations are reported.

I've also documented a workaround I'm using to get tracing working with locally built python bindings. Using this requires a recent commit of IREE: iree-org/iree#20448