### PR TITLE
[Wave] Add support for init args in while loops

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1782,7 +1782,9 @@ class GetResult(CustomOp):
             return None
         if not isinstance(custom, Iterate):
             return custom_index
-        assert isinstance(custom_index, Sequence) and self.res_idx < len(
+        if not isinstance(custom_index, Sequence):
+            return custom_index
+        assert self.res_idx < len(
             custom.indexing_dims
         ), f"Invalid {custom_index=} with {self.res_idx=} and {custom.indexing_dims=}\n{custom}"
         return custom_index[self.res_idx]

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -9,6 +9,7 @@ from ...ops.wave_ops import (
     BinaryPyOp,
     Broadcast,
     CustomOp,
+    GetResult,
     IterArg,
     MMA,
     NestedRegionOp,
@@ -290,28 +291,30 @@ def populate_mma_source_indices(
             dim, dim_index, node.mma_type
         )
     node.index = combine_indices(node.index, index)
-    return [
-        (
-            get_custom(node.lhs),
-            specialize_index(index, {MMA_LHS: 1, MMA_RHS: 0, MMA_ACC: 0}),
-            node.vector_shapes,
-        ),
-        (
-            get_custom(node.rhs),
-            specialize_index(index, {MMA_LHS: 0, MMA_RHS: 1, MMA_ACC: 0}),
-            node.vector_shapes,
-        ),
-        (
-            get_custom(node.acc),
-            specialize_index(index, {MMA_LHS: 0, MMA_RHS: 0, MMA_ACC: 1}),
-            node.vector_shapes,
-        ),
-        (
-            node,
-            specialize_index(index, {MMA_LHS: 0, MMA_RHS: 0, MMA_ACC: 1}),
-            node.vector_shapes,
-        ),
-    ]
+    lhs_tuple = (
+        get_custom(node.lhs),
+        specialize_index(index, {MMA_LHS: 1, MMA_RHS: 0, MMA_ACC: 0}),
+        node.vector_shapes,
+    )
+    rhs_tuple = (
+        get_custom(node.rhs),
+        specialize_index(index, {MMA_LHS: 0, MMA_RHS: 1, MMA_ACC: 0}),
+        node.vector_shapes,
+    )
+    acc_tuple = (
+        get_custom(node.acc),
+        specialize_index(index, {MMA_LHS: 0, MMA_RHS: 0, MMA_ACC: 1}),
+        node.vector_shapes,
+    )
+    mma_tuple = (
+        node,
+        specialize_index(index, {MMA_LHS: 0, MMA_RHS: 0, MMA_ACC: 1}),
+        node.vector_shapes,
+    )
+    # Remove reduction dim from index of accumulator and mma nodes.
+    del acc_tuple[1][node.reduction_dim]
+    del mma_tuple[1][node.reduction_dim]
+    return [lhs_tuple, rhs_tuple, acc_tuple, mma_tuple]
 
 
 def populate_read_write_source_indices(
@@ -476,15 +479,18 @@ def propagate_indices(
                 source, source_index, source_vector_shapes, symbolic_constraints
             ):
                 continue
-            source_index = source.transform_index(source_index)
-            source.index = combine_indices(source.index, source_index)
+            # GetResults inherit their index from the Iterate node
+            # and hence we don't need to update their index.
+            if not isinstance(source, GetResult):
+                source_index = source.transform_index(source_index)
+                source.index = combine_indices(source.index, source_index)
             source.vector_shapes = source_vector_shapes
             append_aliased_shapes(source, symbolic_constraints)
         visited.add(source)
         for func in [get_inputs, get_users]:
-            sources, reduction = add_nodes_to_sources(
+            sources, _ = add_nodes_to_sources(
                 source,
-                reduction,
+                None,
                 func,
                 source_index,
                 source_vector_shapes,

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -381,18 +381,17 @@ def combine_indices(
 
 def add_nodes_to_sources(
     source: CustomOp,
-    reduction: Iterate,
     fn: Callable,
     source_index: dict[IndexSymbol, IndexSequence],
     source_vector_shapes: dict[IndexSymbol, int],
     sources: list[
         tuple[CustomOp, dict[IndexSymbol, IndexSequence], dict[IndexSymbol, int]]
     ],
-) -> tuple[list[CustomOp], Iterate]:
+) -> list[CustomOp]:
     """
     Populate the sources with the inputs and users of the source node.
     """
-    for args, reduction in [fn(source.fx_node, reduction)]:
+    for args, reduction in [fn(source.fx_node, None)]:
         logger.debug(f"{source.fx_node} -> {args}")
         if not args:
             break
@@ -406,7 +405,7 @@ def add_nodes_to_sources(
                 custom.vector_shapes if custom.vector_shapes else source_vector_shapes
             )
             sources.append((custom, source_index, vector_shapes))
-    return sources, reduction
+    return sources
 
 
 def should_update_index(
@@ -488,9 +487,8 @@ def propagate_indices(
             append_aliased_shapes(source, symbolic_constraints)
         visited.add(source)
         for func in [get_inputs, get_users]:
-            sources, _ = add_nodes_to_sources(
+            sources = add_nodes_to_sources(
                 source,
-                None,
                 func,
                 source_index,
                 source_vector_shapes,

--- a/iree/turbine/kernel/wave/expansion/expansion.py
+++ b/iree/turbine/kernel/wave/expansion/expansion.py
@@ -401,7 +401,6 @@ def add_get_results(trace: CapturedTrace):
             get_result = get_custom(
                 GetResult(reduction.fx_node, 0).add_to_graph(reduction.graph)
             )
-            get_result.vector_shapes = reduction.init_args[0].vector_shapes
             reduction.replace_all_uses_with_except(get_result, [get_result])
 
 
@@ -737,8 +736,6 @@ def expand_graph(
     The expansion does a DFS starting at the leaf nodes and expanding them
     to the root of the graph.
     """
-
-    add_get_results(trace)
 
     leaf_ops = [get_custom(node) for node in reversed(trace.walk(is_leaf_node))]
     if not leaf_ops:

--- a/iree/turbine/kernel/wave/utils/graph_utils.py
+++ b/iree/turbine/kernel/wave/utils/graph_utils.py
@@ -219,11 +219,10 @@ def get_inputs(
     custom = get_custom(node)
     if isinstance(custom, IterArg):
         # Map iter args to init args
-        local_reduction = reduction
         if reduction is None:
-            local_reduction = custom.parent_op()
+            reduction = custom.parent_op()
         iter_arg_idx = custom.iter_idx
-        inputs.append(local_reduction.init_args[iter_arg_idx])
+        inputs.append(reduction.init_args[iter_arg_idx])
     elif isinstance(custom, GetResult):
         assert custom.value is not None, f"GetResult node {custom} has no value"
         reduction = get_custom(custom.value)

--- a/iree/turbine/kernel/wave/utils/mma_utils.py
+++ b/iree/turbine/kernel/wave/utils/mma_utils.py
@@ -67,18 +67,20 @@ def get_mma_dimensional_mapping(
         acc_shape = custom.acc_type.symbolic_shape
 
         try:
-            common_dims = (set(lhs_shape) & set(rhs_shape)) - set(acc_shape)
-            if len(common_dims) > 1:
+            reduction_dim_candidates = (set(lhs_shape) & set(rhs_shape)) - set(
+                acc_shape
+            )
+            if len(reduction_dim_candidates) > 1:
                 # Indicates we have batch dimensions as well.
                 # Eliminate these using the vector shapes.
                 for dim, value in hardware_constraint.vector_shapes.items():
-                    if dim in common_dims and value == 0:
-                        common_dims.remove(dim)
+                    if dim in reduction_dim_candidates and value == 0:
+                        reduction_dim_candidates.remove(dim)
                 assert (
-                    len(common_dims) == 1
-                ), f"Expected 1 reduction dimension, got {common_dims}"
+                    len(reduction_dim_candidates) == 1
+                ), f"Expected 1 reduction dimension, got {reduction_dim_candidates}"
 
-            k = common_dims.pop()
+            k = reduction_dim_candidates.pop()
         except KeyError as e:
             raise RuntimeError(
                 f"{node}: Invalid MMA shapes\n{lhs_shape=}\n{rhs_shape=}\n{acc_shape=}\n{m=}, {n=}\n{custom}"

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -47,7 +47,7 @@ from .codegen import WaveEmitter
 from .compile_options import WaveCompileOptions
 from .decompose_reduce_ops import decompose_reduce_ops
 from .decompose_vmma_ops import decompose_vmma_ops
-from .expansion.expansion import expand_graph
+from .expansion.expansion import expand_graph, add_get_results
 from .global_to_shared_gathers import global_to_shared_gathers
 from .hoisting import hoist_loop_invariant_ops
 from .minimize_global_loads import minimize_global_loads
@@ -459,6 +459,7 @@ class LaunchableWave(Launchable):
             partial(self.initialize_workgroup_constraints, trace),
             finalize_indices,
             substitute_vector_shapes,
+            partial(add_get_results, trace),
             partial(infer_types, trace),
             partial(promote_placeholders, trace, self.constraints),
             partial(

--- a/lit_tests/kernel/wave/barriers.py
+++ b/lit_tests/kernel/wave/barriers.py
@@ -11,7 +11,7 @@ from iree.turbine.kernel.wave.analysis.index_sequence_analysis import (
 from iree.turbine.kernel.wave.promotion import promote_node, promote_placeholders
 from iree.turbine.kernel.wave.barriers import add_shared_memory_barriers
 from iree.turbine.kernel.wave.hoisting import hoist_loop_invariant_ops
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel._support.tracing import CapturedTrace
@@ -93,6 +93,7 @@ def test_read_write_equal_sizes():
         graph: fx.Graph = trace.get_root_graph()
         read_node = get_read_nodes(graph)[0]
         IndexingContext.current().finalize()
+        add_get_results(trace)
         infer_types(trace)
         promote_node(read_node, None, SHARED_ADDRESS_SPACE, constraints)
         set_node_indices(trace, constraints)
@@ -180,6 +181,7 @@ def test_gemm():
         graph: fx.Graph = trace.get_subgraph("region_0")
         IndexingContext.current().finalize()
         initialize_iter_args(trace)
+        add_get_results(trace)
         infer_types(trace)
         read_nodes = get_read_nodes(graph)
         for read_node in read_nodes:

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -4,7 +4,7 @@ import logging
 import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.wave.analysis.index_sequence_analysis import (
     set_node_indices,
@@ -77,6 +77,7 @@ def test_read_write_equal_sizes():
     ):
         graph = read_write_same_size()
         IndexingContext.current().finalize()
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -159,6 +160,7 @@ def test_read_write():
     ):
         graph = read_write_different_dims()
         IndexingContext.current().finalize()
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -241,6 +243,7 @@ def test_write_in_iterate():
         graph = write_in_iterate()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -323,6 +326,7 @@ def test_no_writes():
         graph = no_writes()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -363,6 +367,7 @@ def test_gemm():
         graph = gemm()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -554,6 +559,7 @@ def test_batched_gemm():
         graph = batched_gemm()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -736,6 +742,7 @@ def test_gemm_non_direct_acc():
         graph = gemm_non_direct_acc()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -804,6 +811,7 @@ def test_tiled_max():
         graph = tiled_max()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -837,6 +845,7 @@ def test_gemm_iterate_expansion_only():
         graph = gemm()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -983,6 +992,7 @@ def test_attention():
         graph = attention()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -1078,6 +1088,7 @@ def py_arithmetic_different_dims():
     ):
         graph = py_arithmetic_different_dims()
         IndexingContext.current().finalize()
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)
@@ -1185,6 +1196,7 @@ def test_chained_gemm_32x32x8():
         graph = chained_gemm_32x32x8()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -6,7 +6,7 @@ import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.wave.promotion import promote_placeholders
 from iree.turbine.kernel.wave.hoisting import hoist_loop_invariant_ops
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel._support.tracing import CapturedTrace
@@ -95,6 +95,7 @@ def test_gemm():
         trace: CapturedTrace = gemm()
         IndexingContext.current().finalize()
         initialize_iter_args(trace)
+        add_get_results(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)
         set_node_indices(trace, constraints)

--- a/lit_tests/kernel/wave/iteration.py
+++ b/lit_tests/kernel/wave/iteration.py
@@ -32,7 +32,7 @@ def test_iteration():
             threads_per_wave=64,
             waves_per_block=(2, 2, 1),
             mma_type=tkw.MMAType.F32_16x16x16_F16,
-            vector_shapes={B: 1, M: 16, N: 16, K: 16},
+            vector_shapes={B: 0, M: 16, N: 16, K: 16},
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
@@ -115,7 +115,7 @@ def test_iteration_with_condition():
             threads_per_wave=64,
             waves_per_block=(2, 2, 1),
             mma_type=tkw.MMAType.F32_16x16x16_F16,
-            vector_shapes={B: 1, M: 16, N: 16, K: 16},
+            vector_shapes={B: 0, M: 16, N: 16, K: 16},
         )
     ]
     constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
@@ -199,3 +199,107 @@ def test_iteration_with_condition():
     # CHECK:                        amdgpu.mfma
     # CHECK:                        scf.yield
     # CHECK-COUNT-4:            vector.store
+
+
+@run_test
+def test_iteration_with_condition_and_init_value():
+    constraints: list[tkw.Constraint] = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+            vector_shapes={B: 0, M: 16, N: 16, K: 16},
+        )
+    ]
+    constraints += [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    # B is iterated over and so we define a tiling constraint on it.
+    # However, there is no notion of tile size for the iteration as
+    # it is an unstructured loop.
+    constraints += [tkw.TilingConstraint(B)]
+
+    @tkw.wave(constraints)
+    def iterated_gemm(
+        a: tkl.Memory[B, M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[B, N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, M, N, ADDRESS_SPACE_0, tkl.f32],
+        output_sum: tkl.Memory[N, M, ADDRESS_SPACE_0, tkl.f32],
+        init_value: tkl.i32,  # type: ignore
+    ):
+
+        o_reg = tkl.Register[N, M, tkl.f32](0.0)
+
+        @tkw.iterate(B, start=init_value, condition=B < 10, init_args=[o_reg])
+        def body(outer_acc: tkl.Register[N, M, tkl.f32]):
+            c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+            @tkw.iterate(K, init_args=[c_reg])
+            def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+                a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+                b_reg = tkw.read(b, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+                acc = tkw.mma(a_reg, b_reg, acc)
+                return acc
+
+            tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
+            permuted = tkw.permute(repeat, target_shape=[N, M])
+            outer_acc += permuted
+
+            # Set the next value for the iteration.
+            # In this case, we are using a simple increment operation,
+            # but this can be replaced with any other operation.
+            index_b = tkw.self_index(B, tkl.i32)
+            next_value = tkw.apply_expr(index_b, lambda x: x + 1)
+            tkw.set_symbol(B, next_value)
+
+            return outer_acc
+
+        tkw.write(body, output_sum, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    options = WaveCompileOptions(
+        subs={
+            M: 64,
+            N: 128,
+            K: 64,
+            B: 10,
+            BLOCK_M: 32,
+            BLOCK_N: 32,
+            BLOCK_K: 16,
+            BLOCK_B: 1,
+            LOAD_ELEMS_PER_THREAD: 4,
+            STORE_ELEMS_PER_THREAD: 4,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        compile_to_mlir=True,
+    )
+    iterated_gemm = wave_compile(options, iterated_gemm)
+    print(iterated_gemm.asm)
+
+    # CHECK-DAG:            %[[C1:.*]] = arith.constant 1 : index
+    # CHECK-DAG:            %[[C4:.*]] = arith.constant 4 : index
+    # CHECK-DAG:            %[[C0:.*]] = arith.constant 0 : index
+    # CHECK-DAG:            %[[C10:.*]] = arith.constant 10 : index
+    # CHECK-DAG:            %[[CST_0:.*]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+    # CHECK:                %[[CAST_INIT_B:.*]] = arith.index_cast
+    # CHECK:                %[[WHILE:.*]] = scf.while (%[[ACC:.*]] = %[[CST_0]], %[[B:.*]] = %[[CAST_INIT_B]]) : (vector<4xf32>, index) -> (vector<4xf32>, index) {
+    # CHECK:                    %[[COND:.*]] = arith.cmpi slt, %[[B]], %[[C10]] : index
+    # CHECK:                    scf.condition(%[[COND]]) %[[ACC]], %[[B]] : vector<4xf32>, index
+    # CHECK:                } do {
+    # CHECK:                ^bb0(%[[ACC:.*]]: vector<4xf32>, %[[B:.*]]: index):
+    # CHECK:                    amdgpu.lds_barrier
+    # CHECK:                    %[[FOR:.*]] = scf.for %[[ARG7:.*]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[ARG8:.*]] = %[[CST_0]]) -> (vector<4xf32>) {
+    # CHECK:                        amdgpu.lds_barrier
+    # CHECK-COUNT-2:                memref.alloc
+    # CHECK-COUNT-1:                vector.load
+    # CHECK-COUNT-1:                vector.store
+    # CHECK-COUNT-1:                vector.load
+    # CHECK-COUNT-1:                vector.store
+    # CHECK:                        amdgpu.lds_barrier
+    # CHECK-COUNT-2:                vector.load
+    # CHECK:                        amdgpu.mfma
+    # CHECK:                        scf.yield
+    # CHECK-COUNT-4:                vector.store

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -7,7 +7,7 @@ import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.wave.promotion import promote_placeholders
 from iree.turbine.kernel.wave.hoisting import hoist_loop_invariant_ops
 from iree.turbine.kernel.wave.barriers import add_shared_memory_barriers
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel._support.tracing import CapturedTrace
@@ -95,6 +95,7 @@ def test_gemm():
         visualize = False
         IndexingContext.current().finalize()
         initialize_iter_args(trace)
+        add_get_results(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)
         set_node_indices(trace, constraints)

--- a/lit_tests/kernel/wave/multi_buffering.py
+++ b/lit_tests/kernel/wave/multi_buffering.py
@@ -6,7 +6,7 @@ import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.wave.promotion import promote_placeholders
 from iree.turbine.kernel.wave.hoisting import hoist_loop_invariant_ops
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.lang.global_symbols import (
     GLOBAL_ADDRESS_SPACE,
@@ -120,6 +120,7 @@ def test_gemm_multibuffering():
         trace: CapturedTrace = gemm()
         IndexingContext.current().finalize()
         initialize_iter_args(trace)
+        add_get_results(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)
         set_node_indices(trace, constraints)

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -6,7 +6,7 @@ import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.wave.promotion import promote_placeholders
 from iree.turbine.kernel.wave.hoisting import hoist_loop_invariant_ops
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 from iree.turbine.kernel.lang.global_symbols import *
@@ -100,6 +100,7 @@ def test_gemm_pipelined():
         trace: CapturedTrace = gemm_pipelined()
         IndexingContext.current().finalize()
         initialize_iter_args(trace)
+        add_get_results(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)
         set_node_indices(trace, constraints)

--- a/tests/kernel/wave/scheduling_test.py
+++ b/tests/kernel/wave/scheduling_test.py
@@ -29,7 +29,7 @@ from iree.turbine.kernel._support.tracing import CapturedTrace
 from iree.turbine.kernel._support.indexing import IndexingContext
 from iree.turbine.kernel.wave.promotion import promote_placeholders
 from iree.turbine.kernel.wave.hoisting import hoist_loop_invariant_ops
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.wave.minimize_global_loads import minimize_global_loads
 from iree.turbine.kernel.wave.scheduling.schedule import schedule_graph
@@ -285,6 +285,7 @@ class SchedulingTest(unittest.TestCase):
             trace: CapturedTrace = gemm()
             IndexingContext.current().finalize()
             initialize_iter_args(trace)
+            add_get_results(trace)
             infer_types(trace)
             promote_placeholders(trace, constraints)
             hoist_loop_invariant_ops(trace, constraints)

--- a/tests/kernel/wave/visualization_test.py
+++ b/tests/kernel/wave/visualization_test.py
@@ -12,7 +12,7 @@ import pytest
 import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
-from iree.turbine.kernel.wave.expansion.expansion import expand_graph
+from iree.turbine.kernel.wave.expansion.expansion import expand_graph, add_get_results
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel._support.tracing import CapturedTrace
 from iree.turbine.kernel._support.indexing import IndexingContext
@@ -96,6 +96,7 @@ def test_gemm():
         graph = gemm()
         IndexingContext.current().finalize()
         initialize_iter_args(graph)
+        add_get_results(graph)
         infer_types(graph)
         set_node_indices(graph, constraints)
         expand_graph(graph, constraints)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -1058,3 +1058,126 @@ def testSequentialBatchedGemmWhile(
 
     torch_ref = torch.matmul(a, b.transpose(-2, -1))
     assert_close(c.to(torch.float16), torch_ref, atol=1e-3, rtol=5e-3)
+
+
+@require_cdna3
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_batched_gemm"))
+@pytest.mark.parametrize(
+    "enable_scheduling",
+    [SchedulingType.NONE],
+)
+def testSequentialBatchedGemmWhileWithOutputSum(
+    shape: tuple[int], enable_scheduling: SchedulingType, request
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    B = tkl.sym.B
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+    constraints += [tkw.TilingConstraint(B)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(2, 2, 1), vector_shapes={B: 0}
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def batched_gemm(
+        a: tkl.Memory[B, M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[B, N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[B, M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        output_sum: tkl.Memory[N, M, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        init_value: tkl.i32,  # type: ignore
+    ):
+        o_reg = tkl.Register[N, M, tkl.f32](0.0)
+
+        @tkw.iterate(B, start=init_value, condition=B < shape[0], init_args=[o_reg])
+        def body(outer_acc: tkl.Register[N, M, tkl.f32]):
+            c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+            @tkw.iterate(K, init_args=[c_reg])
+            def repeat(
+                acc: tkl.Register[B, M, N, tkl.f32],
+            ) -> tkl.Register[B, M, N, tkl.f32]:
+                a_reg = tkw.read(a)
+                b_reg = tkw.read(b)
+                acc = tkw.mma(a_reg, b_reg, acc)
+                return acc
+
+            tkw.write(repeat, c)
+            permuted = tkw.permute(repeat, target_shape=[N, M])
+            outer_acc += permuted
+
+            # Set the next value for the iteration.
+            # In this case, we are using a simple increment operation,
+            # but this can be replaced with any other operation.
+            index_b = tkw.self_index(B, tkl.i32)
+            next_value = tkw.apply_expr(index_b, lambda x: x + 1)
+            tkw.set_symbol(B, next_value)
+
+            return outer_acc
+
+        tkw.write(body, output_sum)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K: 32,
+        B: shape[0],
+        M: shape[1],
+        N: shape[2],
+        K: shape[3],
+    }
+    hyperparams.update(get_default_scheduling_params())
+
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=(
+            os.path.join(dump_perf, "tk_" + request.node.name + ".json")
+            if dump_perf
+            else None
+        ),
+        wave_runtime=True,
+    )
+    options = set_default_run_config(options)
+    batched_gemm = wave_compile(options, batched_gemm)
+
+    torch.manual_seed(0)
+    a = device_randn(shape[0], shape[1], shape[3], dtype=torch.float16)
+    b = device_randn(shape[0], shape[2], shape[3], dtype=torch.float16)
+    c = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
+    d = device_zeros(shape[2], shape[1], dtype=torch.float32)
+    asm = batched_gemm(a, b, c, d, 0)
+
+    if dump_generated_mlir:
+        filename = f"wave_batched_gemm_{'x'.join(map(str, shape))}.mlir"
+        with open(filename, "w") as f:
+            f.write(asm)
+
+    torch_ref = torch.matmul(a, b.transpose(-2, -1))
+    assert_close(c.to(torch.float16), torch_ref, atol=1e-3, rtol=5e-3)
+    assert_close(d.T, torch.sum(c, dim=0), atol=1e-3, rtol=5e-3)


### PR DESCRIPTION
This PR adds support for init args in the while loop style iterate ops. In order to accomplish this, a couple of changes had to be made
1. Moving add_get_results out from an expansion specific pass to one before the infer types pass
2. Fixing indices of MMA and ACC nodes during index propagation
3. Updates to handler. Specifically since the while loop returns the value of the induction variable while we don't expose this in the DSL, we reorder the arguments.
4. Changes to lit tests to fix this
5. Updates to logic to determine MMA reduction dims and added validation to avoid ambiguities