### PR TITLE
[Wave] Add install requirement for mermaid diagrams

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx==8.1.3
 sphinx-autobuild==2024.10.3
 sphinx-rtd-theme==3.0.2
+sphinxcontrib-mermaid==1.0.0
 myst-parser==4.0.0
 shibuya


### PR DESCRIPTION
This PR adds imports for drawing mermaid diagrams
in the sphinx documentation pages.