### PR TITLE
[runtime] Rename dltensor capsule to avoid memory leak

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -510,6 +510,9 @@ def _device_export_torch_tensor_cpu(
 # CUDA and HIP import/export
 ################################################################################
 
+_dl_tensor_name = ctypes.create_string_buffer(b"dltensor")
+_set_capsule_name = ctypes.pythonapi.PyCapsule_SetName
+
 
 def _device_import_torch_tensor_cuda_hip(
     device: Device, t: torch.Tensor
@@ -522,6 +525,9 @@ def _device_import_torch_tensor_cuda_hip(
     # event is raised on Torch's stream at the current position.
     capsule = t.__dlpack__(None)
     bv = device.hal_device.from_dlpack_capsule(capsule)
+    # TODO: iree runtime renames the capsule to `dltensor_used`, but doesn't free up the renamed capsule.
+    # Instead of renaming the capsule so it gets freed, we should address the bug in iree-runtime.
+    _set_capsule_name(ctypes.py_object(capsule), _dl_tensor_name)
     return bv
 
 


### PR DESCRIPTION
Adds code similar to <https://github.com/iree-org/iree-turbine/blob/d71316265c73c2d0c8487e1d98ca69a94d7a107c/iree/turbine/kernel/wave/utils/run_utils.py#L104>

There seems to be an issue with memory not getting freed when the py capsule for a dlpack tensor gets renamed. 

I filed an issue in iree: <https://github.com/iree-org/iree/issues/20849>, but in the meantime, we need this fix in order to do basically anything for BOO without running out of memory.