### PR TITLE
[BOO] allow `BooConv2d` to take advantage of non-contiguous memory formats

### DIFF
--- a/iree/turbine/kernel/boo/examples/resnet_18_backward.py
+++ b/iree/turbine/kernel/boo/examples/resnet_18_backward.py
@@ -25,7 +25,9 @@ resnet_model = replace_conv2d_with_boo_conv(resnet_model)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 assert device == "cuda", f"device is {device}."
 
-resnet_model = resnet_model.to(device=device)
+resnet_model = resnet_model.to(
+    dtype=torch.bfloat16, device=device, memory_format=torch.channels_last
+)
 
 import torch.optim as optim
 import torch.nn.functional as F
@@ -56,7 +58,9 @@ for epoch in range(epochs):
     resnet_model.train()
     running_loss = 0.0
     for inputs, labels in train_loader:  # Assuming you have a train_loader
-        inputs, labels = inputs.to(device), labels.to(device)
+        inputs, labels = inputs.to(device=device, dtype=torch.bfloat16), labels.to(
+            device
+        )
 
         optimizer.zero_grad()  # Zero the gradients
 

--- a/iree/turbine/kernel/boo/modeling/replace.py
+++ b/iree/turbine/kernel/boo/modeling/replace.py
@@ -29,7 +29,9 @@ class BooConv2d(torch.nn.Module):
         super(BooConv2d, self).__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
-        self.kernel_size = kernel_size
+        self.kernel_size = (
+            [kernel_size] * 2 if isinstance(kernel_size, int) else kernel_size
+        )
         self.stride = stride
         self.padding = padding
         self.dilation = dilation
@@ -37,7 +39,7 @@ class BooConv2d(torch.nn.Module):
         self._bias = bias
 
         self.weight = torch.nn.Parameter(
-            torch.randn(out_channels, in_channels // groups, *kernel_size)
+            torch.randn(out_channels, in_channels // groups, *self.kernel_size)
         )
         if bias:
             self.bias = torch.nn.Parameter(torch.randn(out_channels))

--- a/iree/turbine/kernel/boo/modeling/replace.py
+++ b/iree/turbine/kernel/boo/modeling/replace.py
@@ -50,6 +50,9 @@ class BooConv2d(torch.nn.Module):
         input_layout = "NCHW"
         kernel_layout = "NCHW"
         output_layout = "NCHW"
+        no_batch = len(x.shape) == 3
+        if no_batch:
+            x = x.unsqueeze(0)
         if x.is_contiguous(memory_format=torch.channels_last):
             x = x.permute([0, 2, 3, 1])
             input_layout = "NHWC"
@@ -74,7 +77,7 @@ class BooConv2d(torch.nn.Module):
         )
         if output_layout == "NHWC":
             result = result.permute([0, 3, 1, 2])
-        return result
+        return result.squeeze(0) if no_batch else result
 
 
 def replace_conv2d_with_boo_conv(model):

--- a/tests/kernel/boo/modeling/boo_conv_2d_test.py
+++ b/tests/kernel/boo/modeling/boo_conv_2d_test.py
@@ -1,3 +1,9 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 import unittest
 import tempfile
 from pathlib import Path

--- a/tests/kernel/boo/modeling/boo_conv_2d_test.py
+++ b/tests/kernel/boo/modeling/boo_conv_2d_test.py
@@ -1,0 +1,126 @@
+import unittest
+import tempfile
+from pathlib import Path
+
+import torch
+
+from iree.turbine.kernel.boo.modeling import BooConv2d, replace_conv2d_with_boo_conv
+from iree.turbine.kernel.boo.conv_exports import set_boo_cache
+
+
+class BooConv2dTest(unittest.TestCase):
+    def setUp(self):
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        self.model0 = BooConv2d(
+            in_channels=2, out_channels=3, kernel_size=2, bias=False
+        ).to(device=self.device)
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv0 = torch.nn.Conv2d(
+                    in_channels=3, out_channels=2, kernel_size=3, bias=False
+                )
+                self.conv1 = torch.nn.Conv2d(
+                    in_channels=2, out_channels=3, kernel_size=2, bias=True
+                )
+
+            def forward(self, x):
+                return self.conv1(self.conv0(x))
+
+        self.model1 = M().to(device=self.device)
+
+    def testBasic(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            x = torch.ones([10, 2, 16, 16], device=self.device, dtype=torch.float32)
+            _ = self.model0(x)
+            self.assertIn(
+                "conv_2d_float32_forward_10x2x16x16_nchw_3x2x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                [i.name for i in cache_dir.glob("*")],
+            )
+
+    def testReplacement(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            x = torch.ones([10, 3, 16, 16], device=self.device, dtype=torch.float32)
+            model2 = replace_conv2d_with_boo_conv(self.model1)
+            _ = model2(x)
+            func_names = [i.name for i in cache_dir.glob("*")]
+            self.assertIn(
+                "conv_2d_float32_forward_10x3x16x16_nchw_2x3x3x3_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_forward_b_10x2x14x14_nchw_3x2x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+
+    def testChannelsLast(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            x = torch.ones([10, 2, 16, 16], device=self.device, dtype=torch.float32).to(
+                memory_format=torch.channels_last
+            )
+            model = self.model0.to(memory_format=torch.channels_last)
+            _ = model(x)
+            self.assertIn(
+                "conv_2d_float32_forward_10x16x16x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                [i.name for i in cache_dir.glob("*")],
+            )
+
+    def testReplacementChannelsLast(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            x = torch.ones([10, 3, 16, 16], device=self.device, dtype=torch.float32).to(
+                memory_format=torch.channels_last
+            )
+            model2 = replace_conv2d_with_boo_conv(self.model1).to(
+                memory_format=torch.channels_last
+            )
+            _ = model2(x)
+            func_names = [i.name for i in cache_dir.glob("*")]
+            self.assertIn(
+                "conv_2d_float32_forward_10x16x16x3_nhwc_2x3x3x3_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_forward_b_10x14x14x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+
+    def testBackward(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            model = self.model0.to(memory_format=torch.channels_last).train()
+            x = torch.ones(
+                [10, 2, 16, 16],
+                device=self.device,
+                dtype=torch.float32,
+                requires_grad=True,
+            ).to(memory_format=torch.channels_last)
+            y = model(x)
+            loss = y.sum()
+            loss.backward()
+            func_names = [i.name for i in cache_dir.glob("*")]
+            self.assertIn(
+                "conv_2d_float32_forward_10x16x16x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_input_backward_10x16x16x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_weight_backward_10x16x16x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernel/boo/modeling/boo_conv_2d_test.py
+++ b/tests/kernel/boo/modeling/boo_conv_2d_test.py
@@ -47,6 +47,17 @@ class BooConv2dTest(unittest.TestCase):
                 [i.name for i in cache_dir.glob("*")],
             )
 
+    def testNoBatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            x = torch.ones([2, 16, 16], device=self.device, dtype=torch.float32)
+            _ = self.model0(x)
+            self.assertIn(
+                "conv_2d_float32_forward_1x2x16x16_nchw_3x2x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                [i.name for i in cache_dir.glob("*")],
+            )
+
     def testReplacement(self):
         with tempfile.TemporaryDirectory() as td:
             cache_dir = Path(td)


### PR DESCRIPTION
In particular, this should allow setting `model = model.to(memory_format=torch.channels_last)` to enable `NHWC` convolutions, whereas previously we had been forcing these tensors back to `NHWC` format by calling `contiguous()` on the inputs inside the `Launchable` call. 

Tests are added to check if `BooConv2d` is calling into the expected kernel signatures.