### PR TITLE
[Wave] Implement NewScalar op support

### DIFF
--- a/iree/turbine/aot/support/ir_utils.py
+++ b/iree/turbine/aot/support/ir_utils.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import tempfile
 from itertools import zip_longest
+from functools import partial
 
 import numpy as np
 import torch
@@ -499,6 +500,49 @@ def _is_integer_like_type(type):
 
 def _is_signed_or_signless_type(type):
     return getattr(type, "is_signed", False) or getattr(type, "is_signless", False)
+
+
+def get_conversion_op(src_elem_type, dst_elem_type, fastmath=None):
+    is_src_float = _is_float_type(src_elem_type)
+    is_dst_float = _is_float_type(dst_elem_type)
+    is_src_int = _is_integer_like_type(src_elem_type)
+    is_dst_int = _is_integer_like_type(dst_elem_type)
+    assert (
+        (is_src_float | is_src_int) & (is_dst_float | is_dst_int),
+        "Found Unsupported lhs/rhs type.",
+    )
+    if (
+        is_src_int
+        and is_dst_int
+        and (_is_index_type(src_elem_type) or _is_index_type(dst_elem_type))
+    ):
+        conversion_op = arith_d.index_cast
+        return conversion_op
+
+    conversion_ops = {
+        (True, False): arith_d.fptosi,
+        (False, True): arith_d.sitofp,
+    }
+
+    float_cast_ops = {
+        True: arith_d.extf,
+        False: arith_d.truncf,
+    }
+
+    int_cast_ops = {
+        True: arith_d.extsi,
+        False: arith_d.trunci,
+    }
+
+    if is_src_float and is_dst_float:
+        conversion_op = float_cast_ops[src_elem_type.width < dst_elem_type.width]
+        conversion_op = partial(conversion_op, fastmath=fastmath)
+    elif is_src_int and is_dst_int:
+        # Currently extsi/trunci do not support fast_math option.
+        conversion_op = int_cast_ops[src_elem_type.width < dst_elem_type.width]
+    else:
+        conversion_op = conversion_ops[(is_src_float, is_dst_float)]
+    return conversion_op
 
 
 def _attribute_from_device_affinity(

--- a/iree/turbine/aot/support/ir_utils.py
+++ b/iree/turbine/aot/support/ir_utils.py
@@ -507,10 +507,6 @@ def get_conversion_op(src_elem_type, dst_elem_type, fastmath=None):
     is_dst_float = _is_float_type(dst_elem_type)
     is_src_int = _is_integer_like_type(src_elem_type)
     is_dst_int = _is_integer_like_type(dst_elem_type)
-    assert (
-        (is_src_float | is_src_int) & (is_dst_float | is_dst_int),
-        "Found Unsupported lhs/rhs type.",
-    )
     if (
         is_src_int
         and is_dst_int

--- a/iree/turbine/kernel/_support/dtype.py
+++ b/iree/turbine/kernel/_support/dtype.py
@@ -72,11 +72,10 @@ class DataType:
 
     @property
     def dtype(self):
-        if self.is_float_asm():
-            return DataType("f32")
-        if self.is_int_asm():
-            return DataType("i32")
-        raise ValueError("Only f32 and i32 scalars are supported.")
+        # This cls is already dtype, hence can return self.
+        # dtype() function is useful here for code reuse between
+        # scalar and vector/register variables.
+        return self
 
     @property
     def symbolic_shape(self):

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -888,9 +888,8 @@ class SelectOp(CustomOp):
         cond_type = get_custom(self.cond).type
         if_true_type = get_custom(self.if_true).type
         if_false_type = get_custom(self.if_false).type
-        cond_dtype = cond_type.dtype
 
-        if cond_dtype != i1:
+        if cond_type.dtype != i1:
             raise ValueError("SelectOp expects condition type to be i1.")
 
         if if_true_type.dtype != if_false_type.dtype:

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1171,8 +1171,8 @@ class NewRegister(CustomOp):
 @define_op("scalar")
 @dataclass
 class NewScalar(CustomOp):
-    dtype: DataType
     value: float | IndexExpr
+    dtype: DataType
 
     @property
     def indexing_dims(self) -> list[IndexSymbol]:

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -99,6 +99,10 @@ def register(shape: tuple[IndexExpr, ...], dtype: DataType, value: float) -> "Re
     ...
 
 
+def scalar(dtype: DataType, value: float) -> "Register":
+    ...
+
+
 def mma(lhs: "Register", rhs: "Register", acc: "Register") -> "Register":
     ...
 
@@ -830,7 +834,10 @@ class BinaryPyOp(BinaryOpBase, ABC):
 @dataclass
 class ComparisonPyOp(BinaryOpBase, ABC):
     def infer_type(self):
-        self.type = Register[(*self.infer_shape(), i1)]
+        # If lhs & rhs is scalar then shape is empty, then type is i1.
+        # Else, output i1 with shape of lhs/rhs.
+        shape = self.infer_shape()
+        self.type = Register[(*shape, i1)] if shape else i1
 
 
 @define_interface_op("abs")
@@ -881,8 +888,9 @@ class SelectOp(CustomOp):
         cond_type = get_custom(self.cond).type
         if_true_type = get_custom(self.if_true).type
         if_false_type = get_custom(self.if_false).type
+        cond_dtype = cond_type.dtype
 
-        if cond_type.dtype != i1:
+        if cond_dtype != i1:
             raise ValueError("SelectOp expects condition type to be i1.")
 
         if if_true_type.dtype != if_false_type.dtype:
@@ -1159,6 +1167,20 @@ class NewRegister(CustomOp):
 
     def infer_type(self):
         self.type = Register[(*self.shape, self.dtype)]
+
+
+@define_op("scalar")
+@dataclass
+class NewScalar(CustomOp):
+    dtype: DataType
+    value: float | IndexExpr
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        return list()
+
+    def infer_type(self):
+        self.type = self.dtype
 
 
 @define_op("mma")

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -151,7 +151,7 @@ def handle_register(emitter: WaveEmitter, node: fx.Node):
 @handle_op(scalar)
 def handle_scalar(emitter: WaveEmitter, node: fx.Node):
     try:
-        dtype, value = node.args
+        value, dtype = node.args
     except ValueError as e:
         raise ValidationError("Malformed arguments") from e
     target_type = IrType.parse(dtype.ir_type_asm())

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -48,6 +48,7 @@ from iree.turbine.aot.support.ir_utils import (
     _is_index_type,
     _is_integer_like_type,
     _is_signed_or_signless_type,
+    get_conversion_op,
 )
 
 # TK infrastructure imports.
@@ -77,6 +78,7 @@ from ...ops.wave_ops import (
     permute,
     reciprocal,
     register,
+    scalar,
     reshape,
     roundeven,
     scheduling_barrier,
@@ -144,6 +146,26 @@ def handle_register(emitter: WaveEmitter, node: fx.Node):
         ),
     ).result
     emitter.bind_node_proxy(node, IRProxyValue(register))
+
+
+@handle_op(scalar)
+def handle_scalar(emitter: WaveEmitter, node: fx.Node):
+    try:
+        dtype, value = node.args
+    except ValueError as e:
+        raise ValidationError("Malformed arguments") from e
+    target_type = IrType.parse(dtype.ir_type_asm())
+    i32_type = IntegerType.get_signless(32)
+    if isinstance(value, IndexExpr):
+        scalar_src = gen_sympy_index(add_emitter_subs(emitter), value)
+        scalar_i32 = arith_d.index_cast(i32_type, scalar_src)
+        conversion_op = get_conversion_op(
+            i32_type, target_type, fastmath=get_fast_math_flags(emitter.options)
+        )
+        scalar = conversion_op(target_type, scalar_i32)
+    elif isinstance(value, (int, float)):
+        scalar = arith_d.constant(target_type, value)
+    emitter.bind_node_proxy(node, IRProxyValue(scalar))
 
 
 @handle_op(allocate)
@@ -1173,49 +1195,10 @@ def handle_cast(emitter: WaveEmitter, node: fx.Node):
     if src_vector_type == dst_vector_type:
         emitter.bind_node_proxy(node, IRProxyValue(vector_src))
         return
-
-    is_src_float = _is_float_type(src_elem_type)
-    is_dst_float = _is_float_type(dst_elem_type)
-    is_src_int = _is_integer_like_type(src_elem_type)
-    is_dst_int = _is_integer_like_type(dst_elem_type)
-    if (
-        is_src_int
-        and is_dst_int
-        and (_is_index_type(src_elem_type) or _is_index_type(dst_elem_type))
-    ):
-        casted_vector = arith_d.index_cast(dst_vector_type, vector_src)
-        emitter.bind_node_proxy(node, IRProxyValue(casted_vector))
-        return
-
-    conversion_ops = {
-        (True, False): arith_d.fptosi,
-        (False, True): arith_d.sitofp,
-    }
-
-    float_cast_ops = {
-        True: arith_d.extf,
-        False: arith_d.truncf,
-    }
-
-    int_cast_ops = {
-        True: arith_d.extsi,
-        False: arith_d.trunci,
-    }
-
-    if is_src_float and is_dst_float:
-        casted_vector = float_cast_ops[
-            src_vector_type.element_type.width < dst_elem_type.width
-        ](dst_vector_type, vector_src, fastmath=get_fast_math_flags(emitter.options))
-    elif is_src_int and is_dst_int:
-        # Currently extsi/trunci do not support fast_math option.
-        casted_vector = int_cast_ops[
-            src_vector_type.element_type.width < dst_elem_type.width
-        ](dst_vector_type, vector_src)
-    else:
-        casted_vector = conversion_ops[(is_src_float, is_dst_float)](
-            dst_vector_type, vector_src
-        )
-
+    conversion_op = get_conversion_op(
+        src_elem_type, dst_elem_type, fastmath=get_fast_math_flags(emitter.options)
+    )
+    casted_vector = conversion_op(dst_vector_type, vector_src)
     emitter.bind_node_proxy(node, IRProxyValue(casted_vector))
 
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -2055,11 +2055,11 @@ def test_scalar_cond_copy():
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        zero = tkw.scalar(tkl.f16, 0.0)
-        one = tkw.scalar(tkl.f16, 1.0)
+        zero = tkw.scalar(0.0, tkl.f16)
+        one = tkw.scalar(1.0, tkl.f16)
 
-        tid = tkw.scalar(tkl.i32, THREAD_0)
-        thresh = tkw.scalar(tkl.i32, thresh_value)
+        tid = tkw.scalar(THREAD_0, tkl.i32)
+        thresh = tkw.scalar(thresh_value, tkl.i32)
 
         mask = tkw.select(tid < thresh, one, zero)
         mask_broadcast = tkw.broadcast(mask, target_shape=[M, N])

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -2025,6 +2025,7 @@ def test_scalar_codegen_i32():
 #  1. tkw.Scalar can handle index expressions correctly.
 #  2. Scalars in Wave can be used for comparison/binaryOps
 #     as well as on select ops.
+@run_test
 def test_scalar_cond_copy():
     M = tkl.sym.M
     N = tkl.sym.N
@@ -2078,7 +2079,7 @@ def test_scalar_cond_copy():
     scalar_cond_copy = wave_compile(options, scalar_cond_copy)
     print(scalar_cond_copy.asm)
 
-    # CHECK: func.func @scalar_cond_copy(
+    # CHECK-LABEL: @scalar_cond_copy
 
     # mask values
     # CHECK: %[[one:.+]] = arith.constant 1.000000e+00 : f16
@@ -2089,6 +2090,7 @@ def test_scalar_cond_copy():
     # CHECK: %[[tidx_i32:.+]] = arith.index_cast %[[tidx]] : index to i32
     # CHECK: %[[cond:.+]] = arith.cmpi slt, %[[tidx_i32]], %c12
     # CHECK: %[[mask:.+]] = arith.select %[[cond]], %cst, %cst_0 : f16
+    # CHECK: %[[splat_mask:.+]] = vector.splat %[[mask]] : vector<1xf16>
 
     # Apply mask
-    # CHECK: arith.mulf {{.*}}, %[[mask]]
+    # CHECK: arith.mulf {{.*}}, %[[splat_mask]]

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -2018,3 +2018,77 @@ def test_scalar_codegen_i32():
     # Final dispatch args dtype
     # CHECK: flow.dispatch @scalar_codegen_i32::@scalar_codegen_i32(
     # CHECK-SAME: %arg0, %arg1, %arg2, %arg3)
+
+
+#  This kernel copies of data from a into b if tid.x < threshold.
+#  This test is important to ensure:
+#  1. tkw.Scalar can handle index expressions correctly.
+#  2. Scalars in Wave can be used for comparison/binaryOps
+#     as well as on select ops.
+def test_scalar_cond_copy():
+    M = tkl.sym.M
+    N = tkl.sym.N
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    wave_size = 64
+    BLOCK_M = 1
+    # Tile size cannot be dynamic, so we use a fixed value here.
+    BLOCK_N = 64
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: BLOCK_M, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    thresh_value = 12
+
+    @tkw.wave(constraints)
+    def scalar_cond_copy(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        zero = tkw.scalar(tkl.f16, 0.0)
+        one = tkw.scalar(tkl.f16, 1.0)
+
+        tid = tkw.scalar(tkl.i32, THREAD_0)
+        thresh = tkw.scalar(tkl.i32, thresh_value)
+
+        mask = tkw.select(tid < thresh, one, zero)
+        mask_broadcast = tkw.broadcast(mask, target_shape=[M, N])
+
+        a_reg = tkw.read(a)
+        res = a_reg * mask_broadcast
+        tkw.write(res, b)
+
+    options = WaveCompileOptions(
+        subs={
+            M: 1,
+            N: 64,
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+    )
+    scalar_cond_copy = wave_compile(options, scalar_cond_copy)
+    print(scalar_cond_copy.asm)
+
+    # CHECK: func.func @scalar_cond_copy(
+
+    # mask values
+    # CHECK: %[[one:.+]] = arith.constant 1.000000e+00 : f16
+    # CHECK: %[[zero:.+]] = arith.constant 0.000000e+00 : f16
+
+    # Condition and mask selection
+    # CHECK: %[[tidx:.+]] = gpu.thread_id  x
+    # CHECK: %[[tidx_i32:.+]] = arith.index_cast %[[tidx]] : index to i32
+    # CHECK: %[[cond:.+]] = arith.cmpi slt, %[[tidx_i32]], %c12
+    # CHECK: %[[mask:.+]] = arith.select %[[cond]], %cst, %cst_0 : f16
+
+    # Apply mask
+    # CHECK: arith.mulf {{.*}}, %[[mask]]

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1668,11 +1668,11 @@ def test_scalar_cond_copy(shape, request):
         a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
     ):
-        zero = tkw.scalar(tkl.f16, 0.0)
-        one = tkw.scalar(tkl.f16, 1.0)
+        zero = tkw.scalar(0.0, tkl.f16)
+        one = tkw.scalar(1.0, tkl.f16)
 
-        tid = tkw.scalar(tkl.i32, tidx_expr)
-        thresh = tkw.scalar(tkl.i32, thresh_value)
+        tid = tkw.scalar(tidx_expr, tkl.i32)
+        thresh = tkw.scalar(thresh_value, tkl.i32)
 
         mask = tkw.select(tid < thresh, one, zero)
         mask_broadcast = tkw.broadcast(mask, target_shape=[M, N])

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1623,3 +1623,82 @@ def test_scalar_codegen(shape, tkl_dtype, torch_dtype, arg_vals, request):
     test(a, scalar_c, scalar_d, b)
 
     assert torch.all(b == arg_vals[3]).item()
+
+
+#  This kernel copies of data from a into b if tid.x < threshold.
+#  This test is important to ensure:
+#  1. tkw.Scalar can handle index expressions correctly.
+#  2. Scalars in Wave can be used for comparison/binaryOps
+#     as well as on select ops.
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_copy"))
+def test_scalar_cond_copy(shape, request):
+    run_bench = request.config.getoption("--runperf")
+    M = tkl.sym.M
+    N = tkl.sym.N
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    wave_size = 64
+    BLOCK_M = 1
+    # Tile size cannot be dynamic, so we use a fixed value here.
+    BLOCK_N = sympy.Max(sympy.Min(shape[1], 256), wave_size)
+
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=wave_size,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: BLOCK_M, N: BLOCK_N},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 1)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+    # multiple of 4 to prevent to not require iota mask.
+    # e.g if each thread has 4 values, and thresh is 10.
+    # then t0 = [0, 1, 2, 3], t1 = [4, 5, 6, 7], t2 = [8, 9, 10, 11],
+    # since t2_tidx_expr = 2 * 4 = 8, which is less than thresh, then
+    # [10, 11] will also not be masked. To fix we'd need the iota mask
+    # but not the main point of this test.
+    thresh_value = 12
+    tidx_expr = THREAD_0 * (BLOCK_N // wave_size) + (WORKGROUP_0 * BLOCK_N)
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        zero = tkw.scalar(tkl.f16, 0.0)
+        one = tkw.scalar(tkl.f16, 1.0)
+
+        tid = tkw.scalar(tkl.i32, tidx_expr)
+        thresh = tkw.scalar(tkl.i32, thresh_value)
+
+        mask = tkw.select(tid < thresh, one, zero)
+        mask_broadcast = tkw.broadcast(mask, target_shape=[M, N])
+
+        a_reg = tkw.read(a)
+        res = a_reg * mask_broadcast
+        tkw.write(res, b)
+
+    a = device_randn(shape, dtype=torch.float16)
+    b = device_zeros(shape, dtype=torch.float16)
+    options = WaveCompileOptions(
+        subs={
+            M: shape[0],
+            N: shape[1],
+            ADDRESS_SPACE: tkl.AddressSpace.GLOBAL_MEMORY.value,
+        },
+        canonicalize=True,
+        run_bench=run_bench,
+    )
+    options = set_default_run_config(options)
+    test = wave_compile(options, test)
+
+    test(a, b)
+    # Check for data from tid.x < threshold
+    assert_close(a[:, :thresh_value], b[:, :thresh_value])
+
+    # Check for data from tid.x >= threshold
+    ref_zeros = device_zeros([shape[0], shape[1] - thresh_value])
+    assert_close(ref_zeros, b[:, thresh_value:], check_dtype=False)


### PR DESCRIPTION
- Refactor conversion op as a util/helper function S.T we can reuse for ScalarOp handler.
- Add support for inferType on ComparisonPyOp on Scalars
- refactor dtype of DataType to be self which is what is expected and can support all dtypes.
- Implement NewScalarOp and handlers