### PR TITLE
[boo] Fix boo_driver sometimes printing result values

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -112,7 +112,7 @@ def run(cli_args: Sequence[str]):
     for _ in range(args.iter):
         result = conv(*conv_args)
 
-    torch.set_printoptions(edgeitems=0)
+    torch.set_printoptions(edgeitems=0, threshold=0)
     print(f">>> {result}")
 
     return sig.get_func_name()


### PR DESCRIPTION
We don't care about the actual values, so set the print threshold to `0` so they're always hidden.