### PR TITLE
[wave] Deduce `waves_per_block`, add `ThreadBlock` class, and improve `wave_id` and checks.

### DIFF
--- a/iree/turbine/kernel/lang/__init__.py
+++ b/iree/turbine/kernel/lang/__init__.py
@@ -4,6 +4,7 @@ from .kernel_buffer import *
 from .wave_types import *
 from .wave_types import Memory, Register, IndexMapping
 from .grid import *
+from .block import *
 
 # Include publics from the _support library.
 from .._support.indexing import (

--- a/iree/turbine/kernel/lang/block.py
+++ b/iree/turbine/kernel/lang/block.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from math import prod
+
+from .global_symbols import THREAD_0, THREAD_1, THREAD_2
+from .._support.indexing import IndexExpr
+
+
+@dataclass
+class ThreadBlock:
+    """Thread block with bounding symbolic shape information."""
+
+    shape: tuple[int, int, int]
+
+    def __post_init__(self):
+        assert 0 < prod(self.shape) <= 1024, "Invalid thread block."
+
+    @property
+    def linearized_thread_id(self) -> IndexExpr:
+        thread_ids = [THREAD_0, THREAD_1, THREAD_2]
+        shape = [
+            1,
+            self.shape[0],
+            self.shape[0] * self.shape[1],
+        ]
+        return sum([x * y for x, y in zip(thread_ids, shape)])
+
+    def linearized_wave_id(self, threads_per_wave: int) -> IndexExpr:
+        """Returns a linearized wave id."""
+        ids = [THREAD_0 // threads_per_wave, THREAD_1, THREAD_2]
+        x_sz, y_sz = (self.shape[0] // threads_per_wave, self.shape[1])
+        shape = (1, x_sz, x_sz * y_sz)
+        non_zero_ids = [i for i, dim in enumerate(self.shape) if dim > 1]
+        return sum([ids[i] * shape[i] for i in non_zero_ids])
+
+
+def dim3_from_num_waves(
+    threads_per_wave: int,
+    x: int,
+    y: int = 1,
+    z: int = 1,
+) -> ThreadBlock:
+    """Creates a thread block from x, y, z num waves"""
+    return ThreadBlock((threads_per_wave * x, y, z))

--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -70,6 +70,7 @@ class WaveCompileOptions:
     print_ir_before: list[str] = field(default_factory=list)
     print_trace_begin: bool = False
     print_grid: bool = False
+    print_block: bool = False
     print_signature: bool = False
     print_mlir: bool = False
     print_ir_after_all: bool = False

--- a/iree/turbine/kernel/wave/global_to_shared_gathers.py
+++ b/iree/turbine/kernel/wave/global_to_shared_gathers.py
@@ -296,9 +296,7 @@ def global_to_shared_gathers(trace: CapturedTrace, constraints: list[Constraint]
         if isinstance(c, TilingConstraint) or isinstance(c, WorkgroupConstraint)
     }
 
-    total_number_of_threads = hardware_constraint.threads_per_wave * prod(
-        hardware_constraint.waves_per_block
-    )
+    total_number_of_threads = prod(hardware_constraint.threads_per_block)
     element_type = get_custom(global_gathers[0]).type.dtype
     load_elems_per_thread = hardware_constraint.max_elems_per_load(element_type)
     max_elements_per_load = total_number_of_threads * load_elems_per_thread

--- a/iree/turbine/kernel/wave/minimize_global_loads.py
+++ b/iree/turbine/kernel/wave/minimize_global_loads.py
@@ -15,7 +15,6 @@ from .._support.indexing import IndexingContext, IndexSequence, IndexSymbol, Ind
 from ..ops.wave_ops import Read, Write, get_custom
 from ..lang.global_symbols import *
 from .utils.general_utils import (
-    delinearize_index,
     ceildiv,
     is_shared_read,
     get_fastest_index,
@@ -25,6 +24,7 @@ from .utils.graph_utils import (
 )
 from .utils.symbol_utils import (
     subs_idxc,
+    delinearize_index,
 )
 from math import prod
 import torch.fx as fx
@@ -364,9 +364,7 @@ def minimize_global_loads(trace: CapturedTrace, constraints: list[Constraint]):
         if isinstance(c, TilingConstraint) or isinstance(c, WorkgroupConstraint)
     }
 
-    total_number_of_threads = hardware_constraint.threads_per_wave * prod(
-        hardware_constraint.waves_per_block
-    )
+    total_number_of_threads = prod(hardware_constraint.threads_per_block)
     element_type = get_custom(global_read_nodes[0]).type.dtype
     load_elems_per_thread = hardware_constraint.max_elems_per_load(element_type)
     max_elements_per_load = total_number_of_threads * load_elems_per_thread

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -58,29 +58,6 @@ def get_default_scheduling_params() -> dict[IndexSymbol, Any]:
     }
 
 
-def delinearize_index(
-    index: IndexExpr, shape: list[int | IndexExpr]
-) -> list[IndexExpr]:
-    """
-    Delinearizes a 1D index into a multi-dimensional index
-    based on the shapes provided. The returned array contains
-    the multi-dimensional index.
-
-    Assume the index is x and the shape is [5, 4, 3]. In this case,
-    this function returns [x % 3, (x // 3) % 4, (x // 12) % 5].
-
-    """
-    nd_index = []
-    product = 1
-    for i, size in enumerate(reversed(shape)):
-        if i == 0:
-            nd_index.append(index % size)
-        else:
-            nd_index.append(sympy.floor(index / product) % size)
-        product *= size
-    return nd_index[::-1]
-
-
 def get_hardware_vector_size(
     dim: IndexSymbol,
     hardware_constraint: HardwareConstraint,

--- a/iree/turbine/kernel/wave/utils/symbol_utils.py
+++ b/iree/turbine/kernel/wave/utils/symbol_utils.py
@@ -26,3 +26,36 @@ def subs_idxc(input: Any) -> Any:
     """
     idxc = IndexingContext.current()
     return safe_subs(input, idxc.subs)
+
+
+def infer_static_shape(
+    shape: tuple[int | IndexExpr], idxc: IndexingContext
+) -> tuple[int, ...]:
+    """Infer the static shape using the indexing context."""
+    shape = tuple(idxc.get_static_value(safe_subs(sym, idxc.subs)) for sym in shape)
+    if None in shape:
+        raise ValueError(f"A dynamic dim found in the shape")
+    return shape
+
+
+def delinearize_index(
+    index: IndexExpr, shape: list[int | IndexExpr]
+) -> list[IndexExpr]:
+    """
+    Delinearizes a 1D index into a multi-dimensional index
+    based on the shapes provided. The returned array contains
+    the multi-dimensional index.
+
+    Assume the index is x and the shape is [5, 4, 3]. In this case,
+    this function returns [x % 3, (x // 3) % 4, (x // 12) % 5].
+
+    """
+    nd_index = []
+    product = 1
+    for i, size in enumerate(reversed(shape)):
+        if i == 0:
+            nd_index.append(index % size)
+        else:
+            nd_index.append(sympy.floor(index / product) % size)
+        product *= size
+    return nd_index[::-1]

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -9,7 +9,7 @@ from sympy.utilities.lambdify import lambdastr
 from itertools import chain
 import iree.turbine.kernel.lang as tkl
 from ..compiler import builder, dispatch_codegen, kernel_codegen, host_codegen
-from ..lang import Grid, IndexMapping
+from ..lang import Grid, IndexMapping, ThreadBlock
 from ..lang.global_symbols import *
 from ..ops import wave_ops
 from ..ops.wave_ops import Iterate, CustomOp, get_custom, IterArg
@@ -31,6 +31,7 @@ from .constraints import (
     WaveConstraint,
     WorkgroupConstraint,
     get_grid_shape,
+    initialize_and_check_constraints,
 )
 
 # Passes
@@ -61,7 +62,7 @@ from .shared_memory_indexing import (
 )
 
 # Utils
-from .utils.symbol_utils import subs_idxc, safe_subs
+from .utils.symbol_utils import subs_idxc, safe_subs, delinearize_index
 from .utils.classes import KernelLaunchInfo
 from .utils.print_utils import print_trace, try_apply_pass
 from .utils.graph_utils import (
@@ -71,7 +72,6 @@ from .utils.graph_utils import (
 )
 from .utils.compile_utils import canonicalize_module
 from .utils.general_utils import (
-    delinearize_index,
     partial,
     get_hardware_constraint,
     remove_files_with_extension,
@@ -253,22 +253,6 @@ class LaunchableWave(Launchable):
             for tiling_constraint in self.tiling_constraints:
                 if tiling_constraint.dim == custom.axis:
                     tiling_constraint.induction_var = self.induction_vars[custom]
-
-    def initialize_wave_constraints(self, trace: CapturedTrace) -> None:
-        """
-        For each wave constraint, determines the appropriate wave id by looking
-        for workgroup constraints along the same dimension and using information
-        from the hardware constraints.
-
-        """
-
-        hardware_constraint = self.hardware_constraints[0]
-        for wave_constraint in self.wave_constraints:
-            for workgroup_constraint in self.workgroup_constraints:
-                if wave_constraint.dim == workgroup_constraint.dim:
-                    wave_constraint.set_wave_id_from_hardware_and_workgroup_constraint(
-                        hardware_constraint, workgroup_constraint
-                    )
 
     def initialize_reductions(self, trace: CapturedTrace) -> None:
         """
@@ -453,7 +437,6 @@ class LaunchableWave(Launchable):
         return [
             partial(initialize_iter_args, trace),
             partial(self.create_induction_vars, trace),
-            partial(self.initialize_wave_constraints, trace),
             partial(self.initialize_reductions, trace),
             partial(self.initialize_symbolic_constraints, trace),
             partial(self.initialize_workgroup_constraints, trace),
@@ -514,6 +497,10 @@ class LaunchableWave(Launchable):
         ):
             print(f"***After trace/Before first pass***\n")
             print_trace(trace)
+
+        idxc = IndexingContext.current()
+        # Check and initialize the constraints.
+        initialize_and_check_constraints(self.constraints, idxc)
 
         # Initial passes, pre-optimization.
         graph_passes = self.build_initial_pass_pipeline(
@@ -582,6 +569,9 @@ class LaunchableWave(Launchable):
         if options.print_grid:
             print(f"Grid: {self.grid_type}")
 
+        if options.print_block:
+            print(f"Block: {self.thread_block}")
+
         # Add grid and block dims to kernel launch info.
         # Convert the grid into a lambda that we can use to compute the grid dimension.
         hw_constraint = get_hardware_constraint(self.constraints)
@@ -591,9 +581,7 @@ class LaunchableWave(Launchable):
         options.kernel_launch_info.grid_str = lambdastr(
             [list(options.dynamic_symbols_map.keys())], self.grid_type.dims
         )
-        options.kernel_launch_info.blocks = [
-            int(x) for x in hw_constraint.threads_per_block
-        ]
+        options.kernel_launch_info.blocks = hw_constraint.threads_per_block
         options.kernel_launch_info.func_name = self._name
 
         idxc = IndexingContext.current()

--- a/lit_tests/kernel/wave/barriers.py
+++ b/lit_tests/kernel/wave/barriers.py
@@ -93,6 +93,7 @@ def test_read_write_equal_sizes():
         graph: fx.Graph = trace.get_root_graph()
         read_node = get_read_nodes(graph)[0]
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         infer_types(trace)
         promote_node(read_node, None, SHARED_ADDRESS_SPACE, constraints)
         set_node_indices(trace, constraints)
@@ -179,6 +180,7 @@ def test_gemm():
         trace: CapturedTrace = gemm()
         graph: fx.Graph = trace.get_subgraph("region_0")
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         initialize_iter_args(trace)
         infer_types(trace)
         read_nodes = get_read_nodes(graph)

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -94,6 +94,7 @@ def test_gemm():
     ):
         trace: CapturedTrace = gemm()
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         initialize_iter_args(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -94,6 +94,7 @@ def test_gemm():
         trace: CapturedTrace = gemm()
         visualize = False
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         initialize_iter_args(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)

--- a/lit_tests/kernel/wave/promotion.py
+++ b/lit_tests/kernel/wave/promotion.py
@@ -71,6 +71,7 @@ def test_read_write_equal_sizes():
         graph: fx.Graph = trace.get_root_graph()
         read_node = get_read_nodes(graph)[0]
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         infer_types(trace)
         promote_node(read_node, None, SHARED_ADDRESS_SPACE, constraints)
         print_trace(trace, False)
@@ -121,6 +122,7 @@ def test_read_write_equal_sizes_different_address_spaces():
     ):
         trace: CapturedTrace = read_write_same_size_different_address_spaces()
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         infer_types(trace)
         promote_placeholders(trace, constraints)
         print_trace(trace, False)
@@ -178,6 +180,7 @@ def test_gemm():
         graph: fx.Graph = trace.get_subgraph("region_0")
         read_nodes = get_read_nodes(graph)
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         infer_types(trace)
         for read_node in read_nodes:
             promote_node(read_node, None, SHARED_ADDRESS_SPACE, constraints)

--- a/lit_tests/kernel/wave/scheduling.py
+++ b/lit_tests/kernel/wave/scheduling.py
@@ -99,6 +99,7 @@ def test_gemm_pipelined():
     ):
         trace: CapturedTrace = gemm_pipelined()
         IndexingContext.current().finalize()
+        tkw.initialize_and_check_constraints(constraints, IndexingContext.current())
         initialize_iter_args(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)

--- a/tests/kernel/wave/wave_utils_test.py
+++ b/tests/kernel/wave/wave_utils_test.py
@@ -6,7 +6,7 @@
 
 import pytest
 from iree.turbine.kernel.lang import sym
-from iree.turbine.kernel.wave.utils.general_utils import (
+from iree.turbine.kernel.wave.utils.symbol_utils import (
     delinearize_index,
 )
 from iree.turbine.kernel.wave.utils.mapping_utils import (


### PR DESCRIPTION
This patch is a follow-up of https://github.com/iree-org/iree-turbine/pull/661.

### TL;DR;

Due to the nature of the wave programming model and its current implementation, given a `WorkGroupConstraint` and `WaveConstraint`, these fully determine a uniquely valid `waves_per_block`. Therefore, this patch removes `waves_per_block` and adds `thread_block` that can be inferred from `WorkGroupConstraint` and `WaveConstraint`.

### Motivation:

Currently the usage of `waves_per_block` by an user can introduce many subtle bugs. For example, if `waves_per_block=(2, 2, 1)` and we add the following constraints:
```python
WaveConstraint(M, BLOCK_M)
WaveConstraint(N, BLOCK_N)
```
the resulting code will likely cause a memory fault error. As mentioned above, the root of the issue is that given the model and implementation there's only one valid `waves_per_block` for a `WorkGroupConstraint` and `WaveConstraint` pair.

This change, should improve the user experience, as it reduces the complexity of understanding how to specify the constraint. Furthermore, if an user tries to specify an invalid combination, then an error will produced.

Finally, as part of this patch we remove the restriction of at most `3` `WaveConstraint`. We do this by computing the linearized wave Id:
```C++
linear_wave_id = floor(threadIdx.x / threads_per_wave) + threadIdx.y * (blockDim.x / threads_per_wave) + threadIdx.z * (blockDim.x / threads_per_wave) * blockDim.y
```
and then delinearizing the `linear_wave_id` using `WorkgroupConstraint[dim].tile_size / WaveConstraint[dim].tile_size` as a base.

To better model GPU hardware semantics, the `ThreadBlock` class was added, and serves a similar role to `Grid`. However, this class shouldn't be used by users at the moment.

### Comments:

Some of the tests changed by either one of 3 reasons:
1. A call to `tkw.initialize_and_check_constraints(constraints, IndexingContext.current())` was added.
2. The test was semantically wrong. For example, it had `tkw.WaveConstraint(M, BLOCK_M / 2)` and only one wave per block in the corresponding dimension
3. The index changed because of `wave.Constraints._simplify_wave_ids`, which removes expressions like `floor(T0 / threads_per_block)` if `T0 < threads_per_block`.


CC: @harsh-amd , @Hardcode84, @raikonenfnu 