### PR TITLE
[TKW] Avoid cache folder race conditions when running tests in parallel

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -101,11 +101,13 @@ jobs:
       - name: Run e2e tests on AMD GPU
         if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && (github.event_name == 'pull_request') && !cancelled()"
         run: |
+          rm -rf ~/.wave
           WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/wave/
 
       - name: Run expensive e2e tests on AMD GPU
         if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && (github.event_name != 'pull_request') && !cancelled()"
         run: |
+          rm -rf ~/.wave
           WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --run-expensive-tests --durations=100 ./tests/kernel/wave/
 
       - name: Run LIT tests

--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -101,13 +101,11 @@ jobs:
       - name: Run e2e tests on AMD GPU
         if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && (github.event_name == 'pull_request') && !cancelled()"
         run: |
-          rm -rf ~/.wave
           WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --durations=100 ./tests/kernel/wave/
 
       - name: Run expensive e2e tests on AMD GPU
         if: "(contains(toJSON(matrix.os), 'amdgpu') || contains(toJSON(matrix.os), 'mi300')) && (github.event_name != 'pull_request') && !cancelled()"
         run: |
-          rm -rf ~/.wave
           WAVE_CACHE_ON=0 pytest -n 4 --capture=tee-sys -vv --run-e2e --run-expensive-tests --durations=100 ./tests/kernel/wave/
 
       - name: Run LIT tests

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -42,6 +42,14 @@ def is_cache_enabled() -> bool:
     return bool(WAVE_CACHE_ON)
 
 
+def get_cache_base_dir() -> Path:
+    return CACHE_BASE_DIR
+
+
+def get_wave_runtime_dir() -> Path:
+    return WAVE_RUNTIME_DIR
+
+
 @dataclass
 class WaveCache:
     """

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -242,7 +242,7 @@ class WaveCacheManager(object):
         cur_module_path.write_text(module_str)
         kernel_sig_str = json.dumps([usage.name for usage in kernel_sig])
         cur_kernelsig_path.write_text(kernel_sig_str)
-        cur_hsaco_path = glob.glob(str(WAVE_RUNTIME_DIR / "*.hsaco"))
+        cur_hsaco_path = glob.glob(str(get_wave_runtime_dir() / "*.hsaco"))
         # Copy the hsaco file to the cache directory only if it exists.
         if cur_hsaco_path:
             cur_hsaco_path = cur_hsaco_path[0]

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -9,7 +9,7 @@ from .compile_options import WaveCompileOptions
 from .cache import (
     is_cache_enabled,
     get_cache_manager,
-    WAVE_RUNTIME_DIR,
+    get_wave_runtime_dir,
 )
 from .utils.compile_utils import compile_to_vmfb
 from .utils.run_utils import invoke_vmfb, _write_file
@@ -92,7 +92,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     # dumping of binaries and store in wave runtime directory. If we
     # are caching, this will be moved to the appropriate directory.
     if options.wave_runtime:
-        options.dump_binaries = str(WAVE_RUNTIME_DIR)
+        options.dump_binaries = str(get_wave_runtime_dir())
 
     # Recompile kernel from scratch if not found in cache.
     (

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -242,15 +242,16 @@ def invoke_with_wave_runtime(
     Invokes the kernel with the wave runtime.
     """
     import wave_runtime
-    from ..cache import WAVE_RUNTIME_DIR, CACHE_BASE_DIR
+    from ..cache import get_wave_runtime_dir, get_cache_base_dir
 
     # Get the path to the binary.
     if options.kernel_hash:
         binary = (
-            str(CACHE_BASE_DIR / options.kernel_hash / options.kernel_hash) + ".hsaco"
+            str(get_cache_base_dir() / options.kernel_hash / options.kernel_hash)
+            + ".hsaco"
         )
     else:
-        binary = glob.glob(str(WAVE_RUNTIME_DIR / "*.hsaco"))[0]
+        binary = glob.glob(str(get_wave_runtime_dir() / "*.hsaco"))[0]
 
     dynamic_dims = tuple(options.dynamic_symbols_map.values())
     # Update the grid size as this may vary depending

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -501,7 +501,7 @@ class LaunchableWave(Launchable):
             # If the kernel is being cached, then it will be referenced from the
             # cache directory. When kernels are not being cached, we remove them
             # to ensure that at any time there is only one hsaco file in this directory.
-            remove_files_with_extension(WAVE_RUNTIME_DIR, ".hsaco")
+            remove_files_with_extension(get_wave_runtime_dir(), ".hsaco")
 
         print_ir_after = options.print_ir_after
         print_ir_before = options.print_ir_before

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -21,7 +21,7 @@ from .._support.tracing import (
     KernelRegionGraph,
     Launchable,
 )
-from .cache import WAVE_RUNTIME_DIR
+from .cache import get_wave_runtime_dir
 from ..compiler.ir import Context, Module, Operation
 from .codegen import WaveEmitter
 from .constraints import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,9 @@ def _get_worker_id(config):
 
 
 def _set_default_device(config):
+    """
+    Distributes the tests over multiple GPUs.
+    """
     distribute = int(config.getoption("--gpu-distribute"))
     if distribute < 1:
         return
@@ -75,6 +78,9 @@ def _set_default_device(config):
 
 
 def _set_cache_dir(config):
+    """
+    Sets the unique cache directory for the current worker to avoid race conditions.
+    """
     worker_id = _get_worker_id(config)
     if worker_id is None:
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,8 +87,10 @@ def _set_cache_dir(config):
 
     import iree.turbine.kernel.wave.cache as cache
 
-    base = cache.CACHE_BASE_DIR
-    cache.CACHE_BASE_DIR = base / f"worker_{worker_id}"
+    base_cache_dir = cache.CACHE_BASE_DIR
+    cache.CACHE_BASE_DIR = base_cache_dir / f"worker_{worker_id}"
+    base_runtime_dir = cache.WAVE_RUNTIME_DIR
+    cache.WAVE_RUNTIME_DIR = base_runtime_dir / f"worker_{worker_id}"
 
 
 def _has_marker(item, marker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,13 +48,20 @@ def pytest_configure(config):
 
 
 def _get_worker_id(config):
+    """
+    Returns the worker id for the current worker if running with pytest-xdist.
+    None if pytest-xdist is not installed or not running in parallel.
+    """
+    # Extract the worker id using internal pytest APIs.
     if not hasattr(config, "workerinput"):
         return None
 
+    # workerid has format 'gw0', 'gw1', etc.
     worker_id = config.workerinput["workerid"]
     if not worker_id.startswith("gw"):
         return None
 
+    # skip the 'gw' prefix.
     return int(worker_id[2:])
 
 


### PR DESCRIPTION
Even if caching is disabled, we are using cache dir for the wave_runtime and hsaco files.

Assign each worker an unique dir to avoid race conditions.