### PR TITLE
[Wave] Add first speculative sampling kernel

### DIFF
--- a/iree/turbine/kernel/compiler/kernel_codegen.py
+++ b/iree/turbine/kernel/compiler/kernel_codegen.py
@@ -290,7 +290,7 @@ class KernelSignature:
         # Extract all placeholder nodes.
         placeholder_nodes = filter_fx_graph(graph, is_placeholder)
 
-        def get_users_recursive(node):
+        def get_users_recursive(node, parent=None):
             ret = []
             for user in node.users.keys():
                 custom = get_custom(user)
@@ -302,8 +302,9 @@ class KernelSignature:
                 nested_placeholders = filter_fx_graph(subgraph, is_placeholder)
                 for nested in nested_placeholders:
                     captured = get_custom(nested).get_captured_fx_node()
-                    if captured == node:
-                        ret += get_users_recursive(nested)
+                    parent = node if not parent else parent
+                    if captured == parent:
+                        ret += get_users_recursive(nested, parent)
 
             return ret
 

--- a/iree/turbine/kernel/compiler/kernel_codegen.py
+++ b/iree/turbine/kernel/compiler/kernel_codegen.py
@@ -291,6 +291,10 @@ class KernelSignature:
         placeholder_nodes = filter_fx_graph(graph, is_placeholder)
 
         def get_users_recursive(node, parent=None):
+            # When trying to determine the recursive users of a node, we need to
+            # pass the top-level parent down to the recursive call, since
+            # the cloned variables in each subgraph will refer to the parent
+            # node (and not the node one level up).
             ret = []
             for user in node.users.keys():
                 custom = get_custom(user)

--- a/iree/turbine/kernel/lang/global_symbols.py
+++ b/iree/turbine/kernel/lang/global_symbols.py
@@ -1,4 +1,5 @@
 from .._support.indexing import index_symbol
+import sympy
 
 # Global symbols used throughout the code.
 
@@ -44,3 +45,8 @@ GLOBAL_MEMORY_UNITS = index_symbol("$GLOBAL_MEMORY_UNITS")
 MMA_UNITS = index_symbol("$MMA_UNITS")
 VALU_UNITS = index_symbol("$VALU_UNITS")
 SHUFFLE_UNITS = index_symbol("$SHUFFLE_UNITS")
+
+
+# Iteration symbols.
+def GET_ITER_ARG(i: int):
+    return sympy.Symbol(f"$GET_ITER_ARG_{i}")

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -856,6 +856,7 @@ class ComparisonPyOp(BinaryOpBase, ABC):
 @define_interface_op("tanh")
 @define_interface_op("tanh_approx")
 @define_py_op(operator.neg)
+@define_py_op(operator.invert)
 @dataclass
 class UnaryPyOp(CustomOp, ABC):
     """
@@ -1070,6 +1071,11 @@ class IterArg(Placeholder):
     @iter_idx.setter
     def iter_idx(self, value):
         self.fx_node.iter_idx = value
+
+    def infer_type(self):
+        parent_op = self.parent_op()
+        init_args = parent_op.init_args
+        self.type = init_args[self.iter_idx].type
 
 
 # Ops modeling TKW operations in the kernel language

--- a/iree/turbine/kernel/wave/analysis/partition_strided_operators.py
+++ b/iree/turbine/kernel/wave/analysis/partition_strided_operators.py
@@ -78,6 +78,9 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
         """
         custom = get_custom(node)
         if isinstance(custom, Write):
+            # TODO: Why do we need this check?
+            if not custom.register_index:
+                return False
             strides = [
                 simplify_index(custom.register_index[dim]).stride
                 for dim in custom.register_index

--- a/iree/turbine/kernel/wave/analysis/partition_strided_operators.py
+++ b/iree/turbine/kernel/wave/analysis/partition_strided_operators.py
@@ -78,9 +78,6 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
         """
         custom = get_custom(node)
         if isinstance(custom, Write):
-            # TODO: Why do we need this check?
-            if not custom.register_index:
-                return False
             strides = [
                 simplify_index(custom.register_index[dim]).stride
                 for dim in custom.register_index

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -561,6 +561,13 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Val
                 _enforce_non_rational(lhs, term)
                 res = arith_d.cmpi(arith_d.CmpIPredicate.sge, *_broadcast(lhs, rhs))
                 stack.append(res)
+            case sympy.Eq():
+                rhs = stack.pop()
+                lhs = stack.pop()
+                _enforce_non_rational(rhs, term)
+                _enforce_non_rational(lhs, term)
+                res = arith_d.cmpi(arith_d.CmpIPredicate.eq, *_broadcast(lhs, rhs))
+                stack.append(res)
             case sympy.And():
                 rhs = stack.pop()
                 lhs = stack.pop()

--- a/iree/turbine/kernel/wave/expansion/expansion_utils.py
+++ b/iree/turbine/kernel/wave/expansion/expansion_utils.py
@@ -273,3 +273,14 @@ def remove_unused_registers(trace: CapturedTrace):
     for node in trace.walk(lambda x: isinstance(get_custom(x), NewRegister)):
         if not node.users:
             node.graph.erase_node(node)
+
+
+def remove_unused_iter_args(trace: CapturedTrace):
+    """
+    Remove duplicate iter args that are not used in the graph.
+    """
+    iter_args = trace.walk(lambda x: isinstance(get_custom(x), IterArg))
+    for node in iter_args:
+        custom = get_custom(node)
+        if not custom.users:
+            custom.erase()

--- a/iree/turbine/kernel/wave/hoisting.py
+++ b/iree/turbine/kernel/wave/hoisting.py
@@ -18,7 +18,11 @@ logger = get_logger("turbine.wave.hoisting")
 
 def has_set_symbol_dependent_mapping(custom_node: CustomOp) -> bool:
     """Check if the custom node has a mapping with symbols and a set symbol of any symbols in the
-    mapping occurs prior."""
+    mapping occurs prior.
+
+    TODO: Currently this pass is being conservative as the symbols might not have any dependency
+    on the induction variable. Use this knowledge to allow hoisting of such ops.
+    """
     if not custom_node.mapping:
         return False
     used_symbols = [

--- a/lit_tests/kernel/wave/expansion.py
+++ b/lit_tests/kernel/wave/expansion.py
@@ -260,7 +260,7 @@ def test_write_in_iterate():
 
         # CHECK: Custom format:
         # CHECK: iterate(axis=K,
-        # CHECK: get_result(value=iterate, res_idx=0)
+        # CHECK: get_result(value=iterate, res_idx=0
         # CHECK: write(register_=get_result_M:0_K:0, memory=c, elements_per_thread=4,
 
         # iterate subgraph:
@@ -408,10 +408,10 @@ def test_gemm():
         # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1})
         # CHECK-NEXT: iterate(axis=K, init_args=[register_M:0_N:0_K:0, register_M:0_N:1_K:0, register_M:1_N:0_K:0, register_M:1_N:1_K:0], subgraph_name=region_0, implicit_captures=[a, b])
-        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=1)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=2)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=3)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0
+        # CHECK-NEXT: get_result(value=iterate, res_idx=1
+        # CHECK-NEXT: get_result(value=iterate, res_idx=2
+        # CHECK-NEXT: get_result(value=iterate, res_idx=3
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0
         # CHECK-SAME: index={M:  $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1}
         # CHECK-NEXT: write(register_=get_result_M:0_N:1_K:0
@@ -598,10 +598,10 @@ def test_batched_gemm():
         # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: register(shape=(B, M, N), dtype=f32, value=0.0, index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) + 16 : 1 : 1})
         # CHECK-NEXT: iterate(axis=K, init_args=[register_M:0_N:0_K:0, register_M:0_N:1_K:0, register_M:1_N:0_K:0, register_M:1_N:1_K:0], subgraph_name=region_0, implicit_captures=[a, b])
-        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=1)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=2)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=3)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0
+        # CHECK-NEXT: get_result(value=iterate, res_idx=1
+        # CHECK-NEXT: get_result(value=iterate, res_idx=2
+        # CHECK-NEXT: get_result(value=iterate, res_idx=3
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0
         # CHECK-SAME: index={B: $WG2*BLOCK_B : 1 : 1, M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1}
         # CHECK-NEXT: write(register_=get_result_M:0_N:1_K:0
@@ -868,7 +868,7 @@ def test_gemm_iterate_expansion_only():
         # CHECK-NEXT: placeholder(_name=c
         # CHECK-NEXT: register(shape=(M, N), dtype=f32, value=0.0, index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: iterate(axis=K, init_args=[register_M:0_N:0_K:0]
-        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0
         # CHECK-SAME: index={M: $T0*BLOCK_M/128 + $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $T1*BLOCK_N/2 + $WG1*BLOCK_N + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: output(return_vals=(None,))

--- a/lit_tests/kernel/wave/index_sequence_analysis.py
+++ b/lit_tests/kernel/wave/index_sequence_analysis.py
@@ -209,10 +209,10 @@ def test_gemm():
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: iterate(
-        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=1)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=2)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=3)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0
+        # CHECK-NEXT: get_result(value=iterate, res_idx=1
+        # CHECK-NEXT: get_result(value=iterate, res_idx=2
+        # CHECK-NEXT: get_result(value=iterate, res_idx=3
         # CHECK-NEXT: extract_slice(register_=get_result_M:0_N:0_K:0, offset=[0], size=[1], stride=[1])
         # CHECK-NEXT: write(register_=extract_slice, memory=c, elements_per_thread=1,
         # CHECK-SAME: index={M: 64*$WG0 + 4*floor((Mod($T0, 64))/16) : 1 : 1, N: 64*$WG1 + Mod($T0, 16) + 32 : 1 : 1})

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -157,10 +157,10 @@ def test_gemm():
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: allocate(
         # CHECK-NEXT: iterate(
-        # CHECK-NEXT: get_result(value=iterate, res_idx=0)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=1)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=2)
-        # CHECK-NEXT: get_result(value=iterate, res_idx=3)
+        # CHECK-NEXT: get_result(value=iterate, res_idx=0
+        # CHECK-NEXT: get_result(value=iterate, res_idx=1
+        # CHECK-NEXT: get_result(value=iterate, res_idx=2
+        # CHECK-NEXT: get_result(value=iterate, res_idx=3
         # CHECK-NEXT: write(register_=get_result_M:0_N:0_K:0, memory=c
         # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) : 1 : 1})
         # CHECK-NEXT: write(register_=get_result_M:0_N:1_K:0, memory=c

--- a/lit_tests/kernel/wave/promotion.py
+++ b/lit_tests/kernel/wave/promotion.py
@@ -13,6 +13,7 @@ from iree.turbine.kernel._support.indexing import IndexingContext
 from iree.turbine.kernel.ops.wave_ops import *
 from iree.turbine.kernel.wave.utils.general_utils import run_test
 from iree.turbine.kernel.wave.utils.print_utils import print_trace
+from iree.turbine.kernel.wave.utils.graph_utils import initialize_iter_args
 
 
 def get_read_nodes(graph: fx.Graph) -> list[CustomOp]:
@@ -71,6 +72,7 @@ def test_read_write_equal_sizes():
         graph: fx.Graph = trace.get_root_graph()
         read_node = get_read_nodes(graph)[0]
         IndexingContext.current().finalize()
+        initialize_iter_args(trace)
         infer_types(trace)
         promote_node(read_node, None, SHARED_ADDRESS_SPACE, constraints)
         print_trace(trace, False)
@@ -121,6 +123,7 @@ def test_read_write_equal_sizes_different_address_spaces():
     ):
         trace: CapturedTrace = read_write_same_size_different_address_spaces()
         IndexingContext.current().finalize()
+        initialize_iter_args(trace)
         infer_types(trace)
         promote_placeholders(trace, constraints)
         print_trace(trace, False)
@@ -178,6 +181,7 @@ def test_gemm():
         graph: fx.Graph = trace.get_subgraph("region_0")
         read_nodes = get_read_nodes(graph)
         IndexingContext.current().finalize()
+        initialize_iter_args(trace)
         infer_types(trace)
         for read_node in read_nodes:
             promote_node(read_node, None, SHARED_ADDRESS_SPACE, constraints)

--- a/lit_tests/kernel/wave/speculative_decoding.py
+++ b/lit_tests/kernel/wave/speculative_decoding.py
@@ -1,0 +1,69 @@
+# RUN: python %s | FileCheck %s
+
+from typing import Callable
+import iree.turbine.kernel as tk
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
+from iree.turbine.kernel.wave.utils.general_utils import (
+    run_test,
+)
+from iree.turbine.kernel.wave.templates.speculative_decoding import (
+    get_speculative_decoding_kernel,
+    get_speculative_sampling_kernel,
+)
+
+
+@run_test
+def test_speculative_decoding():
+    # Get the kernel and its hyperparameters
+    kernel, hyperparams, _, _ = get_speculative_sampling_kernel(
+        batch_size=10,
+        num_speculative_tokens=3,
+        threshold_single=0.01,
+        threshold_acc=0.01,
+        num_draft_tokens=6,
+        d=20,
+    )
+
+    # Create the kernel with the hyperparameters
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        compile_to_mlir=True,
+    )
+    kernel = wave_compile(options, kernel)
+    print(kernel.asm)
+
+    # CHECK: #map = affine_map<()[s0] -> (s0 + (s0 floordiv 64) * 64)>
+    # CHECK: #translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
+    # CHECK: module attributes {transform.with_named_sequence} {
+    # CHECK:   stream.executable private @tree_speculative_sampling {
+    # CHECK:     stream.executable.export public @tree_speculative_sampling workgroups() -> (index, index, index) {
+    # CHECK:       %c1 = arith.constant 1 : index
+    # CHECK:       stream.return %c1, %c1, %c1 : index, index, index
+    # CHECK:     }
+    # CHECK:     builtin.module {
+    # CHECK:       func.func @tree_speculative_sampling(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: !stream.binding) attributes {translation_info = #translation} {
+    # CHECK:         %c0 = arith.constant 0 : index
+    # CHECK:         %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+    # CHECK:         %thread_id_x = gpu.thread_id  x
+    # CHECK:         %0 = stream.binding.subspan %arg0[%c0] : !stream.binding -> memref<64xf32, strided<[1], offset: ?>>
+    # CHECK:         %1 = affine.apply #map()[%thread_id_x]
+    # CHECK:         %2 = vector.load %0[%1] : memref<64xf32, strided<[1], offset: ?>>, vector<1xf32>
+    # CHECK:         %129 = stream.binding.subspan %arg1[%c0] : !stream.binding -> memref<64xf32, strided<[1], offset: ?>>
+    # CHECK:         %130 = vector.load %129[%1] : memref<64xf32, strided<[1], offset: ?>>, vector<1xf32>
+    # CHECK:         %194 = arith.subf %2, %130 : vector<1xf32>
+    # CHECK:         %258 = arith.maximumf %194, %cst : vector<1xf32>
+    # CHECK:         %322 = stream.binding.subspan %arg2[%c0] : !stream.binding -> memref<64xf32, strided<[1], offset: ?>>
+    # CHECK:         vector.store %258, %322[%1] : memref<64xf32, strided<[1], offset: ?>>, vector<1xf32>
+    # CHECK:         return
+    # CHECK:       }
+    # CHECK:     }
+    # CHECK:   }
+    # CHECK:   func.func @isolated_benchmark(%arg0: tensor<64xf32>, %arg1: tensor<64xf32>, %arg2: tensor<64xf32>) -> tensor<64xf32> {
+    # CHECK:     %0 = flow.dispatch @tree_speculative_sampling::@tree_speculative_sampling(%arg0, %arg1, %arg2) : (tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> %arg2
+    # CHECK:     return %0 : tensor<64xf32>
+    # CHECK:   }
+    # CHECK: }

--- a/lit_tests/kernel/wave/speculative_decoding.py
+++ b/lit_tests/kernel/wave/speculative_decoding.py
@@ -36,34 +36,22 @@ def test_speculative_decoding():
     kernel = wave_compile(options, kernel)
     print(kernel.asm)
 
-    # CHECK: #map = affine_map<()[s0] -> (s0 + (s0 floordiv 64) * 64)>
-    # CHECK: #translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [64, 1, 1] subgroup_size = 64>
-    # CHECK: module attributes {transform.with_named_sequence} {
-    # CHECK:   stream.executable private @tree_speculative_sampling {
-    # CHECK:     stream.executable.export public @tree_speculative_sampling workgroups() -> (index, index, index) {
-    # CHECK:       %c1 = arith.constant 1 : index
-    # CHECK:       stream.return %c1, %c1, %c1 : index, index, index
-    # CHECK:     }
-    # CHECK:     builtin.module {
-    # CHECK:       func.func @tree_speculative_sampling(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: !stream.binding) attributes {translation_info = #translation} {
-    # CHECK:         %c0 = arith.constant 0 : index
-    # CHECK:         %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
-    # CHECK:         %thread_id_x = gpu.thread_id  x
-    # CHECK:         %0 = stream.binding.subspan %arg0[%c0] : !stream.binding -> memref<64xf32, strided<[1], offset: ?>>
-    # CHECK:         %1 = affine.apply #map()[%thread_id_x]
-    # CHECK:         %2 = vector.load %0[%1] : memref<64xf32, strided<[1], offset: ?>>, vector<1xf32>
-    # CHECK:         %129 = stream.binding.subspan %arg1[%c0] : !stream.binding -> memref<64xf32, strided<[1], offset: ?>>
-    # CHECK:         %130 = vector.load %129[%1] : memref<64xf32, strided<[1], offset: ?>>, vector<1xf32>
-    # CHECK:         %194 = arith.subf %2, %130 : vector<1xf32>
-    # CHECK:         %258 = arith.maximumf %194, %cst : vector<1xf32>
-    # CHECK:         %322 = stream.binding.subspan %arg2[%c0] : !stream.binding -> memref<64xf32, strided<[1], offset: ?>>
-    # CHECK:         vector.store %258, %322[%1] : memref<64xf32, strided<[1], offset: ?>>, vector<1xf32>
-    # CHECK:         return
-    # CHECK:       }
-    # CHECK:     }
-    # CHECK:   }
-    # CHECK:   func.func @isolated_benchmark(%arg0: tensor<64xf32>, %arg1: tensor<64xf32>, %arg2: tensor<64xf32>) -> tensor<64xf32> {
-    # CHECK:     %0 = flow.dispatch @tree_speculative_sampling::@tree_speculative_sampling(%arg0, %arg1, %arg2) : (tensor<64xf32>, tensor<64xf32>, tensor<64xf32>) -> %arg2
-    # CHECK:     return %0 : tensor<64xf32>
-    # CHECK:   }
-    # CHECK: }
+    # CHECK: scf.while
+    # CHECK: scf.condition
+    # CHECK: scf.while
+    # CHECK: scf.condition
+    # CHECK: arith.divf
+    # CHECK: arith.cmpf
+    # CHECK: arith.xori
+    # CHECK: arith.select
+    # CHECK: scf.if
+    # CHECK: vector.store
+    # CHECK: scf.if
+    # CHECK: vector.load
+    # CHECK: vector.store
+    # CHECK: arith.select
+    # CHECK: arith.addf
+    # CHECK: arith.select
+    # CHECK: scf.yield
+    # CHECK: scf.yield
+    # CHECK: return

--- a/tests/kernel/wave/type_inference_test.py
+++ b/tests/kernel/wave/type_inference_test.py
@@ -20,6 +20,7 @@ from iree.turbine.kernel.wave.utils.mma_utils import (
 from iree.turbine.kernel.wave.constraints import MMAType
 from iree.turbine.kernel.wave.type_inference import infer_types
 from iree.turbine.kernel.ops.wave_ops import get_custom
+from iree.turbine.kernel.wave.utils.graph_utils import initialize_iter_args
 
 
 class TypeInferenceTest(unittest.TestCase):
@@ -154,6 +155,7 @@ class TypeInferenceTest(unittest.TestCase):
         ):
             trace: CapturedTrace = base_attention()
             IndexingContext.current().finalize()
+            initialize_iter_args(trace)
             infer_types(trace)
             expected_type = {
                 "partial_sum": "Register[B, M].of(f32)",


### PR DESCRIPTION
This PR adds the first part of the speculative sampling kernel implemented in Wave. Multiple changes had to be made to produce a functional kernel, such as 
- Handling of multiple iterates 
- Adding support for sympy.Eq, invert operator
- Improvements to expansion 
- Making hoisting aware of setsymbols so that if a read has a mapping that uses a symbol that is being set, dont hoist the read before the setsymbol
