### PR TITLE
[boo_driver] Add option to validate results

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -154,7 +154,10 @@ def trace_gpu(func: Callable[[], str]) -> tuple[dict[str, list[int]], str]:
                 try:
                     queue.put(func())
                 except Exception as exc:
-                    queue.put(str(exc))
+                    # Return a short error string for printing. The full error
+                    # and traceback appear on stderr since we 'raise' here.
+                    err_str = str(exc).splitlines()[0]
+                    queue.put(err_str)
                     raise
 
             process = Process(target=proc_fn)

--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -100,6 +100,12 @@ def run(cli_args: Sequence[str]):
         type=int,
         help="use a splat value for inputs (defaults to random values)",
     )
+    parser.add_argument(
+        "--check-result",
+        default=False,
+        action="store_true",
+        help="check result against torch implementation",
+    )
     args = parser.parse_args(cli_args)
     sig = mio.get_signature(args)
     conv = get_launchable(sig)
@@ -114,6 +120,11 @@ def run(cli_args: Sequence[str]):
 
     torch.set_printoptions(edgeitems=0)
     print(f">>> {result}")
+    if args.check_result:
+        reference_module = sig.get_nn_module(use_custom=False)
+        expected = reference_module(*conv_args)
+        torch.testing.assert_close(result, expected)
+        print(">>> results are correct")
 
     return sig.get_func_name()
 


### PR DESCRIPTION
Adds a  `--check-result` flag which uses the reference torch model to compare results against the IREE implementation using `torch.testing.assert_close`.