### PR TITLE
[Wave] Make speculative decoding test use cdna3

### DIFF
--- a/tests/kernel/wave/speculative_decode_test.py
+++ b/tests/kernel/wave/speculative_decode_test.py
@@ -9,6 +9,7 @@ import torch
 import iree.turbine.kernel as tk
 from iree.turbine.kernel.lang.global_symbols import *
 from .common.utils import (
+    require_cdna3,
     require_e2e,
     enable_scheduling_barriers,
     dump_generated_mlir,
@@ -169,6 +170,7 @@ test_cases = [
 ]
 
 
+@require_cdna3
 @require_e2e
 @pytest.mark.parametrize(
     "threshold_single, threshold_acc, expected_predicts, expected_accept_index, expected_accept_token_num",


### PR DESCRIPTION
This PR changes the spec decode test to require
cdna3 since it uses the wave runtime.