### PR TITLE
[TKW] Allow to bind symbols from the scalar arguments

### DIFF
--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -31,7 +31,7 @@ from ..lang.grid import Grid
 from ..lang.types import (
     Index,
 )
-from ..lang.wave_types import IndexMapping
+from ..lang.wave_types import IndexMapping, SymbolBind
 from ..ops.wave_ops import CustomOp
 
 from .regions import RegionGraph, SubgraphTracer
@@ -44,6 +44,8 @@ from ..ops.base import (
 
 from . import context
 from .dtype import DataType
+
+import inspect
 
 try:
     from typing import assert_type
@@ -61,12 +63,22 @@ TCallable = TypeVar("TCallable", bound=Callable)
 
 
 class KernelRegionGraph(RegionGraph):
+    func: Optional[Callable] = None
+
+    def __init__(
+        self,
+        location_capture_config: Optional[LocationCaptureConfig] = None,
+        func: Optional[Callable] = None,
+    ):
+        super().__init__(location_capture_config=location_capture_config)
+        self.func = func
+
     def new_subtracer(
         self,
         region_graph: "RegionGraph",
         parent: Optional["SubgraphTracer"] = None,
     ) -> "KernelTracer":
-        return KernelTracer(region_graph, parent=parent)
+        return KernelTracer(region_graph, parent=parent, func=self.func)
 
 
 ###############################################################################
@@ -99,6 +111,18 @@ class KernelBufferProxy(fx.Proxy):
 class KernelTracer(SubgraphTracer):
     """Custom Tracer for generating a trace of a kernel computation."""
 
+    arg_names: list[str] = []
+
+    def __init__(
+        self,
+        region_graph: RegionGraph,
+        parent: Optional["SubgraphTracer"] = None,
+        func: Optional[Callable] = None,
+    ):
+        super().__init__(region_graph, parent)
+        if func is not None:
+            self.arg_names = inspect.getfullargspec(func).args
+
     # Property to keep track of current number of arguments.
     current_arg_id = 0
 
@@ -110,6 +134,12 @@ class KernelTracer(SubgraphTracer):
             if isinstance(t, DataType) and node.op == "placeholder":
                 node.meta["arg_id"] = self.current_arg_id
                 node.meta["dtype"] = t
+                node.meta["symbolic_type"] = []
+                self.current_arg_id += 1
+            elif issubclass(t, SymbolBind) and node.op == "placeholder":
+                node.meta["arg_id"] = self.current_arg_id
+                node.meta["symbol_name"] = self.arg_names[self.current_arg_id]
+                node.meta["dtype"] = t.dtype
                 node.meta["symbolic_type"] = []
                 self.current_arg_id += 1
             elif isinstance(t, KernelBufferMeta):

--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -136,7 +136,10 @@ class KernelTracer(SubgraphTracer):
                 node.meta["dtype"] = t
                 node.meta["symbolic_type"] = []
                 self.current_arg_id += 1
-            elif issubclass(t, SymbolBind) and node.op == "placeholder":
+            elif issubclass(t, SymbolBind):
+                assert (
+                    node.op == "placeholder"
+                ), "SymbolBind must be a placeholder, got {node.op}"
                 node.meta["arg_id"] = self.current_arg_id
                 node.meta["symbol_name"] = self.arg_names[self.current_arg_id]
                 node.meta["dtype"] = t.dtype

--- a/iree/turbine/kernel/compiler/dispatch_codegen.py
+++ b/iree/turbine/kernel/compiler/dispatch_codegen.py
@@ -178,6 +178,9 @@ class StreamExecutable:
                         )
                     )
 
+            def is_scalar_symbol(binding: BindingDesc) -> bool:
+                return binding.symbol_type is not None
+
             # Define the export.
             with InsertionPoint.at_block_begin(self._exe_block):
                 index_type = IndexType.get()
@@ -187,7 +190,7 @@ class StreamExecutable:
                         [
                             index_type
                             for b in dynamic_dim_bindings
-                            + [b for b in scalar_bindings if b.symbol_type is not None]
+                            + [b for b in scalar_bindings if is_scalar_symbol(b)]
                         ]
                     )
                 )

--- a/iree/turbine/kernel/compiler/dispatch_codegen.py
+++ b/iree/turbine/kernel/compiler/dispatch_codegen.py
@@ -24,7 +24,6 @@ from .ir import (
     IndexType,
     InsertionPoint,
     IntegerAttr,
-    IntegerType,
     IrType,
     Location,
     StringAttr,

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -70,7 +70,7 @@ def to_index(v: Value) -> Value:
     if isinstance(t, IntegerType):
         return arith_d.index_cast(IndexType.get(), v)
 
-    assert False, f"Expected IndexType or IntegerType, got {v.type}"
+    assert False, f"Expected IndexType or IntegerType, got {t}"
 
 
 def isolated_test_call(

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -6,21 +6,24 @@ from .builder import (
 )
 
 from .ir import (
+    ArrayAttr,
     Block,
+    F32Type,
+    F64Type,
     FunctionType,
     IndexType,
     InsertionPoint,
-    IrType,
-    Location,
-    ArrayAttr,
-    SymbolRefAttr,
-    MemRefType,
-    RankedTensorType,
-    flow_d,
-    func_d,
-    F32Type,
     IntegerAttr,
     IntegerType,
+    IrType,
+    Location,
+    MemRefType,
+    RankedTensorType,
+    SymbolRefAttr,
+    Value,
+    arith_d,
+    flow_d,
+    func_d,
 )
 
 from .._support.indexing import IndexSymbol
@@ -35,7 +38,9 @@ def memref_to_tensor(memrefs: list[IrType]):
     tensors = []
     for m in memrefs:
         # append scalars as-it-is to tensors list
-        if isinstance(m, F32Type) or (isinstance(m, IntegerType) and m.is_signless):
+        if isinstance(m, (F32Type, F64Type, IndexType)) or (
+            isinstance(m, IntegerType) and m.is_signless
+        ):
             tensors.append(m)
             continue
         assert isinstance(m, MemRefType)
@@ -90,18 +95,40 @@ def isolated_test_call(
         func_op = func_d.FuncOp(func_name, ftype)
         captured_loc = capture_location(location_capture_config)
         actual_loc = captured_loc.to_mlir() if captured_loc else Location.unknown()
+        scalar_bindings = sig.scalar_bindings
         arg_locs = [
             (Location.name(b.name, actual_loc) if b.name is not None else actual_loc)
             for b in sig.kernel_buffer_bindings
-            + sig.scalar_bindings
+            + scalar_bindings
             + sig.dynamic_dim_bindings
         ]
         entry_block = func_op.add_entry_block(arg_locs)
-        offset = len(sig.kernel_buffer_bindings)
-        dynamic_argument_map = {
-            k: v for k, v in zip(dynamic_symbols, entry_block.arguments[offset:])
-        }
+        scalars_offset = len(sig.kernel_buffer_bindings)
+        scalars_count = len(scalar_bindings)
+        dynamic_offset = scalars_offset + scalars_count
+
+        def to_index(v: Value) -> Value:
+            t = v.type
+            if isinstance(t, IndexType):
+                return v
+
+            if isinstance(t, IntegerType):
+                return arith_d.index_cast(IndexType.get(), v)
+
+            assert False, f"Expected IndexType or IntegerType, got {v.type}"
+
         with InsertionPoint(entry_block):
+            arguments = entry_block.arguments
+            scalars_args = [
+                to_index(v)
+                for v, b in zip(
+                    arguments[scalars_offset:dynamic_offset], scalar_bindings
+                )
+                if b.symbol_type is not None
+            ]
+            dynamic_args = [to_index(v) for v in arguments[dynamic_offset:]]
+            dynamic_argument_map = {k: v for k, v in zip(dynamic_symbols, dynamic_args)}
+
             assert isinstance(entry_block, Block)
             # Create a flow.dispatch op to the kernel
             dispatch = SymbolRefAttr.get([exe.sym_name.value, entrypoint])
@@ -115,9 +142,10 @@ def isolated_test_call(
                     for out_idx in range(input_binding_count, buffer_binding_count)
                 ]
             )
+
             out = flow_d.DispatchOp(
                 output_tensors,
-                [dynamic_argument_map[dim] for dim in dynamic_symbols],
+                [dynamic_argument_map[dim] for dim in dynamic_symbols] + scalars_args,
                 entrypoints,
                 entry_block.arguments,
                 [dynamic_argument_map[dim] for dim in argument_dims],

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -62,6 +62,17 @@ def get_dynamic_dims(bindings: list[BindingDesc], dynamic_symbols: list[IndexSym
     return dynamic_dims
 
 
+def to_index(v: Value) -> Value:
+    t = v.type
+    if isinstance(t, IndexType):
+        return v
+
+    if isinstance(t, IntegerType):
+        return arith_d.index_cast(IndexType.get(), v)
+
+    assert False, f"Expected IndexType or IntegerType, got {v.type}"
+
+
 def isolated_test_call(
     mb: ModuleBuilder,
     exe: StreamExecutable,
@@ -106,16 +117,6 @@ def isolated_test_call(
         scalars_offset = len(sig.kernel_buffer_bindings)
         scalars_count = len(scalar_bindings)
         dynamic_offset = scalars_offset + scalars_count
-
-        def to_index(v: Value) -> Value:
-            t = v.type
-            if isinstance(t, IndexType):
-                return v
-
-            if isinstance(t, IntegerType):
-                return arith_d.index_cast(IndexType.get(), v)
-
-            assert False, f"Expected IndexType or IntegerType, got {v.type}"
 
         with InsertionPoint(entry_block):
             arguments = entry_block.arguments

--- a/iree/turbine/kernel/lang/__init__.py
+++ b/iree/turbine/kernel/lang/__init__.py
@@ -2,7 +2,7 @@ from .prims import *
 from .types import *
 from .kernel_buffer import *
 from .wave_types import *
-from .wave_types import Memory, Register, IndexMapping
+from .wave_types import Memory, Register, IndexMapping, SymbolBind
 from .grid import *
 
 # Include publics from the _support library.

--- a/iree/turbine/kernel/lang/wave_types.py
+++ b/iree/turbine/kernel/lang/wave_types.py
@@ -151,6 +151,21 @@ class Register(metaclass=KernelBufferMeta):
         )
 
 
+class SymbolBind:
+    """
+    Represents a binding between a symbol and a kernel argument.
+    """
+
+    dtype: DataType
+
+    def __class_getitem__(cls, dt: DataType) -> Type["SymbolBind"]:
+        class Subtype(cls):
+            dtype = dt
+
+        Subtype.__name__ = cls.__name__
+        return Subtype
+
+
 SymbolsMap: TypeAlias = dict[IndexSymbol, IndexExpr]
 
 

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -131,7 +131,9 @@ def has_scaled_indices(node: fx.Node):
     node_type = node.type
     if not node_type:
         return False
-    shape = node_type.symbolic_shape
+    shape = getattr(node_type, "symbolic_shape", None)
+    if shape is None:
+        return False
     # Skip for cases where it is a single symbol or number.
     if all(not is_scaled_dim(dim) for dim in shape):
         return False

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -46,7 +46,7 @@ from ...compiler.ir import (
 
 from ..utils.general_utils import get_hardware_constraint
 from ...compiler.builder import IRProxyValue
-from ...compiler.kernel_codegen import BoundKernelSignature
+from ...compiler.kernel_codegen import BoundKernelSignature, BindingType
 from ..._support.tracing import CapturedTrace
 from ...compiler.base import CodegenError, NDEBUG
 
@@ -85,10 +85,12 @@ class WaveEmitter:
         ]
         self.induction_vars: dict[IndexSymbol, Value] = {}
         self.dynamic_dims: dict[IndexSymbol, Value] = {}
-        symbol_iterator = iter(self.dynamic_symbols)
-        for arg in self.root_sig.entry_block.arguments:
-            if arg.type == IndexType.get():
-                self.dynamic_dims[next(symbol_iterator)] = arg
+
+        for bind, arg in zip(
+            self.root_sig.sig.bindings, self.root_sig.entry_block.arguments
+        ):
+            if bind.binding_type == BindingType.SYMBOL_VALUE:
+                self.dynamic_dims[bind.symbol_type] = arg
 
     def emit(self, graph: Optional[fx.Graph] = None):
         with self.ip, Location.unknown():

--- a/iree/turbine/kernel/wave/runtime/runtime.cpp
+++ b/iree/turbine/kernel/wave/runtime/runtime.cpp
@@ -62,22 +62,22 @@ static int launch(const KernelLaunchInfo &info, const Int64Vector &tensors,
     uint64_t *ptr = (uint64_t *)kernelArguments;
     for (auto val : tensors) *ptr++ = val;
 
-    uint32_t *ptr2 = (uint32_t *)ptr;
-    for (auto dim : dynamicDims) {
-        *ptr2++ = static_cast<uint32_t>(dim);
-        *ptr2++ = static_cast<uint32_t>(dim >> 32);
-    }
-
-    uint32_t* ptr3 = ptr2;
+    uint32_t* ptr2 = (uint32_t *)ptr;
     // ToDo: we would like to use bit_cast in the follow-up PR.
     for (auto arg : scalarArgs){
         if (nb::isinstance<nb::int_>(arg)){
-            *ptr3++ = static_cast<uint32_t>(nb::cast<uint32_t>(arg));
+            *ptr2++ = static_cast<uint32_t>(nb::cast<uint32_t>(arg));
         }
         else if (nb::isinstance<nb::float_>(scalarArgs[0])){
             float val = nb::cast<float>(arg);
-            std::memcpy(ptr3++, &val, sizeof(float));
+            std::memcpy(ptr2++, &val, sizeof(float));
         }
+    }
+
+    uint32_t *ptr3 = (uint32_t *)ptr2;
+    for (auto dim : dynamicDims) {
+        *ptr3++ = static_cast<uint32_t>(dim);
+        *ptr3++ = static_cast<uint32_t>(dim >> 32);
     }
 
     void *hipLaunchParams[] = {

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -412,10 +412,21 @@ def get_extend_attention_kernel(
         qo_indptr: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
         kv_indptr: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
         kv_indices: tkl.Memory[N_KV, GLOBAL_ADDRESS_SPACE, tkl.i32, kv_indices_layout],
+        MAX_EXTEND_SEQ_LEN: tkl.SymbolBind[tkl.i32],
         c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
     ):
         extend_attention_core(
-            q, k, v, k_cache, v_cache, qo_indptr, kv_indptr, kv_indices, None, None, c
+            q,
+            k,
+            v,
+            k_cache,
+            v_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            None,
+            None,
+            c,
         )
 
     @tkw.wave(constraints)
@@ -436,6 +447,7 @@ def get_extend_attention_kernel(
             MASK_LEN, GLOBAL_ADDRESS_SPACE, tkl.i8, num_seqs_layout
         ],
         mask_offsets: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
+        MAX_EXTEND_SEQ_LEN: tkl.SymbolBind[tkl.i32],
         c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
     ):
         extend_attention_core(
@@ -468,12 +480,11 @@ def get_extend_attention_kernel(
         D_Q: shape.head_size,
     }
 
-    dynamic_symbols = [N_Q, N_KV, S, MAX_EXTEND_SEQ_LEN]
+    dynamic_symbols = [N_Q, N_KV, S]
     dynamic_symbols_map = {
         N_Q: q_shape[0],
         N_KV: k_shape[0],
         S: shape.num_seqs,
-        MAX_EXTEND_SEQ_LEN: shape.max_seq_len,
     }
 
     if use_custom_mask:

--- a/iree/turbine/kernel/wave/templates/extend_attention_rpe.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention_rpe.py
@@ -193,6 +193,7 @@ def get_extend_attention_rpe_kernel(
         kv_indptr: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32, num_seqs_layout],
         kv_indices: tkl.Memory[N_KV, GLOBAL_ADDRESS_SPACE, tkl.i32, kv_indices_layout],
         rpe: tkl.Memory[N_KV, GLOBAL_ADDRESS_SPACE, tkl.f32, rpe_layout],
+        MAX_EXTEND_SEQ_LEN: tkl.SymbolBind[tkl.i32],
         c: tkl.Memory[N_Q, H, D_KV, GLOBAL_ADDRESS_SPACE, wave_output_dtype, o_layout],
     ):
         c_reg = tkl.Register[H, D_KV, N_Q, tkl.f32](0.0)
@@ -366,12 +367,11 @@ def get_extend_attention_rpe_kernel(
         D_Q: shape.head_size,
     }
 
-    dynamic_symbols = [N_Q, N_KV, S, MAX_EXTEND_SEQ_LEN]
+    dynamic_symbols = [N_Q, N_KV, S]
     dynamic_symbols_map = {
         N_Q: q_shape[0],
         N_KV: k_shape[0],
         S: shape.num_seqs,
-        MAX_EXTEND_SEQ_LEN: shape.max_seq_len,
     }
 
     return extend_attention_rpe, hyperparams, dynamic_symbols, dynamic_symbols_map

--- a/iree/turbine/kernel/wave/utils/graph_utils.py
+++ b/iree/turbine/kernel/wave/utils/graph_utils.py
@@ -59,6 +59,11 @@ def DCE(trace: CapturedTrace):
         if custom.users or custom.has_side_effects or is_global_write(node):
             return False
 
+        if isinstance(custom, Placeholder) and custom.graph == trace.get_root_graph():
+            # Do not remove root placeholders as they correspond to kernel
+            # arguments and removind them will change the kernel signature.
+            return False
+
         if has_nested_writes(node):
             return False
 

--- a/iree/turbine/kernel/wave/utils/graph_utils.py
+++ b/iree/turbine/kernel/wave/utils/graph_utils.py
@@ -61,7 +61,7 @@ def DCE(trace: CapturedTrace):
 
         if isinstance(custom, Placeholder) and custom.graph == trace.get_root_graph():
             # Do not remove root placeholders as they correspond to kernel
-            # arguments and removind them will change the kernel signature.
+            # arguments and removing them will change the kernel signature.
             return False
 
         if has_nested_writes(node):

--- a/tests/kernel/wave/attention/extend_attention_test.py
+++ b/tests/kernel/wave/attention/extend_attention_test.py
@@ -439,6 +439,7 @@ def testExtendAttention(
             kv_indices,
             custom_mask,
             mask_offsets,
+            max_len_extend,
             output,
         )
     else:
@@ -451,6 +452,7 @@ def testExtendAttention(
             qo_indptr,
             kv_indptr,
             kv_indices,
+            max_len_extend,
             output,
         )
 
@@ -589,6 +591,7 @@ def testExtendRpeAttention(
         kv_indptr,
         kv_indices,
         rpe_bias,
+        max_len_extend,
         output,
     )
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1633,7 +1633,10 @@ def test_cast(shape, request):
     ],
     ids=["i32", "f32"],
 )
-def test_scalar_codegen(shape, tkl_dtype, torch_dtype, arg_vals, request):
+@param_bool("use_wave_runtime", "wr", [False, True])
+def test_scalar_codegen(
+    shape, tkl_dtype, torch_dtype, arg_vals, request, use_wave_runtime
+):
     run_bench = request.config.getoption("--runperf")
     M = tkl.sym.M
     N = tkl.sym.N
@@ -1683,12 +1686,19 @@ def test_scalar_codegen(shape, tkl_dtype, torch_dtype, arg_vals, request):
         },
         canonicalize=True,
         run_bench=run_bench,
-        wave_runtime=True,
+        wave_runtime=use_wave_runtime,
     )
+    options = set_default_run_config(options)
     test = wave_compile(options, test)
     test(a, scalar_c, scalar_d, b)
 
-    assert torch.all(b == arg_vals[3]).item()
+    expected_val = torch.full_like(b, arg_vals[3])
+    if tkl.f32 == tkl_dtype and not use_wave_runtime:
+        # TODO: iree runtime doesn't work with f32.
+        with pytest.raises(Exception):
+            assert_close(b, expected_val)
+    else:
+        assert_close(b, expected_val)
 
 
 #  This kernel copies of data from a into b if tid.x < threshold.


### PR DESCRIPTION
I'm planning to retire `dynamic_symbols_map` eventually and extract symbol values directly from the input tensor dimensions. One exception is `extend_attention` which have `MAX_EXTEND_SEQ_LEN` symbol which does not correspond to any input tensor dimension.

As we now support scalar codegen, instead of using `dynamic_symbols_map` we now can just pass `MAX_EXTEND_SEQ_LEN` directly as kernel argument.

Extend attention is using `MAX_EXTEND_SEQ_LEN` for grid dimension calculation so normal scalar + `set_symbol` won't work. Instead, introduce `SymbolBind` annotation, which works exactly like scalar arg, but also immediately binds value to the corresponding symbol.

Most of the codegen changes are to propagate scalar args to the dispatch dims and to generally support scalar args in iree runtime path.