### PR TITLE
[TKW] Silence expansion warning

### DIFF
--- a/iree/turbine/kernel/wave/expansion/expansion.py
+++ b/iree/turbine/kernel/wave/expansion/expansion.py
@@ -733,7 +733,7 @@ def fixup_reduction_nodes(
                 new_condition = value
                 break
         if new_condition is None:
-            logger.warning(
+            logger.info(
                 f"Condition was not expanded: {condition}. Using the original condition."
             )
             continue


### PR DESCRIPTION
Demote it from warning to info (which is not printed by default)