### PR TITLE
[Wave] Rename reduction to iterate

### DIFF
--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -33,7 +33,7 @@ from ..lang.types import (
     Index,
 )
 from ..lang.wave_types import IndexMapping
-from ..ops.wave_ops import CustomOp, Placeholder, Reduction, Unknown
+from ..ops.wave_ops import CustomOp, Placeholder, Iterate, Unknown
 
 from .regions import RegionGraph, SubgraphTracer
 

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -89,7 +89,7 @@ def conditional(
     ...
 
 
-def reduction(
+def iterate(
     axis: IndexExpr, init_args: Sequence["Register"]
 ) -> Callable[[Callable[[AccT], AccT]], AccT]:
     ...
@@ -1424,9 +1424,9 @@ class Conditional(NestedRegionOp):
         return []
 
 
-@define_op("reduction")
+@define_op("iterate")
 @dataclass
-class Reduction(NestedRegionOp):
+class Iterate(NestedRegionOp):
     axis: IndexSymbol
     init_args: Sequence[Any]
     subgraph_name: str
@@ -1442,7 +1442,7 @@ class Reduction(NestedRegionOp):
         def wrapper(f):
             with graph.subtracer() as subtracer:
                 subgraph_name, implicit_captures = subtracer.trace(f)
-            node = Reduction(
+            node = Iterate(
                 *args,
                 **kwargs,
                 subgraph_name=subgraph_name,
@@ -1751,7 +1751,7 @@ class GetResult(CustomOp):
         custom_index = custom.index
         if custom_index is None:
             return None
-        if not isinstance(custom, Reduction):
+        if not isinstance(custom, Iterate):
             return custom_index
         assert isinstance(custom_index, Sequence) and self.res_idx < len(
             custom.indexing_dims

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -16,7 +16,7 @@ from ...ops.wave_ops import (
     Placeholder,
     Read,
     ReduceOp,
-    Reduction,
+    Iterate,
     Write,
     get_custom,
 )
@@ -228,7 +228,7 @@ def set_thread_independent_index(
     Set the index of the node based on all constraints except the hardware constraint.
     """
     custom = get_custom(node)
-    if isinstance(custom, (Reduction, Placeholder)) and not isinstance(custom, IterArg):
+    if isinstance(custom, (Iterate, Placeholder)) and not isinstance(custom, IterArg):
         return
 
     hw_cons = get_hardware_constraint(constraints)
@@ -378,14 +378,14 @@ def combine_indices(
 
 def add_nodes_to_sources(
     source: CustomOp,
-    reduction: Reduction,
+    reduction: Iterate,
     fn: Callable,
     source_index: dict[IndexSymbol, IndexSequence],
     source_vector_shapes: dict[IndexSymbol, int],
     sources: list[
         tuple[CustomOp, dict[IndexSymbol, IndexSequence], dict[IndexSymbol, int]]
     ],
-) -> tuple[list[CustomOp], Reduction]:
+) -> tuple[list[CustomOp], Iterate]:
     """
     Populate the sources with the inputs and users of the source node.
     """

--- a/iree/turbine/kernel/wave/barriers.py
+++ b/iree/turbine/kernel/wave/barriers.py
@@ -6,7 +6,7 @@
 
 from .utils.graph_utils import is_reduction_subgraph
 from .._support.tracing import CapturedTrace
-from ..ops.wave_ops import get_custom, Read, SharedMemoryBarrier, Write, Reduction
+from ..ops.wave_ops import get_custom, Read, SharedMemoryBarrier, Write, Iterate
 from ..lang.global_symbols import SHARED_ADDRESS_SPACE
 import torch.fx as fx
 
@@ -41,7 +41,7 @@ def add_shared_memory_barriers(
                 with graph.inserting_before(node):
                     SharedMemoryBarrier().add_to_graph(graph)
             last_node = custom
-        if isinstance(custom, Reduction):
+        if isinstance(custom, Iterate):
             last_node = add_shared_memory_barriers(
                 trace.get_subgraph(custom.subgraph_name), last_node
             )

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -67,6 +67,7 @@ from ...ops.wave_ops import (
     get_custom,
     get_result,
     gt,
+    iterate,
     le,
     log2,
     lt,
@@ -75,7 +76,6 @@ from ...ops.wave_ops import (
     mma,
     permute,
     reciprocal,
-    reduction,
     register,
     reshape,
     roundeven,
@@ -841,8 +841,8 @@ def handle_conditional(emitter: WaveEmitter, node: fx.Node):
         scf_d.YieldOp([])
 
 
-@handle_op(reduction)
-def handle_reduction(emitter: WaveEmitter, node: fx.Node):
+@handle_op(iterate)
+def handle_iterate(emitter: WaveEmitter, node: fx.Node):
     try:
         axis, init_args, subgraph, implicit_capture = node.args
     except ValueError as e:

--- a/iree/turbine/kernel/wave/decompose_reduce_ops.py
+++ b/iree/turbine/kernel/wave/decompose_reduce_ops.py
@@ -21,7 +21,7 @@ from ..ops.wave_ops import (
     ShuffleOp,
     CustomOp,
     Extract,
-    Reduction,
+    Iterate,
 )
 from ..lang.global_symbols import *
 

--- a/iree/turbine/kernel/wave/hoisting.py
+++ b/iree/turbine/kernel/wave/hoisting.py
@@ -83,7 +83,7 @@ def hoist_loop_invariant_ops(trace: CapturedTrace, constraints: list[Constraint]
     for node in root_graph.nodes:
         custom_node = get_custom(node)
         match custom_node:
-            case Reduction():
+            case Iterate():
                 with root_graph.inserting_before(custom_node.fx_node):
                     induction_variable = get_induction_variable(
                         custom_node, constraints

--- a/iree/turbine/kernel/wave/nn/linear.py
+++ b/iree/turbine/kernel/wave/nn/linear.py
@@ -68,7 +68,7 @@ def get_linear_kernel(
     ]
 
     # With dynamic dimensions, we need to add an assumption on how big
-    # the reduction dimension is to determine whether we can schedule or not.
+    # the iterate dimension is to determine whether we can schedule or not.
     if dynamic_dims:
         constraints += [tkw.Assumption(K > BLOCK_K * 4)]
 
@@ -79,7 +79,7 @@ def get_linear_kernel(
     # and data movement strategy is determined during the compilation process.
     # These can be influenced by introducing constraints.
     def gemm_core(a, b, c_reg, result):
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:

--- a/iree/turbine/kernel/wave/nn/quant_linear.py
+++ b/iree/turbine/kernel/wave/nn/quant_linear.py
@@ -72,7 +72,7 @@ def get_quant_linear_kernel(
     ]
 
     # With dynamic dimensions, we need to add an assumption on how big
-    # the reduction dimension is to determine whether we can schedule or not.
+    # the iterate dimension is to determine whether we can schedule or not.
     if dynamic_dims:
         constraints += [tkw.Assumption(K > BLOCK_K * 4)]
 
@@ -104,7 +104,7 @@ def get_quant_linear_kernel(
         a_scale_deq = tkl.Register[B, M, N, input_wtype](input_scale.item())
         b_scale_deq = tkl.Register[B, M, N, input_wtype](weight_scale.item())
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:

--- a/iree/turbine/kernel/wave/scheduling/loop_reconstruction_utils.py
+++ b/iree/turbine/kernel/wave/scheduling/loop_reconstruction_utils.py
@@ -2,7 +2,7 @@ from ..constraints import Constraint, TilingConstraint
 from ..._support.indexing import IndexSymbol
 from ..._support.tracing import CapturedTrace
 from ...ops.wave_ops import (
-    Reduction,
+    Iterate,
     IterArg,
     Output,
     Write,
@@ -230,7 +230,7 @@ def create_drain_stage_schedule(n: int) -> list[list[int]]:
     return schedule
 
 
-def liveness_analysis(graph: fx.Graph, reduction: Reduction) -> dict[fx.Node, int]:
+def liveness_analysis(graph: fx.Graph, reduction: Iterate) -> dict[fx.Node, int]:
     """
     Perform liveness analysis on the graph to determine the live ranges of
     variables and use that to deduce how many rotating registers we need.

--- a/iree/turbine/kernel/wave/scheduling/multi_buffering.py
+++ b/iree/turbine/kernel/wave/scheduling/multi_buffering.py
@@ -17,7 +17,7 @@ from ...ops.wave_ops import (
     Read,
     Write,
     CustomOp,
-    Reduction,
+    Iterate,
 )
 import iree.turbine.kernel.lang as tkl
 
@@ -26,7 +26,7 @@ def multi_buffer(trace: CapturedTrace):
     """Perform multi buffering for all supported shared memory locations"""
 
     # Find all reductions
-    reductions = trace.walk(lambda node: isinstance(get_custom(node), Reduction))
+    reductions = trace.walk(lambda node: isinstance(get_custom(node), Iterate))
 
     # Get reduction dimension from first reduction
     if not reductions or len(reductions) != 1:

--- a/iree/turbine/kernel/wave/scheduling/schedule.py
+++ b/iree/turbine/kernel/wave/scheduling/schedule.py
@@ -6,7 +6,7 @@
 
 from ..constraints import Constraint
 from ..._support.tracing import CapturedTrace
-from ...ops.wave_ops import Reduction, IterArg, get_custom, CustomOp
+from ...ops.wave_ops import Iterate, IterArg, get_custom, CustomOp
 from .multi_buffering import multi_buffer
 from .modulo_scheduling import ModuloScheduler
 from .prefetch_scheduling import PrefetchScheduler
@@ -43,7 +43,7 @@ def visualize_scheduling_graph(edges: list[Edge]):
 
 
 def schedule_reduction(
-    reduction: Reduction,
+    reduction: Iterate,
     trace: CapturedTrace,
     constraints: list[Constraint],
     use_scheduling_barriers: bool = False,
@@ -183,7 +183,7 @@ def schedule_graph(
         return
 
     def is_reduction(node: fx.Node) -> bool:
-        return isinstance(get_custom(node), Reduction)
+        return isinstance(get_custom(node), Iterate)
 
     reduction_nodes = trace.walk(is_reduction)
     if not reduction_nodes:

--- a/iree/turbine/kernel/wave/templates/alibi_attention.py
+++ b/iree/turbine/kernel/wave/templates/alibi_attention.py
@@ -96,7 +96,7 @@ def get_alibi_attention_kernel(
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/conv.py
+++ b/iree/turbine/kernel/wave/templates/conv.py
@@ -135,9 +135,9 @@ def get_igemm_conv2d(
     ):
         c_reg = tkl.Register[M, NF, output_dtype](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(
-            acc: tkl.Register[M, NF, output_dtype]
+            acc: tkl.Register[M, NF, output_dtype],
         ) -> tkl.Register[M, NF, output_dtype]:
             a_reg = tkw.read(
                 x,

--- a/iree/turbine/kernel/wave/templates/decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/decode_attention.py
@@ -156,7 +156,7 @@ def get_decode_attention_kernels(
         init_sum = tkl.Register[B, M, tkl.f32](0.0)
         init_max = tkl.Register[B, M, tkl.f32](-1e6)
 
-        @tkw.reduction(U, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(U, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/evoformer.py
+++ b/iree/turbine/kernel/wave/templates/evoformer.py
@@ -120,7 +120,7 @@ def get_evoformer_kernel(
         init_sum = tkl.Register[B, BN, H, M, tkl.f32](0.0)
         init_max = tkl.Register[B, BN, H, M, tkl.f32](-1e6)
 
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, BN, H, M, tkl.f32],
             partial_sum: tkl.Register[B, BN, H, M, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -246,7 +246,7 @@ def get_extend_attention_kernel(
             seq_mask_start_idx = tkw.read(mask_offsets, elements_per_thread=1)
             tkw.set_symbol(MASK_START_IDX, seq_mask_start_idx)
 
-        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(N_KV, init_args=[init_max, init_sum, c_reg])
         def first_loop(
             partial_max: tkl.Register[H, N_Q, tkl.f32],
             partial_sum: tkl.Register[H, N_Q, tkl.f32],
@@ -320,7 +320,7 @@ def get_extend_attention_kernel(
         if use_custom_mask:
             tkw.set_symbol(PREFIX_LEN, seq_len_prefix)
 
-        @tkw.reduction(N_KV, init_args=[res_max, res_sum, res_mm])
+        @tkw.iterate(N_KV, init_args=[res_max, res_sum, res_mm])
         def second_loop(
             partial_max: tkl.Register[H, N_Q, tkl.f32],
             partial_sum: tkl.Register[H, N_Q, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/extend_attention_rpe.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention_rpe.py
@@ -218,7 +218,7 @@ def get_extend_attention_rpe_kernel(
         )
         tkw.set_symbol(N_KV, seq_len_prefix)
 
-        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(N_KV, init_args=[init_max, init_sum, c_reg])
         def first_loop(
             partial_max: tkl.Register[H, N_Q, tkl.f32],
             partial_sum: tkl.Register[H, N_Q, tkl.f32],
@@ -277,7 +277,7 @@ def get_extend_attention_rpe_kernel(
 
         tkw.set_symbol(N_KV, seq_len_extend)
 
-        @tkw.reduction(N_KV, init_args=[res_max, res_sum, res_mm])
+        @tkw.iterate(N_KV, init_args=[res_max, res_sum, res_mm])
         def second_loop(
             partial_max: tkl.Register[H, N_Q, tkl.f32],
             partial_sum: tkl.Register[H, N_Q, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/gqa_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/gqa_decode_attention.py
@@ -176,7 +176,7 @@ def get_gqa_decode_attention_kernels(
         zero = tkl.Register[H_Q, N_KV, tkl.f32](0.0)
         neg_infinity = tkl.Register[H_Q, N_KV, tkl.f32](-1e6)
 
-        @tkw.reduction(N_KV, init_args=[init_max, init_sum, new_acc])
+        @tkw.iterate(N_KV, init_args=[init_max, init_sum, new_acc])
         def loop(
             partial_max: tkl.Register[B, H_Q, tkl.f32],
             partial_sum: tkl.Register[B, H_Q, tkl.f32],
@@ -227,7 +227,7 @@ def get_gqa_decode_attention_kernels(
         init_sum = tkl.Register[B, H_Q, tkl.f32](0.0)
         init_max = tkl.Register[B, H_Q, tkl.f32](-1e6)
 
-        @tkw.reduction(U, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(U, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, H_Q, tkl.f32],
             partial_sum: tkl.Register[B, H_Q, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/gqa_vanilla_attention.py
+++ b/iree/turbine/kernel/wave/templates/gqa_vanilla_attention.py
@@ -158,7 +158,7 @@ def get_gqa_bshd_attention_kernel(
         ZEROF = tkl.Register[N_Q, N_KV, tkl.f32](0.0)
         MIN_INF = tkl.Register[N_Q, N_KV, tkl.f32](-1e6)
 
-        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(N_KV, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, H, N_Q, tkl.f32],
             partial_sum: tkl.Register[B, H, N_Q, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -243,7 +243,7 @@ def get_paged_decode_attention_kernels(
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
 
-        @tkw.reduction(K2, init_args=[init_max, init_sum, new_acc])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(
             partial_max: tkl.Register[S, B, tkl.f32],
             partial_sum: tkl.Register[S, B, tkl.f32],
@@ -315,7 +315,7 @@ def get_paged_decode_attention_kernels(
         init_sum = tkl.Register[S, B, tkl.f32](0.0)
         init_max = tkl.Register[S, B, tkl.f32](-1e6)
 
-        @tkw.reduction(U, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(U, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[S, B, tkl.f32],
             partial_sum: tkl.Register[S, B, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/prefill_attention.py
+++ b/iree/turbine/kernel/wave/templates/prefill_attention.py
@@ -148,7 +148,7 @@ def get_prefill_attention_kernel(
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(N_KV, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[H, N_Q, tkl.f32],
             partial_sum: tkl.Register[H, N_Q, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/quantized_attention.py
+++ b/iree/turbine/kernel/wave/templates/quantized_attention.py
@@ -138,7 +138,7 @@ def get_brevitas_pertensor_fp8_attention_kernel(
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(N_KV, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(N_KV, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, N_Q, tkl.f32],
             partial_sum: tkl.Register[B, N_Q, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
+++ b/iree/turbine/kernel/wave/templates/t5_rpe_attention.py
@@ -104,7 +104,7 @@ def get_t5_rpe_attention_kernel(
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],

--- a/iree/turbine/kernel/wave/templates/vanilla_attention.py
+++ b/iree/turbine/kernel/wave/templates/vanilla_attention.py
@@ -91,7 +91,7 @@ def get_vanilla_attention_kernel(
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
@@ -282,7 +282,7 @@ def get_bshd_attention_kernel(
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, H, M, tkl.f32],
             partial_sum: tkl.Register[B, H, M, tkl.f32],
@@ -331,7 +331,7 @@ def get_bshd_attention_kernel(
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, H, M, tkl.f32],
             partial_sum: tkl.Register[B, H, M, tkl.f32],

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Optional
 
 from ..._support.indexing import IndexExpr, IndexSequence, IndexSymbol
 from ...lang.global_symbols import *
-from ...ops.wave_ops import CustomOp, Read, Reduction, Write
+from ...ops.wave_ops import CustomOp, Read, Iterate, Write
 from ..assumptions import Assumption
 from ..constraints import (
     Constraint,
@@ -178,7 +178,7 @@ def find_index_bounds(
 
 
 def get_induction_variable(
-    reduction: Reduction, constraints: list[Constraint]
+    reduction: Iterate, constraints: list[Constraint]
 ) -> IndexSymbol:
     induction_var = None
     for constraint in constraints:
@@ -194,7 +194,7 @@ def get_induction_variable(
 
 
 def get_tiling_constraint(
-    reduction: Reduction, constraints: list[Constraint]
+    reduction: Iterate, constraints: list[Constraint]
 ) -> TilingConstraint:
     for constraint in constraints:
         if (

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -11,7 +11,7 @@ from ..compiler import builder, dispatch_codegen, kernel_codegen, host_codegen
 from ..lang import Grid, IndexMapping
 from ..lang.global_symbols import *
 from ..ops import wave_ops
-from ..ops.wave_ops import Reduction, CustomOp, get_custom, IterArg
+from ..ops.wave_ops import Iterate, CustomOp, get_custom, IterArg
 from .._support.indexing import IndexingContext, IndexExpr
 from .symbolic_constraints import SymbolicAlias
 from .._support.tracing import (
@@ -241,7 +241,7 @@ class LaunchableWave(Launchable):
 
         def is_reduction(node: fx.Node):
             custom = get_custom(node)
-            return isinstance(custom, Reduction)
+            return isinstance(custom, Iterate)
 
         reduction_nodes = trace.walk(is_reduction)
         for node in reduction_nodes:
@@ -275,7 +275,7 @@ class LaunchableWave(Launchable):
         tiling constraints associated with the reduction.
 
         """
-        is_reduction = lambda node: isinstance(get_custom(node), Reduction)
+        is_reduction = lambda node: isinstance(get_custom(node), Iterate)
         for reduction in trace.walk(is_reduction):
             for tiling_constraint in self.tiling_constraints:
                 if tiling_constraint.dim == get_custom(reduction).axis:

--- a/iree/turbine/kernel/wave/wave_sim.py
+++ b/iree/turbine/kernel/wave/wave_sim.py
@@ -219,7 +219,7 @@ class _TklProxy:
     Register = _RegisterProxy()
 
 
-def _reduction_proxy(axis: int, init_args: list[Any]):
+def _iterate_proxy(axis: int, init_args: list[Any]):
     def decorator(func: Callable[..., Any]) -> Any:
         return func(*init_args)
 
@@ -295,7 +295,7 @@ def _mma_proxy(a: "Register", b: "Register", acc: "Register") -> "Register":
 
 
 class _TkwProxy:
-    reduction = _reduction_proxy
+    iterate = _iterate_proxy
     read = _read_proxy
     write = _write_proxy
     mma = _mma_proxy

--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -84,7 +84,7 @@ def test_attention_32x32x8():
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
@@ -218,7 +218,7 @@ def test_dynamic_attention_32x32x8():
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],

--- a/lit_tests/kernel/wave/attention/attention_bias.py
+++ b/lit_tests/kernel/wave/attention/attention_bias.py
@@ -79,7 +79,7 @@ def test_attention_bias():
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],

--- a/lit_tests/kernel/wave/attention/evoformer.py
+++ b/lit_tests/kernel/wave/attention/evoformer.py
@@ -104,7 +104,7 @@ def test_evoformer():
         init_sum = tkl.Register[B, BN, H, M, tkl.f32](0.0)
         init_max = tkl.Register[B, BN, H, M, tkl.f32](-1e6)
 
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, BN, H, M, tkl.f32],
             partial_sum: tkl.Register[B, BN, H, M, tkl.f32],

--- a/lit_tests/kernel/wave/attention/pipelined_attention.py
+++ b/lit_tests/kernel/wave/attention/pipelined_attention.py
@@ -84,7 +84,7 @@ def test_dynamic_attention_pipelined():
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
@@ -218,7 +218,7 @@ def test_attention_pipelined():
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],

--- a/lit_tests/kernel/wave/barriers.py
+++ b/lit_tests/kernel/wave/barriers.py
@@ -151,7 +151,7 @@ def gemm(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -203,16 +203,16 @@ def test_gemm():
         # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %allocate
         # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
-        # CHECK-NEXT: reduction
+        # CHECK-NEXT: iterate
         # CHECK-SAME: (K, [%register_M:0_N:0_K:0, %register_M:0_N:1_K:0, %register_M:1_N:0_K:0, %register_M:1_N:1_K:0]
         # CHECK-NEXT: %get_result_M:0_N:0_K:0
-        # CHECK-SAME: (%reduction, 0)
+        # CHECK-SAME: (%iterate, 0)
         # CHECK-NEXT: %get_result_M:0_N:1_K:0
-        # CHECK-SAME: (%reduction, 1)
+        # CHECK-SAME: (%iterate, 1)
         # CHECK-NEXT: %get_result_M:1_N:0_K:0
-        # CHECK-SAME: (%reduction, 2)
+        # CHECK-SAME: (%iterate, 2)
         # CHECK-NEXT: %get_result_M:1_N:1_K:0
-        # CHECK-SAME: (%reduction, 3)
+        # CHECK-SAME: (%iterate, 3)
         # CHECK-NEXT: %write_M:0_N:0_K:0
         # CHECK-SAME: (%get_result_M:0_N:0_K:0, %c, 4, None, ())
         # CHECK-NEXT: %write_M:0_N:1_K:0
@@ -223,7 +223,7 @@ def test_gemm():
         # CHECK-SAME: (%get_result_M:1_N:1_K:0, %c, 4, None, ())
         # CHECK-NEXT: return None
 
-        # Reduction subgraph:
+        # iterate subgraph:
         # CHECK: %b
         # CHECK: %a
         # CHECK-NEXT: %acc_M:0_N:0_K:0

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -1140,7 +1140,7 @@ def test_reduction_and_elemwise():
     ):
         init_max = tkl.Register[M, tkl.f16](-1e6)
 
-        @tkw.reduction(N, init_args=[init_max])
+        @tkw.iterate(N, init_args=[init_max])
         def repeat(
             partial_max: tkl.Register[M, tkl.f16],
         ) -> tkl.Register[M, tkl.f16]:
@@ -1228,7 +1228,7 @@ def test_tiled_reduce_max():
     ):
         init_max = tkl.Register[M, tkl.f16](-1e6)
 
-        @tkw.reduction(N, init_args=[init_max])
+        @tkw.iterate(N, init_args=[init_max])
         def repeat(
             partial_max: tkl.Register[M, tkl.f16],
         ) -> tkl.Register[M, tkl.f16]:
@@ -1320,7 +1320,7 @@ def test_tiled_reduce_min():
     ):
         init_min = tkl.Register[M, tkl.f16](1e6)
 
-        @tkw.reduction(N, init_args=[init_min])
+        @tkw.iterate(N, init_args=[init_min])
         def repeat(
             partial_min: tkl.Register[M, tkl.f16],
         ) -> tkl.Register[M, tkl.f16]:
@@ -1411,7 +1411,7 @@ def test_tiled_reduce_min_unaligned():
     ):
         init_min = tkl.Register[M, tkl.f16](1e6)
 
-        @tkw.reduction(N, init_args=[init_min])
+        @tkw.iterate(N, init_args=[init_min])
         def repeat(
             partial_min: tkl.Register[M, tkl.f16],
         ) -> tkl.Register[M, tkl.f16]:
@@ -1489,7 +1489,7 @@ def test_multiple_reduction_iv():
         init_max = tkl.Register[M, tkl.f16](-1e6)
         init_sum = tkl.Register[M, tkl.f16](0)
 
-        @tkw.reduction(N, init_args=[init_max, init_sum])
+        @tkw.iterate(N, init_args=[init_max, init_sum])
         def repeat(
             partial_max: tkl.Register[M, tkl.f16],
             partial_sum: tkl.Register[M, tkl.f16],
@@ -1589,7 +1589,7 @@ def test_reduce_propagate_broadcast():
         init_max = tkl.Register[M, tkl.f32](-1e6)
         init_sum = tkl.Register[M, tkl.f32](0)
 
-        @tkw.reduction(N, init_args=[init_max, init_sum])
+        @tkw.iterate(N, init_args=[init_max, init_sum])
         def repeat(
             partial_max: tkl.Register[M, tkl.f32],
             partial_sum: tkl.Register[M, tkl.f32],

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -201,17 +201,17 @@ def test_read_write():
 
 
 @tkw.wave_trace_only()
-def write_in_reduction(
+def write_in_iterate(
     a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
     b: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
     c: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
 ):
     # TODO(#364): simplify this by removing the max once it's possible to have a
-    # loop/reduction without reducing over something.
+    # loop/iterate without reducing over something.
     init_max = tkl.Register[M, tkl.f16](-1e6)
 
     # TODO: Cannot deduce elements_per_thread for a_reg without a workgroup constraint yet.
-    @tkw.reduction(K, init_args=[init_max])
+    @tkw.iterate(K, init_args=[init_max])
     def repeat(acc: tkl.Register[M, tkl.f16]) -> tkl.Register[M, tkl.f16]:
         a_reg = tkw.read(a, elements_per_thread=4)
         tkw.write(a_reg, b, elements_per_thread=4)
@@ -221,7 +221,7 @@ def write_in_reduction(
 
 
 @run_test
-def test_write_in_reduction():
+def test_write_in_iterate():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.TilingConstraint(K, BLOCK_K, ARGK)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M / 2, THREAD_0 / 64)]
@@ -238,7 +238,7 @@ def test_write_in_reduction():
             BLOCK_K: 32,
         }
     ):
-        graph = write_in_reduction()
+        graph = write_in_iterate()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
         infer_types(graph)
@@ -248,19 +248,19 @@ def test_write_in_reduction():
         print_trace(graph)
         # Root graph:
         # CHECK: graph()
-        # CHECK: %reduction :
+        # CHECK: %iterate :
         # CHECK-SAME: args = (K,
         # CHECK: %get_result_M:0_K:0 :
-        # CHECK-SAME: args = (%reduction, 0)
+        # CHECK-SAME: args = (%iterate, 0)
         # CHECK: %write_M:0_K:0 :
         # CHECK-SAME: (%get_result_M:0_K:0, %c, 4,
 
         # CHECK: Custom format:
-        # CHECK: reduction(axis=K,
-        # CHECK: get_result(value=reduction, res_idx=0)
+        # CHECK: iterate(axis=K,
+        # CHECK: get_result(value=iterate, res_idx=0)
         # CHECK: write(register_=get_result_M:0_K:0, memory=c, elements_per_thread=4,
 
-        # Reduction subgraph:
+        # iterate subgraph:
         # CHECK: graph():
         # CHECK: %read_M:0_K:0 :
         # CHECK-SAME: (args = (%a, 4,
@@ -287,7 +287,7 @@ def gemm(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -378,7 +378,7 @@ def test_gemm():
         # CHECK-NEXT: %register_M:0_N:1_K:0
         # CHECK-NEXT: %register_M:1_N:0_K:0
         # CHECK-NEXT: %register_M:1_N:1_K:0
-        # CHECK-NEXT: %reduction
+        # CHECK-NEXT: %iterate
         # CHECK-SAME: %register_M:0_N:0_K:0, %register_M:0_N:1_K:0, %register_M:1_N:0_K:0, %register_M:1_N:1_K:0
         # CHECK-NEXT: %get_result_M:0_N:0_K:0
         # CHECK-NEXT: %get_result_M:0_N:1_K:0
@@ -402,11 +402,11 @@ def test_gemm():
         # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1})
         # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1})
-        # CHECK-NEXT: reduction(axis=K, init_args=[register_M:0_N:0_K:0, register_M:0_N:1_K:0, register_M:1_N:0_K:0, register_M:1_N:1_K:0], subgraph_name=region_0, implicit_captures=[a, b])
-        # CHECK-NEXT: get_result(value=reduction, res_idx=0)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=1)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=2)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=3)
+        # CHECK-NEXT: iterate(axis=K, init_args=[register_M:0_N:0_K:0, register_M:0_N:1_K:0, register_M:1_N:0_K:0, register_M:1_N:1_K:0], subgraph_name=region_0, implicit_captures=[a, b])
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=1)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=2)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=3)
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0
         # CHECK-SAME: index={M:  $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1}
         # CHECK-NEXT: write(register_=get_result_M:0_N:1_K:0
@@ -417,7 +417,7 @@ def test_gemm():
         # CHECK-SAME: index={M:  $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1}
         # CHECK-NEXT: output
 
-        # Reduction subgraph:
+        # iterate subgraph:
         # CHECK: region_0:
         # CHECK: graph():
         # CHECK: %acc_M:0_N:0_K:0
@@ -515,7 +515,7 @@ def batched_gemm(
 ):
     c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[B, M, N, tkl.f32]) -> tkl.Register[B, M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -567,7 +567,7 @@ def test_batched_gemm():
         # CHECK-NEXT: %register_M:0_N:1_K:0
         # CHECK-NEXT: %register_M:1_N:0_K:0
         # CHECK-NEXT: %register_M:1_N:1_K:0
-        # CHECK-NEXT: %reduction
+        # CHECK-NEXT: %iterate
         # CHECK-SAME: %register_M:0_N:0_K:0, %register_M:0_N:1_K:0, %register_M:1_N:0_K:0, %register_M:1_N:1_K:0
         # CHECK-NEXT: %get_result_M:0_N:0_K:0
         # CHECK-NEXT: %get_result_M:0_N:1_K:0
@@ -591,11 +591,11 @@ def test_batched_gemm():
         # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1})
         # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1})
-        # CHECK-NEXT: reduction(axis=K, init_args=[register_M:0_N:0_K:0, register_M:0_N:1_K:0, register_M:1_N:0_K:0, register_M:1_N:1_K:0], subgraph_name=region_0, implicit_captures=[a, b])
-        # CHECK-NEXT: get_result(value=reduction, res_idx=0)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=1)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=2)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=3)
+        # CHECK-NEXT: iterate(axis=K, init_args=[register_M:0_N:0_K:0, register_M:0_N:1_K:0, register_M:1_N:0_K:0, register_M:1_N:1_K:0], subgraph_name=region_0, implicit_captures=[a, b])
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=1)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=2)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=3)
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0
         # CHECK-SAME: index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1}
         # CHECK-NEXT: write(register_=get_result_M:0_N:1_K:0
@@ -606,7 +606,7 @@ def test_batched_gemm():
         # CHECK-SAME: index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1}
         # CHECK-NEXT: output
 
-        # Reduction subgraph:
+        # iterate subgraph:
 
         # CHECK: %acc_M:0_N:0_K:0
         # CHECK-NEXT: %acc_M:0_N:1_K:0
@@ -704,7 +704,7 @@ def gemm_non_direct_acc(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -774,7 +774,7 @@ def tiled_max(
 ):
     init_max = tkl.Register[M, tkl.f16](-1e6)
 
-    @tkw.reduction(K, init_args=[init_max])
+    @tkw.iterate(K, init_args=[init_max])
     def repeat(acc: tkl.Register[M, tkl.f16]) -> tkl.Register[M, tkl.f16]:
         a_reg = tkw.read(a, elements_per_thread=4)
         partial_max = tkw.max(a_reg, acc, dim=K)
@@ -816,9 +816,9 @@ def test_tiled_max():
 
 
 @run_test
-def test_gemm_reduction_expansion_only():
+def test_gemm_iterate_expansion_only():
     # Note: This does not implement an actual gemm computation but reuses the
-    # gemm kernel to test the expansion of the reduction subgraph.
+    # gemm kernel to test the expansion of the iterate subgraph.
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
     constraints += [tkw.TilingConstraint(K, BLOCK_K, ARGK)]
@@ -847,7 +847,7 @@ def test_gemm_reduction_expansion_only():
         # CHECK-NEXT: %b
         # CHECK-NEXT: %c
         # CHECK-NEXT: %register_M:0_N:0_K:0
-        # CHECK-NEXT: %reduction
+        # CHECK-NEXT: %iterate
         # CHECK-NEXT: %get_result_M:0_N:0_K:0
         # CHECK-NEXT: %write_M:0_N:0_K:0
         # CHECK-SAME: (%get_result_M:0_N:0_K:0, %c, 4, None, ())
@@ -858,13 +858,13 @@ def test_gemm_reduction_expansion_only():
         # CHECK-NEXT: placeholder(_name=b
         # CHECK-NEXT: placeholder(_name=c
         # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
-        # CHECK-NEXT: reduction(axis=K, init_args=[register_M:0_N:0_K:0]
-        # CHECK-NEXT: get_result(value=reduction, res_idx=0)
+        # CHECK-NEXT: iterate(axis=K, init_args=[register_M:0_N:0_K:0]
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0
         # CHECK-SAME: index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: output(return_vals=(None,))
 
-        # Reduction subgraph:
+        # iterate subgraph:
 
         # CHECK: %acc_M:0_N:0_K:0
 
@@ -918,9 +918,9 @@ def attention(
     init_sum = tkl.Register[B, M, tkl.f32](0.0)
     init_max = tkl.Register[B, M, tkl.f32](-1e6)
 
-    # This microkernel encodes the fact that if the reduction
+    # This microkernel encodes the fact that if the iterate
     # dimension were tiled, then we would need to materialize a loop.
-    @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+    @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
     def repeat(
         partial_max: tkl.Register[B, M, tkl.f32],
         partial_sum: tkl.Register[B, M, tkl.f32],
@@ -999,7 +999,7 @@ def test_attention():
     # CHECK: write(register_=truediv_M:1_N:1_K2:0,
     # CHECK-SAME: index={B: $WG2*BLOCK_B : 1 : 1, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16) + 16 : 1 : 1})
 
-    # Reduction graph:
+    # iterate graph:
     # CHECK: read(memory=q,
     # CHECK-SAME: index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + Mod($T0, 16) : 1 : 1, K1: 4*floor((Mod($T0, 64))/16) : 4 : 1})
     # CHECK: read(memory=q,
@@ -1139,7 +1139,7 @@ def chained_gemm_32x32x8(
 ):
     c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K2, init_args=[c_reg])
+    @tkw.iterate(K2, init_args=[c_reg])
     def repeat(acc: tkl.Register[B, M, N, tkl.f32]) -> tkl.Register[B, M, N, tkl.f32]:
         inner_acc = tkl.Register[B, K2, M, tkl.f32](0.0)
         q_reg = tkw.read(q, elements_per_thread=4)

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -79,7 +79,7 @@ def test_gemm():
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -156,7 +156,7 @@ def test_cdna2_int_gemm():
     ):
         c_reg = tkl.Register[M, N, tkl.i32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.i32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -231,7 +231,7 @@ def test_cdna3_int_gemm():
     ):
         c_reg = tkl.Register[M, N, tkl.i32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.i32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -307,7 +307,7 @@ def test_batched_gemm():
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:
@@ -396,7 +396,7 @@ def test_chained_gemm():
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K2, init_args=[c_reg])
+        @tkw.iterate(K2, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:
@@ -479,7 +479,7 @@ def test_chained_gemm_32x32x8():
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K2, init_args=[c_reg])
+        @tkw.iterate(K2, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:
@@ -565,7 +565,7 @@ def test_chained_gemm_32x32x16():
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K2, init_args=[c_reg])
+        @tkw.iterate(K2, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:
@@ -659,7 +659,7 @@ def test_chained_gemm_16x16x32():
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K2, init_args=[c_reg])
+        @tkw.iterate(K2, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:
@@ -744,7 +744,7 @@ def test_gemm_pipelined():
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -837,7 +837,7 @@ def test_gemm_prefetch():
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -936,7 +936,7 @@ def test_dynamic_gemm_pipelined():
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -1039,7 +1039,7 @@ def test_gemm_with_gpr_offsets():
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
             a_reg = tkw.cast(a_reg, tkl.f8e4m3fnuz)
@@ -1121,7 +1121,7 @@ def test_gemm_and_reduce():
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
         init_max = tkl.Register[M, tkl.f16](-1e6)
 
-        @tkw.reduction(K, init_args=[init_max, c_reg])
+        @tkw.iterate(K, init_args=[init_max, c_reg])
         def repeat(
             partial_max: tkl.Register[M, tkl.f16], acc: tkl.Register[M, N, tkl.f32]
         ) -> tkl.Register[M, N, tkl.f32]:
@@ -1209,7 +1209,7 @@ def test_gemm_with_maximized_shared_read_32x32x16():
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             # a_reg: tkw.Register[M, K, tkl.f16]
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -1295,7 +1295,7 @@ def test_gemm_with_maximized_shared_read_16x16x32():
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             # a_reg: tkw.Register[M, K, tkl.f16]
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -1384,7 +1384,7 @@ def test_broadcast_batched_gemm_with_vmma():
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:

--- a/lit_tests/kernel/wave/igemm.py
+++ b/lit_tests/kernel/wave/igemm.py
@@ -149,7 +149,7 @@ def test_igemm():
     ):
         c_reg = tkl.Register[M, NF, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, NF, tkl.f32]) -> tkl.Register[M, NF, tkl.f32]:
             a_reg = tkw.read(
                 x,

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -59,7 +59,7 @@ def gemm(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -121,16 +121,16 @@ def test_gemm():
         # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %allocate
         # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
-        # CHECK-NEXT: reduction
+        # CHECK-NEXT: iterate
         # CHECK-SAME (K, [%register_M:0_N:0_K:0, %register_M:1_N:1_K:0, %register_M:1_N:0_K:0, %register_M:0_N:1_K:0]
         # CHECK-NEXT: %get_result_M:0_N:0_K:0
-        # CHECK-SAME: (%reduction, 0)
+        # CHECK-SAME: (%iterate, 0)
         # CHECK-NEXT: %get_result_M:0_N:1_K:0
-        # CHECK-SAME: (%reduction, 1)
+        # CHECK-SAME: (%iterate, 1)
         # CHECK-NEXT: %get_result_M:1_N:0_K:0
-        # CHECK-SAME: (%reduction, 2)
+        # CHECK-SAME: (%iterate, 2)
         # CHECK-NEXT: %get_result_M:1_N:1_K:0
-        # CHECK-SAME: (%reduction, 3)
+        # CHECK-SAME: (%iterate, 3)
         # CHECK-NEXT: %write_M:0_N:0_K:0
         # CHECK-SAME: (%get_result_M:0_N:0_K:0, %c, 4, None, ())
         # CHECK-NEXT: %write_M:0_N:1_K:0
@@ -155,11 +155,11 @@ def test_gemm():
         # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1})
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: allocate(
-        # CHECK-NEXT: reduction(
-        # CHECK-NEXT: get_result(value=reduction, res_idx=0)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=1)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=2)
-        # CHECK-NEXT: get_result(value=reduction, res_idx=3)
+        # CHECK-NEXT: iterate(
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=1)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=2)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=3)
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0, memory=c
         # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: write(register_=get_result_M:0_N:1_K:0, memory=c
@@ -169,7 +169,7 @@ def test_gemm():
         # CHECK-NEXT: write(register_=get_result_M:1_N:1_K:0, memory=c
         # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1})
 
-        # Reduction subgraph:
+        # iterate subgraph:
         # CHECK: %shared_memory_barrier_1
         # CHECK-NEXT: %b
         # CHECK-NEXT: %a
@@ -227,7 +227,7 @@ def test_gemm():
         # CHECK-NEXT: %mma_M:1_N:1_K:2
         # CHECK-NEXT: %mma_M:1_N:1_K:3
 
-        # Reduction subgraph (custom format):
+        # iterate subgraph (custom format):
         # CHECK: Custom format:
         # CHECK-NEXT: shared_memory_barrier()
         # CHECK-NEXT: placeholder(_name=b, _type=Memory[N, K].of(f16))

--- a/lit_tests/kernel/wave/multi_buffering.py
+++ b/lit_tests/kernel/wave/multi_buffering.py
@@ -29,7 +29,7 @@ from iree.turbine.kernel._support.indexing import IndexingContext
 from iree.turbine.kernel.ops.wave_ops import (
     Allocate,
     Read,
-    Reduction,
+    Iterate,
     Write,
     get_custom,
     GetResult,
@@ -73,7 +73,7 @@ def gemm(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -142,7 +142,7 @@ def test_gemm_multibuffering():
                 case Read() | Write():
                     if custom.memory_type.address_space == SHARED_ADDRESS_SPACE:
                         print(custom)
-                case Reduction():
+                case Iterate():
                     print("reduction begin")
                     for node in trace.get_subgraph(custom.subgraph_name).nodes:
                         print_affected_node(node)

--- a/lit_tests/kernel/wave/promotion.py
+++ b/lit_tests/kernel/wave/promotion.py
@@ -148,7 +148,7 @@ def gemm(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -192,11 +192,11 @@ def test_gemm():
         # CHECK-SAME: ((N, K), (BLOCK_N, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
         # CHECK-NEXT: %allocate
         # CHECK-SAME: ((M, K), (BLOCK_M, BLOCK_K + 4), f16, $SHARED_ADDRESS_SPACE, 4)
-        # CHECK-NEXT: reduction
+        # CHECK-NEXT: iterate
         # CHECK-NEXT: %write
-        # CHECK-SAME: (%reduction, %c, 4, None, ())
+        # CHECK-SAME: (%iterate, %c, 4, None, ())
 
-        # Reduction subgraph:
+        # iterate subgraph:
         # CHECK: %b
         # CHECK-NEXT: %a
         # CHECK-NEXT: %acc

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -53,7 +53,7 @@ def gemm_pipelined(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)
@@ -110,7 +110,7 @@ def test_gemm_pipelined():
         apply_shared_memory_indexing_corrections(trace, constraints)
         schedule_graph(trace, constraints, True, SchedulingType.MODULO)
 
-        print_subgraph(trace, "pipelined_reduction", False)
+        print_subgraph(trace, "pipelined_iterate", False)
         # CHECK: %acc_m_0_n_0_k_0
         # CHECK-NEXT: %acc_m_0_n_1_k_0
         # CHECK-NEXT: %acc_m_1_n_0_k_0
@@ -177,7 +177,7 @@ def test_gemm_pipelined():
         # CHECK-NEXT: %read_2_shared_M:1_N:0_K:1
         # CHECK-NEXT: %read_4_shared_M:0_N:0_K:1
         # CHECK-NEXT: %read_2_shared_M:0_N:0_K:1
-        # CHECK-NEXT: %reduction_1
+        # CHECK-NEXT: %iterate_1
         # CHECK-NEXT: %get_result_M:0_N:0_K:0
         # CHECK-NEXT: %get_result_M:0_N:1_K:0
         # CHECK-NEXT: %get_result_M:1_N:0_K:0

--- a/lit_tests/kernel/wave/tracing.py
+++ b/lit_tests/kernel/wave/tracing.py
@@ -199,7 +199,7 @@ def test_trace_gemm():
     ):
         c = tkl.Register[M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c])
+        @tkw.iterate(K, init_args=[c])
         def repeat(acc) -> tkl.Register[M, N, tkl.f32]:
             a = tkw.read(A)
             b = tkw.read(B)
@@ -216,7 +216,7 @@ def test_trace_gemm():
     # CHECK-NEXT: %b
     # CHECK-NEXT: %c
     # CHECK-NEXT: %register
-    # CHECK-NEXT: %reduction
+    # CHECK-NEXT: %iterate
     # CHECK-NEXT: %write
     # CHECK-NEXT: return None
 
@@ -225,7 +225,7 @@ def test_trace_gemm():
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: placeholder
     # CHECK-NEXT: register
-    # CHECK-NEXT: reduction
+    # CHECK-NEXT: iterate
     # CHECK-NEXT: write
     # CHECK-NEXT: output
 

--- a/tests/kernel/wave/attention/chained_gemm_test.py
+++ b/tests/kernel/wave/attention/chained_gemm_test.py
@@ -107,7 +107,7 @@ def testChainedGemm(
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K2, init_args=[c_reg])
+        @tkw.iterate(K2, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:
@@ -255,7 +255,7 @@ def testChainedGemmF8(
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K2, init_args=[c_reg])
+        @tkw.iterate(K2, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -511,9 +511,9 @@ def testAttentionBias(
         init_sum = tkl.Register[B, M, tkl.f32](0.0)
         init_max = tkl.Register[B, M, tkl.f32](-1e6)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
@@ -714,9 +714,9 @@ def testAttentionSoftCap(
         log2e = 1.44269504089
         soft_cap = tkl.Register[B, M, K2, tkl.f32](softcap_val * log2e)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],
@@ -906,9 +906,9 @@ def testAttentionF8(
         init_sum = tkl.Register[B, M, tkl.f32](0.0)
         init_max = tkl.Register[B, M, tkl.f32](-1e6)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+        @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
         def repeat(
             partial_max: tkl.Register[B, M, tkl.f32],
             partial_sum: tkl.Register[B, M, tkl.f32],

--- a/tests/kernel/wave/scheduling_test.py
+++ b/tests/kernel/wave/scheduling_test.py
@@ -249,7 +249,7 @@ class SchedulingTest(unittest.TestCase):
         ):
             c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-            @tkw.reduction(K, init_args=[c_reg])
+            @tkw.iterate(K, init_args=[c_reg])
             def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
                 a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
                 b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)

--- a/tests/kernel/wave/type_inference_test.py
+++ b/tests/kernel/wave/type_inference_test.py
@@ -87,7 +87,7 @@ class TypeInferenceTest(unittest.TestCase):
 
             # This microkernel encodes the fact that if the reduction
             # dimension were tiled, then we would need to materialize a loop.
-            @tkw.reduction(K2, init_args=[init_max, init_sum, c_reg])
+            @tkw.iterate(K2, init_args=[init_max, init_sum, c_reg])
             def repeat(
                 partial_max: tkl.Register[B, M, tkl.f32],
                 partial_sum: tkl.Register[B, M, tkl.f32],

--- a/tests/kernel/wave/visualization_test.py
+++ b/tests/kernel/wave/visualization_test.py
@@ -58,7 +58,7 @@ def gemm(
 ):
     c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-    @tkw.reduction(K, init_args=[c_reg])
+    @tkw.iterate(K, init_args=[c_reg])
     def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
         a_reg = tkw.read(a, elements_per_thread=4)
         b_reg = tkw.read(b, elements_per_thread=4)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1067,7 +1067,7 @@ def test_toy_online_softmax(shape):
         init_max = tkl.Register[M, tkl.f32](-1e6)
         init_sum = tkl.Register[M, tkl.f32](0)
 
-        @tkw.reduction(N, init_args=[init_max, init_sum])
+        @tkw.iterate(N, init_args=[init_max, init_sum])
         def repeat(
             partial_max: tkl.Register[M, tkl.f32],
             partial_sum: tkl.Register[M, tkl.f32],
@@ -1165,7 +1165,7 @@ def test_im2col(request):
     constraints += [tkw.WorkgroupConstraint(K, BLOCK_K, 1)]
     constraints += [tkw.WaveConstraint(M, BLOCK_M)]
     constraints += [tkw.WaveConstraint(K, BLOCK_K)]
-    # TODO: TilingConstraint doesn't work without actual reduction loop, instead
+    # TODO: TilingConstraint doesn't work without actual iterate loop, instead
     # we treat K as WG '1' dimension, but corresponding WG size will be always
     # equal to 1.
     # constraints += [tkw.TilingConstraint(K, BLOCK_K)]
@@ -1289,7 +1289,7 @@ def test_im2col_mma(request):
     ):
         c_reg = tkl.Register[M, NF, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, NF, tkl.f32]) -> tkl.Register[M, NF, tkl.f32]:
             a_reg = tkw.read(
                 x,

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -122,7 +122,7 @@ def testGemm(
     ]
 
     # With dynamic dimensions, we need to add an assumption on how big
-    # the reduction dimension is to determine whether we can schedule or not.
+    # the iterate dimension is to determine whether we can schedule or not.
     if dynamic_dims:
         constraints += [tkw.Assumption(K > BLOCK_K * 4)]
 
@@ -140,9 +140,9 @@ def testGemm(
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             # a_reg: tkw.Register[M, K, tkl.f16]
             a_reg = tkw.read(a)
@@ -265,7 +265,7 @@ def testVMFMAGemm(
     ]
 
     # With dynamic dimensions, we need to add an assumption on how big
-    # the reduction dimension is to determine whether we can schedule or not.
+    # the iterate dimension is to determine whether we can schedule or not.
     if dynamic_dims:
         constraints += [tkw.Assumption(K > BLOCK_K * 4)]
 
@@ -283,9 +283,9 @@ def testVMFMAGemm(
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             # a_reg: tkw.Register[M, K, tkl.f16]
             a_reg = tkw.read(a)
@@ -409,7 +409,7 @@ def testCDNA2IntGemm(
     ]
 
     # With dynamic dimensions, we need to add an assumption on how big
-    # the reduction dimension is to determine whether we can schedule or not.
+    # the iterate dimension is to determine whether we can schedule or not.
     if dynamic_dims:
         constraints += [tkw.Assumption(K > BLOCK_K * 4)]
 
@@ -427,9 +427,9 @@ def testCDNA2IntGemm(
     ):
         c_reg = tkl.Register[M, N, tkl.i32](0.0)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.i32]) -> tkl.Register[M, N, tkl.i32]:
             # a_reg: tkw.Register[M, K, tkl.i8]
             a_reg = tkw.read(a)
@@ -556,9 +556,9 @@ def testCDNA3IntGemm(
     ):
         c_reg = tkl.Register[M, N, tkl.i32](0.0)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.i32]) -> tkl.Register[M, N, tkl.i32]:
             # a_reg: tkw.Register[M, K, tkl.i8]
             a_reg = tkw.read(a)
@@ -670,7 +670,7 @@ def testF8Gemm(
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             a_reg = tkw.read(a)
             a_reg = tkw.cast(a_reg, tkl.f8e4m3fnuz)
@@ -772,7 +772,7 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: SchedulingType, reques
     ):
         c_reg = tkl.Register[B, M, N, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(
             acc: tkl.Register[B, M, N, tkl.f32],
         ) -> tkl.Register[B, M, N, tkl.f32]:

--- a/tests/kernel/wave/wave_sim_test.py
+++ b/tests/kernel/wave/wave_sim_test.py
@@ -196,9 +196,9 @@ def test_gemm():
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 
-        # This microkernel encodes the fact that if the reduction
+        # This microkernel encodes the fact that if the iterate
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             # a_reg: tkw.Register[M, K, tkl.f16]
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
@@ -387,7 +387,7 @@ def test_igemm_conv(n, c, nf, stride):
     ):
         c_reg = tkl.Register[M, NF, tkl.f32](0.0)
 
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, NF, tkl.f32]) -> tkl.Register[M, NF, tkl.f32]:
             a_reg = tkw.read(
                 x,


### PR DESCRIPTION
This PR renames the tkw.reduction op to tkw.iterate. While the original op had reduction semantics, with expansion handling the unrolling of the reductions, this op can now be expanded to an iteration over a dimension D.

This PR just renames the op. Many functions will still refer to the variable as a reduction, but that modification requires more careful thought.