### PR TITLE
Add support for additional type interop

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -50,6 +50,7 @@ __all__ = [
     "DeviceState",
 ]
 
+
 # TODO: move this down into iree as an extention to the
 #       driver api.
 class _HipSemaphoreInterop:
@@ -469,14 +470,15 @@ def _device_import_torch_tensor_cpu(device: Device, t: torch.Tensor) -> HalBuffe
     hal_device = device.hal_device
     element_type = dtype_to_element_type(t.dtype)
 
-    if (t.dtype == torch.bfloat16):
+    if t.dtype == torch.bfloat16:
         t = t.view(torch.int16)
 
-    if (t.dtype in {
+    if t.dtype in {
         torch.float8_e4m3fn,
         torch.float8_e4m3fnuz,
         torch.float8_e5m2,
-        torch.float8_e5m2fnuz}):
+        torch.float8_e5m2fnuz,
+    }:
         t = t.view(torch.int8)
 
     # TODO: In this case, we should be importing the raw buffer, but this is not

--- a/iree/turbine/support/conversions.py
+++ b/iree/turbine/support/conversions.py
@@ -131,6 +131,10 @@ DTYPE_TO_ELEMENT_TYPE: dict[torch.dtype, HalElementType] = {
     torch.quint8: HalElementType.OPAQUE_8,
     torch.complex64: HalElementType.COMPLEX_64,
     torch.complex128: HalElementType.COMPLEX_128,
+    torch.float8_e4m3fn: HalElementType.FLOAT_8_E4M3_FN,
+    torch.float8_e4m3fnuz: HalElementType.FLOAT_8_E4M3_FNUZ,
+    torch.float8_e5m2: HalElementType.FLOAT_8_E5M2,
+    torch.float8_e5m2fnuz: HalElementType.FLOAT_8_E5M2_FNUZ,
 }
 
 
@@ -153,6 +157,11 @@ TORCH_DTYPE_TO_NUMPY = {
     torch.bool: np.dtype("?"),
     torch.complex64: np.dtype("c8"),
     torch.complex128: np.dtype("c16"),
+    torch.bfloat16: np.dtype("i2"),
+    torch.float8_e4m3fn: np.dtype("i1"),
+    torch.float8_e4m3fnuz: np.dtype("i1"),
+    torch.float8_e5m2: np.dtype("i1"),
+    torch.float8_e5m2fnuz: np.dtype("i1"),
 }
 
 

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -160,9 +160,14 @@ class TorchCUDAInterop(unittest.TestCase):
 
     def testJitBF16(self):
         from iree.turbine.ops import _str_format_test_ops as test_ops
-        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0", dtype=torch.bfloat16)
+
+        t = torch.tensor(
+            [1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0", dtype=torch.bfloat16
+        )
         result = test_ops.test_add(t, t)
-        expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu", dtype=torch.bfloat16)
+        expected = torch.tensor(
+            [2.0, 4.0, 6.0, 8.0, 10.0], device="cpu", dtype=torch.bfloat16
+        )
         torch.testing.assert_close(result.cpu(), expected)
 
 
@@ -185,9 +190,14 @@ class TorchCPUInterop(unittest.TestCase):
 
     def testJitBF16(self):
         from iree.turbine.ops import _str_format_test_ops as test_ops
-        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0", dtype=torch.bfloat16)
+
+        t = torch.tensor(
+            [1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0", dtype=torch.bfloat16
+        )
         result = test_ops.test_add(t, t)
-        expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu", dtype=torch.bfloat16)
+        expected = torch.tensor(
+            [2.0, 4.0, 6.0, 8.0, 10.0], device="cpu", dtype=torch.bfloat16
+        )
         torch.testing.assert_close(result.cpu(), expected)
 
 

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -192,7 +192,7 @@ class TorchCPUInterop(unittest.TestCase):
         from iree.turbine.ops import _str_format_test_ops as test_ops
 
         t = torch.tensor(
-            [1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0", dtype=torch.bfloat16
+            [1.0, 2.0, 3.0, 4.0, 5.0], device="cpu", dtype=torch.bfloat16
         )
         result = test_ops.test_add(t, t)
         expected = torch.tensor(

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -158,6 +158,13 @@ class TorchCUDAInterop(unittest.TestCase):
         expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu")
         torch.testing.assert_close(result.cpu(), expected)
 
+    def testJitBF16(self):
+        from iree.turbine.ops import _str_format_test_ops as test_ops
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0", dtype=torch.bfloat16)
+        result = test_ops.test_add(t, t)
+        expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu", dtype=torch.bfloat16)
+        torch.testing.assert_close(result.cpu(), expected)
+
 
 class TorchCPUInterop(unittest.TestCase):
     def testJitStrFormat(self):
@@ -175,6 +182,13 @@ class TorchCPUInterop(unittest.TestCase):
         result = test_ops.test_add(t, t)
         expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu")
         torch.testing.assert_close(result, expected)
+
+    def testJitBF16(self):
+        from iree.turbine.ops import _str_format_test_ops as test_ops
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda:0", dtype=torch.bfloat16)
+        result = test_ops.test_add(t, t)
+        expected = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], device="cpu", dtype=torch.bfloat16)
+        torch.testing.assert_close(result.cpu(), expected)
 
 
 if __name__ == "__main__":

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -191,9 +191,7 @@ class TorchCPUInterop(unittest.TestCase):
     def testJitBF16(self):
         from iree.turbine.ops import _str_format_test_ops as test_ops
 
-        t = torch.tensor(
-            [1.0, 2.0, 3.0, 4.0, 5.0], device="cpu", dtype=torch.bfloat16
-        )
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cpu", dtype=torch.bfloat16)
         result = test_ops.test_add(t, t)
         expected = torch.tensor(
             [2.0, 4.0, 6.0, 8.0, 10.0], device="cpu", dtype=torch.bfloat16


### PR DESCRIPTION
Interop for BF16 / FP8 requires some munging to bypass numpy's lack of support. In these cases we bitcast the underlying tensor and use the integer equivalent bitwidths