### PR TITLE
[BOO] Include tuning specs in pip package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,10 @@ setup(
     packages=packages,
     include_package_data=True,
     package_data={
-        "iree.turbine": ["ops/templates/*.mlir"],  # Include MLIR templates
+        "iree.turbine": [
+            "ops/templates/*.mlir",
+            "kernel/boo/conv_exports/tuning_specs.mlir",
+        ],  # Include MLIR templates
     },
     entry_points={
         "torch_dynamo_backends": [


### PR DESCRIPTION
Boo use was broken in pip install because the tuning spec file wasn't included. 