### PR TITLE
[Wave] Fix missing math import introduced in #677

### DIFF
--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -13,6 +13,7 @@ import json
 import os
 import shutil
 import threading
+import math
 
 from collections import OrderedDict, deque
 from dataclasses import dataclass, asdict


### PR DESCRIPTION
This commit restores the import math statement that was unintentionally removed as part of #677. The missing import caused runtime errors in grid_fn.