### PR TITLE
[TKW] Improve wave runtime

### DIFF
--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -13,6 +13,7 @@ import json
 import os
 import shutil
 import threading
+import math
 import tempfile
 
 from collections import OrderedDict, deque

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -13,7 +13,7 @@ import json
 import os
 import shutil
 import threading
-import math
+import tempfile
 
 from collections import OrderedDict, deque
 from dataclasses import dataclass, asdict
@@ -31,7 +31,6 @@ from .compile_options import WaveCompileOptions
 
 default_cache_base_dir = Path.home() / ".wave"
 CACHE_BASE_DIR = Path(os.environ.get("WAVE_CACHE_DIR", default_cache_base_dir))
-WAVE_RUNTIME_DIR = CACHE_BASE_DIR / "wave_runtime"
 WAVE_ALWAYS_COMPILE = int(os.environ.get("WAVE_ALWAYS_COMPILE", 0))
 WAVE_CACHE_ON = int(os.environ.get("WAVE_CACHE_ON", 1))
 WAVE_CACHE_LIMIT = int(os.environ.get("WAVE_CACHE_LIMIT", 16))
@@ -46,8 +45,15 @@ def get_cache_base_dir() -> Path:
     return CACHE_BASE_DIR
 
 
-def get_wave_runtime_dir() -> Path:
-    return WAVE_RUNTIME_DIR
+_temp_binary_dir = None
+
+
+def get_temp_binary_dir() -> Path:
+    global _temp_binary_dir
+    if _temp_binary_dir is None:
+        _temp_binary_dir = tempfile.TemporaryDirectory()
+
+    return Path(_temp_binary_dir.name)
 
 
 @dataclass
@@ -242,7 +248,7 @@ class WaveCacheManager(object):
         cur_module_path.write_text(module_str)
         kernel_sig_str = json.dumps([usage.name for usage in kernel_sig])
         cur_kernelsig_path.write_text(kernel_sig_str)
-        cur_hsaco_path = glob.glob(str(get_wave_runtime_dir() / "*.hsaco"))
+        cur_hsaco_path = glob.glob(str(get_temp_binary_dir() / "*.hsaco"))
         # Copy the hsaco file to the cache directory only if it exists.
         if cur_hsaco_path:
             cur_hsaco_path = cur_hsaco_path[0]

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -10,7 +10,7 @@ from .compile_options import WaveCompileOptions
 from .cache import (
     get_cache_base_dir,
     get_cache_manager,
-    get_wave_runtime_dir,
+    get_temp_binary_dir,
     is_cache_enabled,
 )
 from .utils.compile_utils import compile_to_vmfb
@@ -94,7 +94,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
                 + ".hsaco"
             )
         else:
-            return glob.glob(str(get_wave_runtime_dir() / "*.hsaco"))[0]
+            return glob.glob(str(get_temp_binary_dir() / "*.hsaco"))[0]
 
     if is_cache_enabled():
         cache_manager = get_cache_manager()
@@ -126,7 +126,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     # dumping of binaries and store in wave runtime directory. If we
     # are caching, this will be moved to the appropriate directory.
     if options.wave_runtime:
-        options.dump_binaries = str(get_wave_runtime_dir())
+        options.dump_binaries = get_temp_binary_dir()
 
     # Recompile kernel from scratch if not found in cache.
     (

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -123,7 +123,6 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     if options.wave_runtime:
         runtime_dir = get_wave_runtime_dir()
         options.dump_binaries = str(runtime_dir)
-        binary_path = glob.glob(str(runtime_dir / "*.hsaco"))[0]
 
     # Recompile kernel from scratch if not found in cache.
     (
@@ -170,5 +169,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
 
     # Remove the indexing context.
     pop(IndexingContext)
+    if options.wave_runtime:
+        binary_path = glob.glob(str(runtime_dir / "*.hsaco"))[0]
 
     return WaveKernel(options, compiled_wave_vmfb, asm, binary_path)

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -1,15 +1,17 @@
-from typing import Any
+from typing import Any, Optional
 
 import torch
+import glob
 from copy import copy
-from .._support.indexing import IndexingContext, IndexExpr
+from .._support.indexing import IndexingContext
 from ..compiler import kernel_codegen, host_codegen
 from .compile_options import WaveCompileOptions
 
 from .cache import (
-    is_cache_enabled,
+    get_cache_base_dir,
     get_cache_manager,
     get_wave_runtime_dir,
+    is_cache_enabled,
 )
 from .utils.compile_utils import compile_to_vmfb
 from .utils.run_utils import invoke_vmfb, _write_file
@@ -21,10 +23,13 @@ class WaveKernel:
     Represents a wave kernel that can be invoked by the user.
     """
 
-    def __init__(self, options: WaveCompileOptions, executable: Any, asm: str):
+    def __init__(self, options: WaveCompileOptions, executable: Any, asm: str, gpu_binary_path: Optional[str]):
         self.options = options
         self.executable = executable
         self.asm = asm
+        if gpu_binary_path:
+            import wave_runtime
+            self.gpu_binary, self.gpu_func = wave_runtime.load_binary(gpu_binary_path, options.kernel_launch_info.func_name)
 
     def __call__(self, *args, **kwargs):
         return self.invoke(*args, **kwargs)
@@ -56,7 +61,7 @@ class WaveKernel:
 
         kernel_inputs.extend(scalar_args)
 
-        invoke_vmfb(self.executable, self.options, kernel_inputs, kernel_outputs)
+        invoke_vmfb(self.executable, self.options, kernel_inputs, kernel_outputs, self.gpu_func)
         return self.asm
 
 
@@ -67,6 +72,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
 
     # Check if this kernel has been compiled before, if the cache is enabled.
     cache_manager = None
+    binary_path = None
     if is_cache_enabled():
         cache_manager = get_cache_manager()
         options.kernel_hash = cache_manager.get_hash(
@@ -78,7 +84,10 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
         if cached_kernel:
             options.kernel_usages = cached_kernel.kernel_sig
             options.kernel_launch_info = cached_kernel.kernel_launch_info
-            return WaveKernel(options, cached_kernel.vmfb, cached_kernel.asm)
+            if options.wave_runtime:
+                binary_path = str(get_cache_base_dir() / options.kernel_hash / options.kernel_hash) + ".hsaco"
+
+            return WaveKernel(options, cached_kernel.vmfb, cached_kernel.asm, binary_path)
 
     # Create an indexing context and populate substitutions.
     push(IndexingContext, IndexingContext())
@@ -92,7 +101,9 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     # dumping of binaries and store in wave runtime directory. If we
     # are caching, this will be moved to the appropriate directory.
     if options.wave_runtime:
-        options.dump_binaries = str(get_wave_runtime_dir())
+        runtime_dir = get_wave_runtime_dir()
+        options.dump_binaries = str(runtime_dir)
+        binary_path = glob.glob(str(runtime_dir / "*.hsaco"))[0]
 
     # Recompile kernel from scratch if not found in cache.
     (
@@ -118,7 +129,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
         asm = options.override_mlir
 
     if options.compile_to_mlir:
-        return WaveKernel(options, None, asm)
+        return WaveKernel(options, None, asm, None)
 
     compiled_wave_vmfb = compile_to_vmfb(asm, options)
     if options.create_vmfb_file:
@@ -140,4 +151,4 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     # Remove the indexing context.
     pop(IndexingContext)
 
-    return WaveKernel(options, compiled_wave_vmfb, asm)
+    return WaveKernel(options, compiled_wave_vmfb, asm, binary_path)

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -126,7 +126,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     # dumping of binaries and store in wave runtime directory. If we
     # are caching, this will be moved to the appropriate directory.
     if options.wave_runtime:
-        options.dump_binaries = get_wave_runtime_dir()
+        options.dump_binaries = str(get_wave_runtime_dir())
 
     # Recompile kernel from scratch if not found in cache.
     (

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -23,13 +23,24 @@ class WaveKernel:
     Represents a wave kernel that can be invoked by the user.
     """
 
-    def __init__(self, options: WaveCompileOptions, executable: Any, asm: str, gpu_binary_path: Optional[str]):
+    def __init__(
+        self,
+        options: WaveCompileOptions,
+        executable: Any,
+        asm: str,
+        gpu_binary_path: Optional[str],
+    ):
         self.options = options
         self.executable = executable
         self.asm = asm
         if gpu_binary_path:
             import wave_runtime
-            self.gpu_binary, self.gpu_func = wave_runtime.load_binary(gpu_binary_path, options.kernel_launch_info.func_name)
+
+            self.gpu_binary, self.gpu_func = wave_runtime.load_binary(
+                gpu_binary_path, options.kernel_launch_info.func_name
+            )
+        else:
+            self.gpu_func = None
 
     def __call__(self, *args, **kwargs):
         return self.invoke(*args, **kwargs)
@@ -61,7 +72,9 @@ class WaveKernel:
 
         kernel_inputs.extend(scalar_args)
 
-        invoke_vmfb(self.executable, self.options, kernel_inputs, kernel_outputs, self.gpu_func)
+        invoke_vmfb(
+            self.executable, self.options, kernel_inputs, kernel_outputs, self.gpu_func
+        )
         return self.asm
 
 
@@ -85,9 +98,16 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
             options.kernel_usages = cached_kernel.kernel_sig
             options.kernel_launch_info = cached_kernel.kernel_launch_info
             if options.wave_runtime:
-                binary_path = str(get_cache_base_dir() / options.kernel_hash / options.kernel_hash) + ".hsaco"
+                binary_path = (
+                    str(
+                        get_cache_base_dir() / options.kernel_hash / options.kernel_hash
+                    )
+                    + ".hsaco"
+                )
 
-            return WaveKernel(options, cached_kernel.vmfb, cached_kernel.asm, binary_path)
+            return WaveKernel(
+                options, cached_kernel.vmfb, cached_kernel.asm, binary_path
+            )
 
     # Create an indexing context and populate substitutions.
     push(IndexingContext, IndexingContext())

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -126,7 +126,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     # dumping of binaries and store in wave runtime directory. If we
     # are caching, this will be moved to the appropriate directory.
     if options.wave_runtime:
-        options.dump_binaries = get_binary_path()
+        options.dump_binaries = get_wave_runtime_dir()
 
     # Recompile kernel from scratch if not found in cache.
     (

--- a/iree/turbine/kernel/wave/runtime/runtime.cpp
+++ b/iree/turbine/kernel/wave/runtime/runtime.cpp
@@ -94,10 +94,13 @@ static int launch(const KernelLaunchInfo &info, const Int64Vector &tensors,
     return hipSuccess;
 }
 
-static void unload_binary(void *ptr)
+static void unload_binary(void *ptr) noexcept
 {
     auto module = reinterpret_cast<hipModule_t>(ptr);
-    HIP_CHECK_EXC(hipModuleUnload(module));
+
+    // Assume it will never fail as we cant do anything meaningful about it
+    // anyway.
+    (void)hipModuleUnload(module);
 }
 
 static nb::tuple load_binary(const std::string &path, const std::string &func_name)

--- a/iree/turbine/kernel/wave/runtime/runtime.cpp
+++ b/iree/turbine/kernel/wave/runtime/runtime.cpp
@@ -100,14 +100,14 @@ static void unload_binary(void *ptr)
     HIP_CHECK_EXC(hipModuleUnload(module));
 }
 
-static py::tuple load_binary(const std::string &path, const std::string &func_name)
+static nb::tuple load_binary(const std::string &path, const std::string &func_name)
 {
     hipModule_t module;
     hipFunction_t function;
     HIP_CHECK_EXC(hipModuleLoad(&module, path.c_str()));
     HIP_CHECK_EXC(hipModuleGetFunction(&function, module, func_name.c_str()));
-    py::capsule capsule(reinterpret_cast<void *>(module), &unload_binary);
-    return py::make_tuple(capsule, reinterpret_cast<uintptr_t>(function));
+    nb::capsule capsule(reinterpret_cast<void *>(module), &unload_binary);
+    return nb::make_tuple(capsule, reinterpret_cast<uintptr_t>(function));
 }
 
 NB_MODULE(wave_runtime, m)

--- a/iree/turbine/kernel/wave/runtime/runtime.cpp
+++ b/iree/turbine/kernel/wave/runtime/runtime.cpp
@@ -97,10 +97,9 @@ static int launch(const KernelLaunchInfo &info, const Int64Vector &tensors,
 static void unload_binary(void *ptr) noexcept
 {
     auto module = reinterpret_cast<hipModule_t>(ptr);
-
-    // Assume it will never fail as we cant do anything meaningful about it
-    // anyway.
-    (void)hipModuleUnload(module);
+    if (auto e = hipModuleUnload(module)) {
+        nb::print(nb::str("Failed to unload module: ") + nb::str(hipGetErrorString(e)));
+    }
 }
 
 static nb::tuple load_binary(const std::string &path, const std::string &func_name)

--- a/iree/turbine/kernel/wave/runtime/runtime.cpp
+++ b/iree/turbine/kernel/wave/runtime/runtime.cpp
@@ -116,7 +116,7 @@ NB_MODULE(wave_runtime, m)
     nb::bind_vector<Int32Vector>(m, "Int32Vector");
     nb::class_<KernelLaunchInfo>(m, "KernelLaunchInfo")
         .def(nb::init<uintptr_t, int, int, int, int, int, int, int>())
-        .def_rw("function", &KernelLaunchInfo::function)
+        .def_rw("gpu_func", &KernelLaunchInfo::function)
         .def_rw("sharedMemoryBytes", &KernelLaunchInfo::sharedMemoryBytes)
         .def_rw("gridX", &KernelLaunchInfo::gridX)
         .def_rw("gridY", &KernelLaunchInfo::gridY)

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -250,7 +250,6 @@ def invoke_with_wave_runtime(
     grid = compute_grid(dynamic_dims, options.kernel_launch_info.grid)
 
     # Populate all the information required to launch the kernel.
-    hash_str = "" if not options.kernel_hash else options.kernel_hash
     kernel_launch_info = wave_runtime.KernelLaunchInfo(
         gpu_func,
         options.kernel_launch_info.shared_memory_bytes,

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -21,7 +21,7 @@ from .._support.tracing import (
     KernelRegionGraph,
     Launchable,
 )
-from .cache import get_wave_runtime_dir
+from .cache import get_temp_binary_dir
 from ..compiler.ir import Context, Module, Operation
 from .codegen import WaveEmitter
 from .constraints import (
@@ -507,7 +507,7 @@ class LaunchableWave(Launchable):
             # If the kernel is being cached, then it will be referenced from the
             # cache directory. When kernels are not being cached, we remove them
             # to ensure that at any time there is only one hsaco file in this directory.
-            remove_files_with_extension(get_wave_runtime_dir(), ".hsaco")
+            remove_files_with_extension(get_temp_binary_dir(), ".hsaco")
 
         print_ir_after = options.print_ir_after
         print_ir_before = options.print_ir_before

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,8 +96,6 @@ def _set_cache_dir(config):
 
     base_cache_dir = cache.CACHE_BASE_DIR
     cache.CACHE_BASE_DIR = base_cache_dir / f"worker_{worker_id}"
-    base_runtime_dir = cache.WAVE_RUNTIME_DIR
-    cache.WAVE_RUNTIME_DIR = base_runtime_dir / f"worker_{worker_id}"
 
 
 def _has_marker(item, marker):


### PR DESCRIPTION
There are multiple changes here:
* Previously calling to `wave_compile` multiple times with `wave_runtime=True` was broken as  `wave_compile`  were overwriting serialized gpu binary on disk. Fixed by moving binary reading into `WaveKernel` init from the invoke.
* Simplified `wave_runtime.cpp` and `invoke_with_wave_runtime` and removed all the caching logic from there as it moved to `WaveKernel`.
* Use `tempfile.TemporaryDirectory()` for the temp bin path so it will be unique for each process to reduce race conditions when Wave called from multiple processes (races are still possible, though, when copying binary into cache dir).
* HIP module lifetime is now bound to `WaveKernel` lifetime.
* `get_wave_runtime_dir()` is no more