### PR TITLE
[Wave] Introduce softsign kernel to replace tanh_approx

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -149,6 +149,15 @@ def abs(src: "Register") -> "Register":
     ...
 
 
+def softsign(
+    src: "Register",
+    logit_cap: float = 30.0,
+    apply_scaling: bool = False,
+    head_dim: int = None,
+) -> "Register":
+    ...
+
+
 def tanh_approx(src: "Register") -> "Register":
     ...
 
@@ -894,6 +903,23 @@ class UnaryPyOp(CustomOp, ABC):
     @property
     def py_operator(self) -> str:
         return self.tkw_op_name
+
+    def infer_type(self):
+        src_type = get_custom(self.arg).type
+        self.type = src_type
+
+
+@define_interface_op("softsign")
+@dataclass
+class SoftsignOp(CustomOp, ABC):
+    arg: fx.Node
+    logit_cap: float = 30.0
+    apply_scaling: bool = False
+    head_dim: int = None
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        return get_custom(self.arg).indexing_dims
 
     def infer_type(self):
         src_type = get_custom(self.arg).type

--- a/iree/turbine/kernel/wave/templates/extend_attention.py
+++ b/iree/turbine/kernel/wave/templates/extend_attention.py
@@ -280,6 +280,13 @@ def get_extend_attention_kernel(
             if logit_cap > 0:
                 logit_cap_reg_inv = tkw.reciprocal(logit_cap_reg)
                 x_j = logit_cap_reg * tkw.tanh_approx(x_j * logit_cap_reg_inv)
+                # We could use tkw.softsign to provide ~10% performance improvement, but this will compromise accuracy.
+                # x_j = logit_cap_reg * tkw.softsign(
+                #     x_j * logit_cap_reg_inv,
+                #     logit_cap=30.0,
+                #     apply_scaling=True,
+                #     head_dim=128,
+                # )
             n_kv_index = tkw.self_index(N_KV, tkl.i32)
             mask = tkw.apply_expr(n_kv_index, lambda x: x < N_KV)
             mask = tkw.broadcast(mask, target_shape=[N_Q, N_KV])
@@ -343,6 +350,13 @@ def get_extend_attention_kernel(
             if logit_cap > 0:
                 logit_cap_reg_inv = tkw.reciprocal(logit_cap_reg)
                 x_j = logit_cap_reg * tkw.tanh_approx(x_j * logit_cap_reg_inv)
+                # We could use tkw.softsign to provide ~10% performance improvement, but this will compromise accuracy.
+                # x_j = logit_cap_reg * tkw.softsign(
+                #     x_j * logit_cap_reg_inv,
+                #     logit_cap=30.0,
+                #     apply_scaling=True,
+                #     head_dim=128,
+                # )
             n_kv_index = tkw.self_index(N_KV, tkl.i32)
             mask = tkw.apply_expr(n_kv_index, lambda x: x < N_KV)
             mask = tkw.broadcast(mask, target_shape=[N_Q, N_KV])


### PR DESCRIPTION
Add a new `softsign` kernel variant that replaces the previous `tanh_approx` implementation. Benchmarks show a 10~15% speedup over `tanh_approx`, but with a modest accuracy drop (e.g. Grok performance falls from ~83% to ~79%). This commit provides the softsign implementation alongside existing approximations for users to choose the appropriate tradeoff.