### PR TITLE
[TKW] Paged Decode dynamic symbols

### DIFF
--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -410,8 +410,6 @@ def get_paged_decode_attention_kernels(
             B: shape.num_query_heads,
             N: shape.head_size_kv,
             K1: shape.head_size,
-            K2: shape.kv_lens,
-            S: shape.num_seqs,
             U: num_kv_splits,
         }
     else:
@@ -425,18 +423,23 @@ def get_paged_decode_attention_kernels(
             B: shape.num_query_heads,
             N: shape.head_size_kv,
             K1: shape.head_size,
-            K2: shape.kv_lens,
             BH: shape.num_kv_heads,
-            S: shape.num_seqs,
             U: num_kv_splits,
         }
     symbols_1 = dict(symbols_0)
     symbols_1[BLOCK_B] = PHASE_1_BLOCK_B
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
+    dynamic_symbols = [K2, S]
+    dynamic_symbols_map = {
+        K2: shape.kv_lens,
+        S: shape.num_seqs,
+    }
 
     return (
         phase_0,
         phase_1,
         symbols_0,
         symbols_1,
+        dynamic_symbols,
+        dynamic_symbols_map,
     )

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -208,11 +208,10 @@ def get_paged_decode_attention_kernels(
         outputs={S: i},
     )
 
-    K2_dim = k_shape[1]
     # Returns the key for the given token index.
     k_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // K2_dim, BH: j, K2: d0 % K2_dim, K1: l},
+        inputs={S: d0 // K2, BH: j, K2: d0 % K2, K1: l},
         outputs={S: i, BH: j, K2: k, K1: l},
         dynamic_val_mappings={K2: k},
     )
@@ -220,7 +219,7 @@ def get_paged_decode_attention_kernels(
     # Returns the value for the given token index.
     v_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // K2_dim, BH: j, N: k, K2: d0 % K2_dim},
+        inputs={S: d0 // K2, BH: j, N: k, K2: d0 % K2},
         outputs={S: i, BH: j, N: k, K2: l},
         dynamic_val_mappings={K2: l},
     )

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -48,6 +48,8 @@ def test_paged_flash_decoding():
         phase_1,
         hyperparams_0,
         hyperparams_1,
+        dynamic_symbols,
+        dynamic_symbols_map,
     ) = get_paged_decode_attention_kernels(
         shape, mfma_variant, num_kv_splits, k_shape, v_shape
     )
@@ -58,6 +60,8 @@ def test_paged_flash_decoding():
         run_bench=False,
         schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
         compile_to_mlir=True,
     )
     phase_0 = wave_compile(options, phase_0)
@@ -91,6 +95,8 @@ def test_paged_flash_decoding():
         run_bench=False,
         schedule=SchedulingType.NONE,
         use_scheduling_barriers=False,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
         compile_to_mlir=True,
     )
     phase_1 = wave_compile(options, phase_1)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -250,6 +250,8 @@ def testPagedFlashDecoding(
         phase_1,
         hyperparams_0,
         hyperparams_1,
+        dynamic_symbols,
+        dynamic_symbols_map,
     ) = get_paged_decode_attention_kernels(
         shape,
         mfma_variant,
@@ -282,6 +284,8 @@ def testPagedFlashDecoding(
         run_bench=run_bench,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=(
@@ -310,6 +314,8 @@ def testPagedFlashDecoding(
         run_bench=run_bench,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=(
@@ -436,6 +442,8 @@ def testPagedFlashDecodingMHA(
         phase_1,
         hyperparams_0,
         hyperparams_1,
+        dynamic_symbols,
+        dynamic_symbols_map,
     ) = get_paged_decode_attention_kernels(
         shape,
         mfma_variant,
@@ -469,6 +477,8 @@ def testPagedFlashDecodingMHA(
         run_bench=run_bench,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=(
@@ -497,6 +507,8 @@ def testPagedFlashDecodingMHA(
         run_bench=run_bench,
         schedule=enable_scheduling,
         use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
         benchmark_batch_size=10,
         benchmark_repetitions=3,
         benchmark_results_file=(


### PR DESCRIPTION
Make `kv_lens` and `num_seqs` args of the Paged Decode kernel dynamic, so they won't trigger the recompilation.