### PR TITLE
[Wave] Plumb func_name into compile.py for wave asm

### DIFF
--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -26,6 +26,7 @@ from .ir import (
 from .._support.indexing import IndexSymbol
 from .._support.location import FileLineColInfo
 from .kernel_codegen import BindingDesc
+from typing import Optional
 
 
 def memref_to_tensor(memrefs: list[IrType]):
@@ -59,6 +60,7 @@ def isolated_test_call(
     exe: StreamExecutable,
     sig: KernelSignature,
     entrypoint: str,
+    func_name: Optional[str],
     dynamic_symbols: list[IndexSymbol] = [],
 ):
     with InsertionPoint(mb.body_block), Location.unknown():
@@ -81,7 +83,7 @@ def isolated_test_call(
         )
 
         ftype = FunctionType.get(input_tensors, output_tensors)
-        func_op = func_d.FuncOp("isolated_benchmark", ftype)
+        func_op = func_d.FuncOp(func_name, ftype)
         actual_loc = FileLineColInfo.capture_current_location().to_mlir()
         arg_locs = [
             (Location.name(b.name, actual_loc) if b.name is not None else actual_loc)

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -26,7 +26,6 @@ from .ir import (
 from .._support.indexing import IndexSymbol
 from .._support.location import FileLineColInfo
 from .kernel_codegen import BindingDesc
-from typing import Optional
 
 
 def memref_to_tensor(memrefs: list[IrType]):
@@ -60,7 +59,7 @@ def isolated_test_call(
     exe: StreamExecutable,
     sig: KernelSignature,
     entrypoint: str,
-    func_name: Optional[str],
+    func_name: str = "isolated_benchmark",
     dynamic_symbols: list[IndexSymbol] = [],
 ):
     with InsertionPoint(mb.body_block), Location.unknown():

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -106,7 +106,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     options.kernel_sig = kernel_sig
 
     host_codegen.isolated_test_call(
-        mb, exe, kernel_sig, entrypoint_name, options.dynamic_symbols
+        mb, exe, kernel_sig, entrypoint_name, options.func_name, options.dynamic_symbols
     )
     asm = mb.module_op.get_asm(
         enable_debug_info=options.debug_info, use_local_scope=options.use_local_scope

--- a/lit_tests/kernel/wave/attention/attention.py
+++ b/lit_tests/kernel/wave/attention/attention.py
@@ -332,6 +332,7 @@ def test_attention():
         schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
         compile_to_mlir=True,
+        func_name="test_vanilla_attention",
     )
     base_attention = wave_compile(options, base_attention)
     print(base_attention.asm)
@@ -344,6 +345,8 @@ def test_attention():
     # CHECK-COUNT-8:            {{.*}} = arith.addf
     # CHECK-COUNT-8:            {{.*}} = gpu.shuffle xor {{.*}}
     # CHECK-COUNT-8:            {{.*}} = amdgpu.mfma
+
+    # CHECK-LABEL:      func.func @test_vanilla_attention
 
 
 @run_test


### PR DESCRIPTION
Plumbs func_name through to the IR creation of `isolated_test_call` instead of hard-coding it to "isolated_benchmark".