### PR TITLE
[runtime] Enable async for `CustomOp` eager execution

### DIFF
--- a/iree/turbine/runtime/__init__.py
+++ b/iree/turbine/runtime/__init__.py
@@ -5,5 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .device import *
+from .invoke import *
 from .launch import *
 from . import op_reg

--- a/iree/turbine/runtime/invoke.py
+++ b/iree/turbine/runtime/invoke.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import (
+    Any,
+    Callable,
+    Sequence,
+)
+
+from .device import Device
+
+from iree.runtime import (
+    VmContext,
+    VmFunction,
+    HalFence,
+    VmVariantList,
+)
+
+
+__all__ = [
+    "invoke_vm_function",
+]
+
+
+def invoke_vm_function(
+    device: Device,
+    is_async: bool,
+    vm_context: VmContext,
+    vm_function: VmFunction,
+    arg_list: VmVariantList,
+    ret_list: VmVariantList,
+    *,
+    timer: Callable[[], float] = (lambda: 0.0)
+):
+    """Invokes a vm function on a device, adding async fences to the arg_list if is_async.
+
+    No checks are made to ensure compatibility between the provided device and vm_function.
+    A timer function (float return) may be provided, and this function will return the invocation time.
+    """
+
+    if is_async:
+        external_timepoint = device.setup_iree_action()
+        wait_fence = HalFence.create_at(
+            device._main_timeline, device._main_timepoint - 1
+        )
+        signal_fence = HalFence.create_at(device._main_timeline, device._main_timepoint)
+
+        arg_list.push_ref(wait_fence)
+        arg_list.push_ref(signal_fence)
+
+    # Invoke.
+    start = timer()
+    vm_context.invoke(vm_function, arg_list, ret_list)
+
+    if is_async:
+        device.finalize_iree_action(external_timepoint)
+
+    return timer() - start

--- a/iree/turbine/runtime/op_reg/base.py
+++ b/iree/turbine/runtime/op_reg/base.py
@@ -184,6 +184,20 @@ class CustomOp(ABC):
         """
         ...
 
+    @property
+    def single_dispatch(self) -> bool:
+        """Indicates whether the CustomOp should be forced into a single dispatch using a util.func pipeline attribute.
+
+        It is recommended to only use this for more complicated ops which would not automatically get compiled into a single dispatch.
+        E.g. A fused conv + bias-add + relu custom op.
+
+        For eager contexts, this will apply the pipeline attribute to the main$async function.
+
+        For aot contexts, this currently does nothing, but could eventually attempt to apply an `util.inline.never` attribute,
+        in addition to the pipeline attribute, to the function being called by the InlineKernelBuilder.
+        """
+        return False
+
     @abstractmethod
     def select(self, sel: "KernelSelection"):
         """Performs kernel selection.


### PR DESCRIPTION
This PR adds async invocation for `CustomOp` eager execution by applying the pass `--torch-iree-func-conversion` to the `FreeFuncKernelBuilder.module_op` to generate a `main$async` function, and factoring out the async invocation from `Launchable.__call__` into a common file `runtime/invoke.py`. 

In addition, this PR allows manually specifying that a `CustomOp` should be compiled as a single dispatch for eager execution.

Both of these will be useful in transitioning the boo conv launchables into custom ops without losing any functionality.