### PR TITLE
[Wave] Add batch_size field to AttentionShape

### DIFF
--- a/iree/turbine/kernel/wave/templates/attention_common.py
+++ b/iree/turbine/kernel/wave/templates/attention_common.py
@@ -16,6 +16,7 @@ class AttentionShape:
     num_kv_heads: int
     head_size: int
     head_size_kv: int
+    batch_size: Optional[int] = None
     # -----------------------
     # Prefill specific
     num_seqs: Optional[int] = None

--- a/iree/turbine/kernel/wave/templates/vanilla_attention.py
+++ b/iree/turbine/kernel/wave/templates/vanilla_attention.py
@@ -665,7 +665,7 @@ def get_bhsd_attention_kernel(
         BLOCK_M: 128,
         BLOCK_N: 64,
         BLOCK_K2: 64,
-        B: 1,
+        B: shape.batch_size,
         H: shape.num_query_heads,
         M: shape.query_seq_len,
         N: shape.head_size_kv,

--- a/tests/kernel/wave/common/shapes.py
+++ b/tests/kernel/wave/common/shapes.py
@@ -21,6 +21,10 @@ _e2e_test_shapes["attention"] = [
     (8, 128, 128, 64, 256),
     (40, 1024, 64, 64, 1024),
 ]
+_e2e_test_shapes["bhsd_attention"] = [
+    (4, 32, 128, 128, 128, 128),
+    (8, 32, 128, 128, 64, 256),
+]
 _e2e_test_shapes["chained_gemm"] = _e2e_test_shapes["attention"]
 _e2e_test_shapes["decode_attention"] = _e2e_test_shapes["attention"]
 _e2e_test_shapes["quantized_attention"] = [(1, 4096, 64, 64, 4096)]
@@ -75,6 +79,7 @@ _e2e_test_shapes["gqa_bshd_decode_attention"] = [
 
 test_names = [
     "attention",
+    "bhsd_attention",
     "chained_gemm",
     "decode_attention",
     "unaligned_attention",

--- a/tests/kernel/wave/common/shapes.py
+++ b/tests/kernel/wave/common/shapes.py
@@ -23,7 +23,6 @@ _e2e_test_shapes["attention"] = [
 ]
 _e2e_test_shapes["bhsd_attention"] = [
     (4, 32, 128, 128, 128, 128),
-    (8, 32, 128, 128, 64, 256),
 ]
 _e2e_test_shapes["chained_gemm"] = _e2e_test_shapes["attention"]
 _e2e_test_shapes["decode_attention"] = _e2e_test_shapes["attention"]


### PR DESCRIPTION
Adds batch_size field to AttentionShape to not have to flatten batch and num head dims for BHSD kernel.