### PR TITLE
[Wave] Add GQA/MQA Vanilla template

### DIFF
--- a/iree/turbine/kernel/wave/templates/gqa_vanilla_attention.py
+++ b/iree/turbine/kernel/wave/templates/gqa_vanilla_attention.py
@@ -1,0 +1,175 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.utils.general_utils import (
+    torch_dtype_to_wave,
+)
+from .attention_common import *
+import math
+import torch
+from typing import Optional
+
+
+def get_gqa_bshd_attention_kernel(
+    shape: AttentionShape,
+    mfma_variant: tuple[MMAType, MMAType],
+    input_dtype: Optional[torch.dtype] = torch.float16,
+    output_dtype: Optional[torch.dtype] = torch.float32,
+    is_causal: Optional[bool] = False,
+    layer_scaling: Optional[float] = None,
+    sliding_window_size: Optional[int] = -1,
+):
+
+    if sliding_window_size > 0 and not is_causal:
+        raise NotImplementedError(
+            "Sliding window is only supported for causal attention."
+        )
+
+    # Determine dtype of operands.
+    wave_input_dtype = torch_dtype_to_wave(input_dtype)
+    wave_output_dtype = torch_dtype_to_wave(output_dtype)
+
+    LOG2E = 1.44269504089
+    dk_sqrt = math.sqrt(1.0 / shape.head_size)
+    layer_scaling = (layer_scaling or dk_sqrt) * LOG2E
+
+    B = tkl.sym.B
+    BLOCK_B = tkl.sym.BLOCK_B
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(N_Q, BLOCK_N_Q, 0)]
+    constraints += [tkw.WorkgroupConstraint(D_KV, BLOCK_D_KV, 1)]
+    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 2)]
+    constraints += [tkw.WorkgroupConstraint(H, BLOCK_H, 3)]
+    constraints += [tkw.WorkgroupConstraint(H_KV, BLOCK_H, 3, primary=False)]
+    constraints += [tkw.TilingConstraint(N_KV, BLOCK_N_KV)]
+    constraints += [tkw.WaveConstraint(N_Q, BLOCK_N_Q / 4)]
+    constraints += [tkw.WaveConstraint(D_KV, BLOCK_D_KV / 1)]
+
+    if mfma_variant[1] == MMAType.F32_16x16x16_F16:
+        Mvec = 16
+        Nvec = 16
+    if mfma_variant[1] == MMAType.F32_32x32x8_F16:
+        Mvec = 32
+        Nvec = 32
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(4, 1, 1),
+            mma_type=mfma_variant[1],
+            vector_shapes={B: 0, H: 0, H_KV: 0, N_Q: Mvec, D_KV: Nvec},
+        )
+    ]
+
+    head_ratio = shape.num_query_heads // shape.num_kv_heads
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    k = tkw.IndexMapping.iterator(2)
+    l = tkw.IndexMapping.iterator(3)
+    mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H: j, D_KV: k, N_Q: l},
+        outputs={B: i, N_Q: l, H: j, D_KV: k},
+    )
+    q_mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H: j, N_Q: k, D_Q: l},
+        outputs={B: i, H: j, N_Q: k, D_Q: l},
+    )
+    k_mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H_KV: j // head_ratio, N_KV: k, D_Q: l},
+        outputs={B: i, H_KV: j, N_KV: k, D_Q: l},
+    )
+    v_mapping = tkw.IndexMapping(
+        num_iterators=4,
+        inputs={B: i, H_KV: j // head_ratio, D_KV: k, N_KV: l},
+        outputs={B: i, H_KV: j, D_KV: k, N_KV: l},
+    )
+
+    @tkw.wave(constraints)
+    def base_attention(
+        q: tkl.Memory[B, N_Q, H, D_Q, GLOBAL_ADDRESS_SPACE, wave_input_dtype],
+        k: tkl.Memory[B, N_KV, H_KV, D_Q, ADDRESS_SPACE, wave_input_dtype],
+        v: tkl.Memory[B, N_KV, H_KV, D_KV, ADDRESS_SPACE, wave_input_dtype],
+        c: tkl.Memory[B, N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype],
+    ):
+
+        qkv_scaling = tkl.Register[B, H, N_Q, D_Q, tkl.f16](layer_scaling)
+        c_reg = tkl.Register[B, H, D_KV, N_Q, tkl.f32](0.0)
+        init_sum = tkl.Register[B, H, N_Q, tkl.f32](0.0)
+        init_max = tkl.Register[B, H, N_Q, tkl.f32](-1e6)
+        sliding_window = tkl.Register[N_Q, N_KV, tkl.i32](sliding_window_size)
+        ZEROF = tkl.Register[N_Q, N_KV, tkl.f32](0.0)
+        MIN_INF = tkl.Register[N_Q, N_KV, tkl.f32](-1e6)
+
+        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
+        def repeat(
+            partial_max: tkl.Register[B, H, N_Q, tkl.f32],
+            partial_sum: tkl.Register[B, H, N_Q, tkl.f32],
+            acc: tkl.Register[B, H, D_KV, N_Q, tkl.f32],
+        ):
+            imm_reg = tkl.Register[B, H, N_KV, N_Q, tkl.f32](0.0)
+            q_reg = tkw.read(q, mapping=q_mapping)
+            q_reg *= qkv_scaling
+            k_reg = tkw.read(k, mapping=k_mapping)
+            inner_acc = tkw.mma(k_reg, q_reg, imm_reg, mfma_variant[0])
+            x_j = tkw.permute(inner_acc, target_shape=[B, H, N_Q, N_KV])
+            k2_index = tkw.self_index(N_KV, tkl.i32)
+            mask = tkw.apply_expr(k2_index, lambda x: x < N_KV)
+            mask = tkw.broadcast(mask, target_shape=[N_Q, N_KV])
+            if is_causal:
+                m_index = tkw.self_index(N_Q, tkl.i32)
+                m_index = tkw.broadcast(m_index, target_shape=[N_Q, N_KV])
+                mask = (m_index >= k2_index) & mask
+                if sliding_window_size > 0:
+                    mask = (m_index - k2_index <= sliding_window) & mask
+            mask = tkw.cast(mask, tkw.i1)
+            bias = tkw.select(mask, ZEROF, MIN_INF)
+            x_j = x_j + bias
+            m_j = tkw.max(x_j, partial_max, dim=N_KV)
+            e_delta_max = tkw.exp2(partial_max - m_j)
+            e_delta = tkw.exp2(x_j - m_j)
+            e_init = partial_sum * e_delta_max
+            d_j = tkw.sum(e_delta, e_init, dim=N_KV)
+            imm_f16 = tkw.cast(e_delta, tkl.f16)
+            v_reg = tkw.read(v, mapping=v_mapping)
+            new_acc = acc * e_delta_max
+            acc = tkw.mma(v_reg, imm_f16, new_acc)
+            return m_j, d_j, acc
+
+        # repeat represents the results of the loop
+        res_max, res_sum, res_mm = repeat
+        reciprocal_sum = tkw.reciprocal(res_sum)
+        res = res_mm * reciprocal_sum
+        tkw.write(res, c, mapping=mapping)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_B: 1,
+        BLOCK_H: 1,
+        BLOCK_N_Q: 128,
+        BLOCK_D_KV: 64,
+        BLOCK_N_KV: 64,
+        B: shape.num_seqs,
+        H: shape.num_query_heads,
+        H_KV: shape.num_kv_heads,
+        N_Q: shape.query_seq_len,
+        D_KV: shape.head_size_kv,
+        D_Q: shape.head_size,
+        N_KV: shape.kv_seq_len,
+    }
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+
+    return base_attention, hyperparams, dynamic_symbols, dynamic_symbols_map

--- a/iree/turbine/kernel/wave/templates/quantized_attention.py
+++ b/iree/turbine/kernel/wave/templates/quantized_attention.py
@@ -22,7 +22,7 @@ def get_brevitas_pertensor_fp8_attention_kernel(
     shape: AttentionShape,
     mfma_variant: MMAType,
     logit_dtype: torch.dtype = torch.float16,
-    f8_dtpye: torch.dtype = torch.float8_e4m3fnuz,
+    f8_dtype: torch.dtype = torch.float8_e4m3fnuz,
     dynamic_dims: bool = False,
     is_causal: bool = False,
     q_scale=1.0,
@@ -102,8 +102,8 @@ def get_brevitas_pertensor_fp8_attention_kernel(
     # Setting up FP8 scaling
     LOG2E = 1.44269504089
     DK_SQRT = math.sqrt(1.0 / shape.head_size)
-    F8_DTYPE = torch_dtype_to_wave(f8_dtpye)
-    F8_MAX = torch.finfo(f8_dtpye).max
+    F8_DTYPE = torch_dtype_to_wave(f8_dtype)
+    F8_MAX = torch.finfo(f8_dtype).max
 
     # maximum expected value from attention softmax
     ATTENTION_SOFTMAX_MAX = 1.0

--- a/iree/turbine/kernel/wave/utils/torch_utils.py
+++ b/iree/turbine/kernel/wave/utils/torch_utils.py
@@ -53,3 +53,9 @@ def device_zeros(*args, **kwargs):
 
 def device_ones(*args, **kwargs):
     return to_default_device(torch.ones(*args, **kwargs))
+
+
+def quantized_tensor(shape: tuple[int], dtype: torch.dtype, scale: float):
+    return torch.ceil(
+        torch.clamp(device_randn(shape, dtype=dtype) * scale, -scale, scale)
+    )

--- a/tests/kernel/wave/attention/gqa_vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/gqa_vanilla_attention_test.py
@@ -1,0 +1,127 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import torch
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.utils.general_utils import (
+    get_default_scheduling_params,
+)
+from iree.turbine.kernel.wave.utils.run_utils import (
+    set_default_run_config,
+)
+from iree.turbine.kernel.wave.utils.torch_utils import (
+    device_randn,
+    device_zeros,
+)
+from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
+from iree.turbine.kernel.wave.constraints import MMAType
+import os
+from torch.testing import assert_close
+from ..common.utils import (
+    enable_scheduling_barriers,
+    require_e2e,
+    scaled_dot_product_attention_bhsd,
+)
+from ..common.shapes import get_test_shapes
+from iree.turbine.kernel.wave.templates.gqa_vanilla_attention import (
+    get_gqa_bshd_attention_kernel,
+)
+from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
+from iree.turbine.kernel.wave.compile import wave_compile, WaveCompileOptions
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("gqa_bshd_attention"))
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
+@pytest.mark.parametrize("sliding_window", [-1, 1024])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        (MMAType.F32_32x32x8_F16, MMAType.F32_32x32x8_F16),
+        (MMAType.F32_16x16x16_F16, MMAType.F32_16x16x16_F16),
+    ],
+)
+def testCausalGQABSHDAttention(
+    shape: AttentionShape,
+    enable_scheduling: SchedulingType,
+    sliding_window: int,
+    mfma_variant: tuple[MMAType],
+    request,
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+
+    (
+        base_attention_func,
+        hyperparams,
+        dynamic_symbols,
+        dynamic_symbols_map,
+    ) = get_gqa_bshd_attention_kernel(
+        shape, mfma_variant, is_causal=True, sliding_window_size=sliding_window
+    )
+    q_shape = (
+        shape.num_seqs,
+        shape.num_query_heads,
+        shape.query_seq_len,
+        shape.head_size,
+    )
+    k_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size)
+    v_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size_kv)
+    hyperparams.update(get_default_scheduling_params())
+    perf_filename = request.node.name + ".json"
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+        run_bench=run_bench,
+        waves_per_eu=2,
+        denorm_fp_math_f32="preserve-sign",
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=(
+            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
+        ),
+    )
+    options = set_default_run_config(options)
+    base_attention = wave_compile(options, base_attention_func)
+
+    torch.manual_seed(1)
+    q = device_randn(q_shape, dtype=torch.float16)
+    k = device_randn(k_shape, dtype=torch.float16)
+    v = device_randn(v_shape, dtype=torch.float16)
+
+    # This variant of wave kernel is BSHD
+    o_shape = (
+        shape.num_seqs,
+        shape.query_seq_len,
+        shape.num_query_heads,
+        shape.head_size_kv,
+    )
+    output = device_zeros(o_shape, dtype=torch.float32)
+
+    asm = base_attention(
+        q.transpose(1, 2).contiguous(),
+        k.transpose(1, 2).contiguous(),
+        v.transpose(1, 2).contiguous(),
+        output,
+    )
+
+    # Torch reference needs to be in BHSD format
+    torch_ref = scaled_dot_product_attention_bhsd(
+        q, k, v, is_causal=True, sliding_window=sliding_window
+    )
+
+    assert_close(
+        output.transpose(1, 2),
+        torch_ref,
+        check_dtype=False,
+        atol=1e-3,
+        rtol=1e-3,
+    )

--- a/tests/kernel/wave/attention/gqa_vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/gqa_vanilla_attention_test.py
@@ -16,6 +16,7 @@ from iree.turbine.kernel.wave.utils.run_utils import (
 from iree.turbine.kernel.wave.utils.torch_utils import (
     device_randn,
     device_zeros,
+    quantized_tensor,
 )
 from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
 from iree.turbine.kernel.wave.constraints import MMAType
@@ -24,6 +25,7 @@ from torch.testing import assert_close
 from ..common.utils import (
     enable_scheduling_barriers,
     require_e2e,
+    require_cdna3,
     scaled_dot_product_attention_bhsd,
 )
 from ..common.shapes import get_test_shapes
@@ -125,3 +127,112 @@ def testCausalGQABSHDAttention(
         atol=1e-3,
         rtol=1e-3,
     )
+
+
+@require_e2e
+@require_cdna3
+@pytest.mark.parametrize("shape", get_test_shapes("gqa_bshd_attention"))
+@pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
+@pytest.mark.parametrize("sliding_window", [-1, 1024])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        (MMAType.F32_32x32x16_F8, MMAType.F32_32x32x16_K4_F8),
+        (MMAType.F32_16x16x32_F8, MMAType.F32_16x16x32_K4_F8),
+    ],
+)
+def testCausalGQABSHDAttentionF8(
+    shape: AttentionShape,
+    enable_scheduling: SchedulingType,
+    sliding_window: int,
+    mfma_variant: tuple[MMAType],
+    request,
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+
+    # Sample tensor scaling from Brevitas SDXL-FP8.
+    q_scale = 0.02578124962747097
+    k_scale = 0.02363281324505806
+    v_scale = 0.010286458767950535
+    (
+        base_attention_func,
+        hyperparams,
+        dynamic_symbols,
+        dynamic_symbols_map,
+    ) = get_gqa_bshd_attention_kernel(
+        shape,
+        mfma_variant,
+        is_causal=True,
+        sliding_window_size=sliding_window,
+        use_fp8=True,
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+
+    q_shape = (
+        shape.num_seqs,
+        shape.num_query_heads,
+        shape.query_seq_len,
+        shape.head_size,
+    )
+    k_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size)
+    v_shape = (shape.num_seqs, shape.num_kv_heads, shape.kv_seq_len, shape.head_size_kv)
+    hyperparams.update(get_default_scheduling_params())
+    perf_filename = request.node.name + ".json"
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+        run_bench=run_bench,
+        waves_per_eu=2,
+        denorm_fp_math_f32="preserve-sign",
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=(
+            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
+        ),
+    )
+    options = set_default_run_config(options)
+    base_attention = wave_compile(options, base_attention_func)
+
+    torch.manual_seed(1)
+
+    # Smaller range to help with FP8 minimum range
+    MAX_RANGE = 128
+    q = quantized_tensor(q_shape, dtype=torch.float16, scale=MAX_RANGE)
+    k = quantized_tensor(k_shape, dtype=torch.float16, scale=MAX_RANGE)
+    v = quantized_tensor(v_shape, dtype=torch.float16, scale=MAX_RANGE)
+
+    # This variant of wave kernel is BSHD
+    o_shape = (
+        shape.num_seqs,
+        shape.query_seq_len,
+        shape.num_query_heads,
+        shape.head_size_kv,
+    )
+    output = device_zeros(o_shape, dtype=torch.float32)
+
+    base_attention(
+        q.transpose(1, 2).contiguous(),
+        k.transpose(1, 2).contiguous(),
+        v.transpose(1, 2).contiguous(),
+        output,
+    )
+
+    # Torch reference needs to be in BHSD format
+    torch_ref = scaled_dot_product_attention_bhsd(
+        q.to(torch.float32) * q_scale,
+        k.to(torch.float32) * k_scale,
+        v.to(torch.float32) * v_scale,
+        is_causal=True,
+        sliding_window=sliding_window,
+    )
+
+    rmse = torch.sqrt(torch.mean(torch.square(output.transpose(1, 2) - torch_ref)))
+    # Higher tolerance because, we are testing a higher range
+    # of numbers here (-128, 128), typically device_rand just gets (-1, 1).
+    assert rmse < 0.04, f"RMSE: {rmse} is too high, expected less than 0.04"

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -298,7 +298,7 @@ def testAttentionCausal(
 
         def sliding_window_mask(q_seq_length, kv_seq_length, window_size):
             mask = device_ones((q_seq_length, kv_seq_length), dtype=torch.bool)
-            mask = mask.tril().triu(-sliding_window)
+            mask = mask.tril().triu(-window_size)
             return mask.to(dtype=torch.bool)
 
         mask = sliding_window_mask(

--- a/tests/kernel/wave/common/shapes.py
+++ b/tests/kernel/wave/common/shapes.py
@@ -50,6 +50,18 @@ _e2e_test_shapes["extend"] = [
     )
 ]
 
+_e2e_test_shapes["gqa_bshd_attention"] = [
+    AttentionShape(
+        num_seqs=1,
+        num_query_heads=32,
+        num_kv_heads=1,
+        query_seq_len=8000,
+        kv_seq_len=8000,
+        head_size_kv=256,
+        head_size=256,
+    ),
+]
+
 test_names = [
     "attention",
     "chained_gemm",
@@ -58,6 +70,7 @@ test_names = [
     "quantized_attention",
     "all_attention",
     "evoformer",
+    "gqa_bshd_attention",
 ]
 for test in test_names:
     _perf_test_shapes[test] = _e2e_test_shapes[test]


### PR DESCRIPTION
This PR creates a new template for GQA/MQA vanilla attention that supports both causal masks and sliding windows for both f16 and f8 datatypes.