### PR TITLE
[Wave] Generalize Barriers to work across iterations

### DIFF
--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -145,14 +145,9 @@ class CapturedTrace:
         self.region_graph = region_graph
         self.root_graph = root_graph
         self.region_graph.subgraphs[root_graph].subgraphs = {}
-        # Allow graphs to access each other.
-        for name, graph in self.region_graph.subgraphs.items():
-            if not hasattr(graph, "subgraphs"):
-                graph.subgraphs = {}
-            # For each graph, add all other graphs as potential subgraphs.
-            for subname, subgraph in self.region_graph.subgraphs.items():
-                if subname != name:
-                    graph.subgraphs[subname] = subgraph
+        for name, subgraph in self.region_graph.subgraphs.items():
+            if name != root_graph:
+                self.region_graph.subgraphs[root_graph].subgraphs[name] = subgraph
 
     def get_subgraph(self, name: str) -> fx.Graph:
         return self.region_graph.subgraphs[name]

--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -158,8 +158,6 @@ class CapturedTrace:
         return self.region_graph.subgraphs[name]
 
     def add_subgraph(self, name: str, graph: fx.Graph):
-        for _, subgraph in self.region_graph.subgraphs.items():
-            subgraph.subgraphs[name] = graph
         self.region_graph.subgraphs[name] = graph
 
     def get_root_graph(self) -> fx.Graph:

--- a/iree/turbine/kernel/wave/barriers.py
+++ b/iree/turbine/kernel/wave/barriers.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .utils.graph_utils import is_reduction_subgraph
+from .utils.graph_utils import is_reduction_subgraph, is_barrier_between
 from .._support.tracing import CapturedTrace
 from ..ops.wave_ops import get_custom, Read, SharedMemoryBarrier, Write, NestedRegionOp
 from ..lang.global_symbols import SHARED_ADDRESS_SPACE
@@ -16,6 +16,7 @@ def add_shared_memory_barriers(
     trace: CapturedTrace,
     graph: Optional[fx.Graph] = None,
     last_node: Optional[fx.Node] = None,
+    check_cycle: Optional[bool] = False,
 ) -> fx.Node:
     """
     Adds shared memory barriers to the graph. The barriers are inserted
@@ -38,7 +39,9 @@ def add_shared_memory_barriers(
             if last_node is None:
                 last_node = custom
                 continue
-            if type(custom) != type(last_node):
+            if type(custom) != type(last_node) and not is_barrier_between(
+                last_node.fx_node, custom.fx_node
+            ):
                 # Synchronize after the write to shared memory before we read from it.
                 with graph.inserting_before(node):
                     SharedMemoryBarrier().add_to_graph(graph)
@@ -49,10 +52,9 @@ def add_shared_memory_barriers(
             )
 
     # Synchronize before the write to shared memory to avoid stepping over
-    # reads in the previous iteration of a loop.
-    if is_reduction_subgraph(graph) and last_node:
-        # Insert barrier at start of block, if load from shared memory exist.
-        with graph.inserting_after(graph._root):
-            SharedMemoryBarrier().add_to_graph(graph)
+    # shared reads in the previous iteration of a loop.
+    if is_reduction_subgraph(graph) and last_node and not check_cycle:
+        # Add barriers between ops from different iterations in the same loop.
+        add_shared_memory_barriers(trace, graph, last_node, check_cycle=True)
 
     return last_node

--- a/iree/turbine/kernel/wave/barriers.py
+++ b/iree/turbine/kernel/wave/barriers.py
@@ -16,7 +16,7 @@ def add_shared_memory_barriers(
     trace: CapturedTrace,
     graph: Optional[fx.Graph] = None,
     last_node: Optional[fx.Node] = None,
-    check_cycle: Optional[bool] = False,
+    checking_next_iter: Optional[bool] = False,
 ) -> fx.Node:
     """
     Adds shared memory barriers to the graph. The barriers are inserted
@@ -53,8 +53,8 @@ def add_shared_memory_barriers(
 
     # Synchronize before the write to shared memory to avoid stepping over
     # shared reads in the previous iteration of a loop.
-    if is_reduction_subgraph(graph) and last_node and not check_cycle:
+    if is_reduction_subgraph(graph) and last_node and not checking_next_iter:
         # Add barriers between ops from different iterations in the same loop.
-        add_shared_memory_barriers(trace, graph, last_node, check_cycle=True)
+        add_shared_memory_barriers(trace, graph, last_node, checking_next_iter=True)
 
     return last_node

--- a/iree/turbine/kernel/wave/decompose_reduce_ops.py
+++ b/iree/turbine/kernel/wave/decompose_reduce_ops.py
@@ -264,7 +264,9 @@ def emit_interwave_reduction(
         ),
         graph,
     )
+    execute_on_lane0_graph.parent_op = execute_on_lane0
     trace.add_subgraph(subgraph_name, execute_on_lane0_graph)
+    trace.get_root_graph().subgraphs[subgraph_name] = execute_on_lane0_graph
 
     # Read shared_memory[:num_waves] and locally reduce.
     # write_dependency on both execute_on_lane0 and write to prevent DCE.

--- a/iree/turbine/kernel/wave/scheduling/loop_reconstruction.py
+++ b/iree/turbine/kernel/wave/scheduling/loop_reconstruction.py
@@ -644,6 +644,7 @@ def construct_pipelined_loop(
         visualize,
         use_scheduling_barriers,
     )
+    pipelined_reduction_graph.parent_op = graph.parent_op
     trace.add_subgraph(
         get_custom(pipelined_reduction).subgraph_name, pipelined_reduction_graph
     )

--- a/iree/turbine/kernel/wave/utils/graph_utils.py
+++ b/iree/turbine/kernel/wave/utils/graph_utils.py
@@ -20,6 +20,7 @@ from ...ops.wave_ops import (
     Conditional,
     MMA,
     IterArg,
+    SharedMemoryBarrier,
 )
 from ..._support.indexing import IndexSymbol
 from typing import Callable, Sequence
@@ -368,15 +369,12 @@ def is_barrier_between_same_graph(src: fx.Node, dst: fx.Node) -> bool:
     Checks if there is a barrier between the source and destination nodes,
     assuming that they are in the same graph.
     """
-    prev_node, next_node = src.prev, dst.next
-    found_src, found_dst = prev_node == src, next_node == dst
-    while prev_node.prev.op != "root" and not found_src:
-        prev_node, found_src = prev_node.prev, prev_node == src
-    if not found_src:
-        return False
-    while next_node.next.op != "root" and not found_dst:
-        next_node, found_dst = next_node.next, next_node == dst
-    return found_dst
+    next_node = src.next
+    while next_node != dst and next_node.next.op != "root":
+        if isinstance(get_custom(next_node), SharedMemoryBarrier):
+            return True
+        next_node = next_node.next
+    return False
 
 
 def is_barrier_between(src: fx.Node, dst: fx.Node) -> bool:
@@ -384,7 +382,22 @@ def is_barrier_between(src: fx.Node, dst: fx.Node) -> bool:
     Checks if there is a barrier between the source and destination nodes.
     """
     if src.graph == dst.graph:
-        return is_barrier_between_same_graph(src, dst)
+        # The following cases are handled when src and dst are in same graph:
+        # 1. src and dst is on the same iteration step and src < dst (topographic).
+        # 2. src and dst are on different iteration step and src > dst (topographic).
+
+        # Case 1:
+        if dst >= src:
+            return is_barrier_between_same_graph(src, dst)
+
+        # Case 2:
+        if dst < src:
+            # Check between src and end of loop.
+            if is_barrier_between_same_graph(src, list(src.graph.nodes)[-1]):
+                return True
+            # If cannot find between src to end of loop,
+            # then, we check beginning of loop to dst.
+            return is_barrier_between_same_graph(list(dst.graph.nodes)[0], dst)
     else:
         # The following cases are handled when src and dst are in different graphs:
         # 1. src and dst graphs at the same nested level.

--- a/iree/turbine/kernel/wave/utils/graph_utils.py
+++ b/iree/turbine/kernel/wave/utils/graph_utils.py
@@ -46,7 +46,7 @@ def DCE(trace: CapturedTrace):
         if not isinstance(custom, NestedRegionOp):
             return False
 
-        subgraph = custom.graph.subgraphs[custom.subgraph_name]
+        subgraph = custom.get_root_graph().subgraphs[custom.subgraph_name]
         for node in subgraph.nodes:
             if is_global_write(node) or has_nested_writes(node):
                 return True
@@ -180,7 +180,7 @@ def get_users(
             if node == custom.condition:
                 users.append(user)
             else:
-                subgraph = custom.graph.subgraphs[custom.subgraph_name]
+                subgraph = custom.get_root_graph().subgraphs[custom.subgraph_name]
                 var = custom.get_captured_fx_node(subgraph, node)
                 assert var is not None, "Invalid captured var"
                 for u in var.users:
@@ -225,7 +225,9 @@ def get_inputs(
             reduction, Iterate
         ), f"GetResult must be using a Reduction, but\n{custom}\nis using\n{reduction}"
         # Map get result to output
-        reduction_subgraph = reduction.graph.subgraphs[reduction.subgraph_name]
+        reduction_subgraph = reduction.get_root_graph().subgraphs[
+            reduction.subgraph_name
+        ]
         if len(reduction.init_args) == 1:
             outputs = reduction.outputs(reduction_subgraph)
             if isinstance(outputs, Sequence):

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -80,7 +80,6 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-2:           vector.load
     # CHECK:                   %[[COUNT2:.*]] = affine.apply #[[map]]()[%[[COUNT1]]]
     # CHECK:                   scf.for %{{.*}} = %[[C0]] to %[[COUNT2]] step %[[C1]]
-    # CHECK:                        amdgpu.lds_barrier
     # 1 masked load block table, 1 for k_cache, and 1 for v_cache.
     # CHECK-COUNT-3:                vector.maskedload
     # CHECK:                        amdgpu.lds_barrier

--- a/lit_tests/kernel/wave/barriers.py
+++ b/lit_tests/kernel/wave/barriers.py
@@ -236,6 +236,8 @@ def test_gemm():
         # CHECK-NEXT: %read_M:0_N:0_K:1
         # CHECK-NEXT: %read_M:1_N:0_K:0
         # CHECK-NEXT: %read_M:1_N:0_K:1
+        # Barrier is from read_shared of previous iter.
+        # CHECK-NEXT: %shared_memory_barrier
         # CHECK-NEXT: %write_shared_M:0_N:0_K:0
         # CHECK-NEXT: %write_shared_M:0_N:0_K:1
         # CHECK-NEXT: %write_shared_M:1_N:0_K:0

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -113,8 +113,8 @@ def test_gemm():
     # CHECK:          func.func @gemm
     # CHECK-COUNT-1:    memref.alloc()
     # CHECK:            scf.for
-    # CHECK:              amdgpu.lds_barrier
     # CHECK:              vector.load
+    # CHECK:              amdgpu.lds_barrier
     # CHECK:              vector.store
     # CHECK:              vector.load
     # CHECK:              vector.store
@@ -408,8 +408,8 @@ def test_batched_gemm():
     # CHECK:          func.func @batched_gemm
     # CHECK-COUNT-1:    memref.alloc()
     # CHECK:            scf.for
-    # CHECK:              amdgpu.lds_barrier
     # CHECK:              vector.load
+    # CHECK:              amdgpu.lds_barrier
     # CHECK:              vector.store
     # CHECK:              vector.load
     # CHECK:              vector.store

--- a/lit_tests/kernel/wave/iteration.py
+++ b/lit_tests/kernel/wave/iteration.py
@@ -126,10 +126,9 @@ def test_iteration():
     # CHECK-DAG:            %[[C1:.*]] = arith.constant 1 : index
     # CHECK-COUNT-1:        memref.alloc
     # CHECK:                scf.for %[[ARG3:.*]] = %[[C0]] to %[[C10]] step %[[C1]] {
-    # CHECK:                    amdgpu.lds_barrier
     # CHECK:                    scf.for %arg4 = %[[C0]] to %[[C4]] step %[[C1]]
-    # CHECK:                        amdgpu.lds_barrier
     # CHECK-COUNT-1:                vector.load
+    # CHECK:                        amdgpu.lds_barrier
     # CHECK-COUNT-1:                vector.store
     # CHECK-COUNT-1:                vector.load
     # CHECK-COUNT-1:                vector.store
@@ -219,10 +218,9 @@ def test_iteration_with_condition():
     # CHECK:                   scf.condition(%[[COND]]) %[[ARG]] : index
     # CHECK:                } do {
     # CHECK:                 ^bb0(%[[ARG:.*]]: index):
-    # CHECK:                    amdgpu.lds_barrier
     # CHECK:                    %[[ARG4:.*]] = scf.for %[[ARG5:.*]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[ARG6:.*]] = %[[CST:.*]]) -> (vector<4xf32>) {
-    # CHECK:                        amdgpu.lds_barrier
     # CHECK-COUNT-1:                vector.load
+    # CHECK:                        amdgpu.lds_barrier
     # CHECK-COUNT-1:                vector.store
     # CHECK-COUNT-1:                vector.load
     # CHECK-COUNT-1:                vector.store
@@ -323,10 +321,9 @@ def test_iteration_with_condition_and_init_value():
     # CHECK:                    scf.condition(%[[COND]]) %[[ACC]], %[[B]] : vector<4xf32>, index
     # CHECK:                } do {
     # CHECK:                ^bb0(%[[ACC:.*]]: vector<4xf32>, %[[B:.*]]: index):
-    # CHECK:                    amdgpu.lds_barrier
     # CHECK:                    %[[FOR:.*]] = scf.for %[[ARG7:.*]] = %[[C0]] to %[[C4]] step %[[C1]] iter_args(%[[ARG8:.*]] = %[[CST_0]]) -> (vector<4xf32>) {
-    # CHECK:                        amdgpu.lds_barrier
     # CHECK-COUNT-1:                vector.load
+    # CHECK:                        amdgpu.lds_barrier
     # CHECK-COUNT-1:                vector.store
     # CHECK-COUNT-1:                vector.load
     # CHECK-COUNT-1:                vector.store

--- a/lit_tests/kernel/wave/minimize_global_loads.py
+++ b/lit_tests/kernel/wave/minimize_global_loads.py
@@ -171,8 +171,7 @@ def test_gemm():
         # CHECK-SAME: index={M: $WG0*BLOCK_M + 4*floor((Mod($T0, 64))/16) + 16 : 4 : 16, N: $WG1*BLOCK_N + BLOCK_N/2 + Mod($T0, 16) + 16 : 1 : 1})
 
         # iterate subgraph:
-        # CHECK: %shared_memory_barrier_1
-        # CHECK-NEXT: %b
+        # CHECK:      %b
         # CHECK-NEXT: %a
         # CHECK: %acc_M:0_N:0_K:0
         # CHECK-NEXT: %acc_M:0_N:1_K:0
@@ -180,6 +179,7 @@ def test_gemm():
         # CHECK-NEXT: %acc_M:1_N:1_K:0
         # CHECK-NEXT: %read_37
         # CHECK-SAME: (%a, 8, None, (), None)
+        # CHECK: %shared_memory_barrier_1
         # CHECK-NEXT: %write_18
         # CHECK-SAME: (%read_37, %allocate, 8, None, ())
         # CHECK-NEXT: %read_38
@@ -230,7 +230,6 @@ def test_gemm():
 
         # iterate subgraph (custom format):
         # CHECK: Custom format:
-        # CHECK-NEXT: shared_memory_barrier()
         # CHECK-NEXT: placeholder(_name=b, _type=Memory[N, K].of(f16))
         # CHECK-NEXT: placeholder(_name=a
         # CHECK-NEXT: placeholder(_name=acc_M:0_N:0_K:0
@@ -239,6 +238,7 @@ def test_gemm():
         # CHECK-NEXT: placeholder(_name=acc_M:1_N:1_K:0
         # CHECK-NEXT: read(memory=a, elements_per_thread=8,
         # CHECK-SAME: index={M: $WG0*BLOCK_M + Mod(16*$T1 + 32*$T2 + floor($T0/8), 64) : 1 : 1, K: ARGK*BLOCK_K + 8*(Mod($T0, 8)) : 8 : 1})
+        # CHECK-NEXT: shared_memory_barrier()
         # CHECK-NEXT: write(register_=read_37, memory=allocate, elements_per_thread=8,
         # CHECK-SAME: index={M: Mod(16*$T1 + 32*$T2 + floor($T0/8), 64) : 1 : 1, K: 8*(Mod($T0, 8)) : 8 : 1})
         # CHECK-NEXT: read(memory=a, elements_per_thread=8,


### PR DESCRIPTION
This PR has two main purpose.

First and most importantly, it teaches our compiler to only insert shared memory barriers when there is truly no barriers in between ops. This was assumed before but with the soon-coming PR of ping-pong where we re-order and want barriers to be precisely inserted, this PR help handles those case and to not accidentally insert too many barriers when not needed.

Secondly, and complimentarily, this PR teaches compiler to insert barrier between ops from different iterations. Most commonly, shared_read at time=t, and shared_write at time=t+1. This allows us to also remove the hardcoded insertion of barrier at the start of every Iterate subgraph. For pingpong, this will allow the PingPong pass to manually insert barriers for next iteration, and this pass can analyze properly to not introduce redundant barriers.

To achieve those two goals we set above, below are listed the changes in code and their motivation:

- Fix bugs in decompose_reduce_ops where subgraph of Conditional is not properly registered to subgraphs and parent_op. Changes can be seen in `tracing.py` and `decompose_reduce_ops.py`

- Fix bug in pipelined_reduction where minimize_alloc cannot handle pipelined_reduce because it did not have a proper parent_op. Previously we have a workaround in tracing.py which is now removed. Changes can be seen in loop_reconstruction.py and tracing.py.

- Generalize insertion of barrier at top of Iterate into something that checks if barrier is required between ops from different iterations. This is done by adding support in `is_barrier_between` for case where the src do not dominate dst. We handle this by doing a check from src to end of loop, and then from start of loop to dst. We also updated implementation of `is_barrier_between_same_graph` since it was not handling these cases above properly.

-  We also made changes into `barriers.py` to do one more round of `add_shared_memory_barriers`, after the first round to mimic the next step of iteration, and see if there are any inter-iteration dependencies. This naturally removes the hardcoded version of inserting barrier at top of loop.

- Many LIT tests are updated because of the two points above, instead of having lds_barrier at top of every iterate, we now have barrier inserted only right before it's actually used which is the first shared_write in a loop (protecting shared read of previous iter).