### PR TITLE
[BOO] Enable `torch.compile` for models with boo convs

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/conv.py
+++ b/iree/turbine/kernel/boo/conv_exports/conv.py
@@ -26,6 +26,7 @@ __all__ = [
     "ConvForward",
     "ConvBackwardWeight",
     "ConvBackwardInput",
+    "DEFAULT_LAYOUTS",
 ]
 
 

--- a/iree/turbine/kernel/boo/examples/resnet_18_backward.py
+++ b/iree/turbine/kernel/boo/examples/resnet_18_backward.py
@@ -4,7 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# NOTE: This script does not currently work because some bwd conv configs in the model fail compilation
+import argparse
+import contextlib
 
 try:
     import torchvision
@@ -14,61 +15,171 @@ except ImportError as e:
     )
 
 import torch
+from torch.profiler import profile, ProfilerActivity, record_function
+
+import torch.optim as optim
+import torchvision.transforms as transforms
+from torch.utils.data import DataLoader
 
 from iree.turbine.kernel.boo.modeling import replace_conv2d_with_boo_conv
 
 # load and modify the model:
 
-resnet_model = torchvision.models.resnet18(pretrained=False)
-resnet_model = replace_conv2d_with_boo_conv(resnet_model)
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
-assert device == "cuda", f"device is {device}."
+def get_model(
+    use_boo=True, compile=False, memory_format=torch.channels_last, **boo_conv_kwargs
+):
+    """Sets up a resnet 18 model on cuda device based on provided parameters."""
+    # base model
+    resnet_model = torchvision.models.resnet18(pretrained=False)
+    # boo replacement
+    resnet_model = (
+        replace_conv2d_with_boo_conv(resnet_model, **boo_conv_kwargs)
+        if use_boo
+        else resnet_model
+    )
+    # move to gpu and apply memory format
+    resnet_model = resnet_model.to(device="cuda", memory_format=memory_format)
+    # compile model
+    resnet_model = torch.compile(resnet_model) if compile else resnet_model
+    return resnet_model
 
-resnet_model = resnet_model.to(
-    dtype=torch.bfloat16, device=device, memory_format=torch.channels_last
-)
 
-import torch.optim as optim
-import torch.nn.functional as F
-import torchvision.transforms as transforms
-from torch.utils.data import DataLoader
+def get_train_loader(batch_size=128, image_size=256, num_workers=2):
+    transform = transforms.Compose(
+        [
+            transforms.RandomResizedCrop(image_size),
+            transforms.RandomHorizontalFlip(),
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+        ]
+    )
+    train_dataset = torchvision.datasets.CIFAR10(
+        root="./data", train=True, download=True, transform=transform
+    )
+    train_loader = DataLoader(
+        train_dataset, batch_size=batch_size, shuffle=True, num_workers=num_workers
+    )
+    return train_loader
 
-# get a training data loader
-transform = transforms.Compose(
-    [
-        transforms.RandomResizedCrop(32),
-        transforms.RandomHorizontalFlip(),
-        transforms.ToTensor(),
-        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
-    ]  # Example normalization
-)
-train_dataset = torchvision.datasets.CIFAR10(
-    root="./data", train=True, download=True, transform=transform
-)
-train_loader = DataLoader(train_dataset, batch_size=4, shuffle=True, num_workers=2)
 
-# Define loss function and optimizer
-criterion = torch.nn.CrossEntropyLoss()
-optimizer = optim.SGD(resnet_model.parameters(), lr=0.001, momentum=0.9)
+def train_loop(
+    trace_path,
+    resnet_model,
+    train_loader,
+    memory_format=torch.channels_last,
+    autocast_dtype=torch.bfloat16,
+):
+    """Runs a training loop and generates a profile to `trace_path`."""
+    device = "cuda"
+    # Define loss function and optimizer
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = optim.SGD(resnet_model.parameters(), lr=0.001, momentum=0.9)
 
-# Training loop
-epochs = 10
-for epoch in range(epochs):
-    resnet_model.train()
-    running_loss = 0.0
-    for inputs, labels in train_loader:  # Assuming you have a train_loader
-        inputs, labels = inputs.to(device=device, dtype=torch.bfloat16), labels.to(
-            device
-        )
+    # Training loop
+    epochs = 3
+    maybe_ctx = lambda iter, ctx: (contextlib.nullcontext() if iter == 0 else ctx)
+    with profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True
+    ) as prof:
+        for epoch in range(epochs):
+            resnet_model.train()
+            running_loss = 0.0
+            for idx, (inputs, labels) in enumerate(train_loader):
+                # For sake of time, only running a few data points
+                if idx > 10:
+                    break
+                inputs, labels = inputs.to(
+                    device=device, memory_format=memory_format
+                ), labels.to(device=device)
+                optimizer.zero_grad()  # Zero the gradients
+                with torch.amp.autocast(
+                    device_type=torch.device(device).type, dtype=autocast_dtype
+                ):
+                    with maybe_ctx(
+                        idx + epoch,
+                        record_function(f"forward epoch {epoch}, iter {idx}"),
+                    ):
+                        outputs = resnet_model(inputs)  # Forward pass
+                    loss = criterion(outputs, labels)  # Calculate loss
 
-        optimizer.zero_grad()  # Zero the gradients
+                with maybe_ctx(
+                    idx + epoch, record_function(f"backward epoch {epoch}, iter {idx}")
+                ):
+                    loss.backward()  # Backpropagate
+                optimizer.step()  # Update weights
 
-        outputs = resnet_model(inputs)  # Forward pass
-        loss = criterion(outputs, labels)  # Calculate loss
-        loss.backward()  # Backpropagate
-        optimizer.step()  # Update weights
+                running_loss += loss.item()
 
-        running_loss += loss.item()
+            print(f"Epoch {epoch+1}, Loss: {running_loss/len(train_loader)}")
 
-    print(f"Epoch {epoch+1}, Loss: {running_loss/len(train_loader)}")
+    # print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=100))
+    prof.export_chrome_trace(trace_path)
+
+
+def _get_argparse():
+    parser = argparse.ArgumentParser(
+        description="A script for generating profiles with boo convs."
+    )
+    parser.add_argument(
+        "trace_path",
+        type=str,
+        help="Specify a path to save a resnet trace json file.",
+    )
+    parser.add_argument(
+        "-c",
+        "--compile",
+        action="store_true",
+        default=False,
+        help="Set this to use torch.compile on the model",
+    )
+    parser.add_argument(
+        "-r",
+        "--use_boo",
+        action="store_true",
+        default=False,
+        help="Set this to replace Conv2d modules with BooConv2d",
+    )
+    parser.add_argument(
+        "-p",
+        "--pytorch_layout",
+        action="store_true",
+        default=False,
+        help="Set this to use NCHW format. Default layout is torch.channels_last.",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch_size",
+        type=int,
+        default=128,
+        help="Specify a batch size for the train loader.",
+    )
+    parser.add_argument(
+        "-s",
+        "--image_size",
+        type=int,
+        default=256,
+        help="Specify the spatial dim size (square) for the model inputs.",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    if not torch.cuda.is_available():
+        print("GPU expected for running this script.")
+        import sys
+
+        sys.exit(1)
+    args = _get_argparse().parse_args()
+    memory_format = (
+        torch.contiguous_format if args.pytorch_layout else torch.channels_last
+    )
+    resnet_model = get_model(args.use_boo, args.compile, memory_format, stride=(1, 1))
+    train_loader = get_train_loader(args.batch_size, args.image_size)
+    train_loop(
+        args.trace_path,
+        resnet_model,
+        train_loader,
+        memory_format,
+        autocast_dtype=torch.bfloat16,
+    )

--- a/tests/kernel/boo/modeling/boo_conv_2d_test.py
+++ b/tests/kernel/boo/modeling/boo_conv_2d_test.py
@@ -7,6 +7,7 @@
 import unittest
 import tempfile
 from pathlib import Path
+import pytest
 
 import torch
 
@@ -189,6 +190,7 @@ class BooConv2dTest(unittest.TestCase):
                 func_names,
             )
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU to test.")
     def testCompileWithBackwardAMPGPU(self):
         with tempfile.TemporaryDirectory() as td:
             cache_dir = Path(td)

--- a/tests/kernel/boo/modeling/boo_conv_2d_test.py
+++ b/tests/kernel/boo/modeling/boo_conv_2d_test.py
@@ -143,6 +143,98 @@ class BooConv2dTest(unittest.TestCase):
                 func_names,
             )
 
+    def testCompileWithBackwardF32(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            x = torch.ones(
+                [10, 3, 16, 16],
+                device=self.device,
+                dtype=torch.float32,
+                requires_grad=True,
+            ).to(memory_format=torch.channels_last)
+            model2 = replace_conv2d_with_boo_conv(self.model1).to(
+                memory_format=torch.channels_last
+            )
+            compiled = torch.compile(model2)
+
+            y = compiled(x)
+            loss = y.sum()
+
+            loss.backward()
+
+            func_names = [i.name for i in cache_dir.glob("*")]
+            self.assertIn(
+                "conv_2d_float32_forward_10x16x16x3_nhwc_2x3x3x3_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_forward_b_10x14x14x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_input_backward_10x16x16x3_nhwc_2x3x3x3_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_input_backward_10x14x14x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_weight_backward_10x16x16x3_nhwc_2x3x3x3_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_float32_weight_backward_10x14x14x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+
+    def testCompileWithBackwardAMPGPU(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_dir = Path(td)
+            set_boo_cache(cache_dir)
+            x = torch.ones(
+                [10, 3, 16, 16],
+                device=self.device,
+                dtype=torch.float32,
+                requires_grad=True,
+            ).to(memory_format=torch.channels_last)
+            model2 = replace_conv2d_with_boo_conv(self.model1).to(
+                memory_format=torch.channels_last
+            )
+            compiled = torch.compile(model2)
+            with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
+                y = compiled(x)
+                loss = y.sum()
+
+            loss.backward()
+
+            func_names = [i.name for i in cache_dir.glob("*")]
+            self.assertIn(
+                "conv_2d_bfloat16_forward_10x16x16x3_nhwc_2x3x3x3_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_bfloat16_forward_b_10x14x14x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_bfloat16_input_backward_10x16x16x3_nhwc_2x3x3x3_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_bfloat16_input_backward_10x14x14x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_bfloat16_weight_backward_10x16x16x3_nhwc_2x3x3x3_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+            self.assertIn(
+                "conv_2d_bfloat16_weight_backward_10x14x14x2_nhwc_3x2x2x2_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+                func_names,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/kernel/boo/ops/boo_conv_test.py
+++ b/tests/kernel/boo/ops/boo_conv_test.py
@@ -59,23 +59,19 @@ class BooConvTest(unittest.TestCase):
 
     def testBooConvBackwardsAmpContextCPU(self):
         """We expect this to not perform autocasting."""
+
+        device = None
+        x = torch.ones(
+            [1, 1, 32, 32], dtype=torch.float32, device=device, requires_grad=True
+        )
+        w = torch.ones(
+            [1, 1, 4, 4], dtype=torch.float32, device=device, requires_grad=True
+        )
+
         with tempfile.TemporaryDirectory() as td:
             set_boo_cache(Path(td))
-            device = None
-            x = torch.ones(
-                [1, 1, 32, 32], dtype=torch.float32, device=device, requires_grad=True
-            )
-            w = torch.ones(
-                [1, 1, 4, 4], dtype=torch.float32, device=device, requires_grad=True
-            )
 
             with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
-                y = boo_conv(x, w)
-                loss = y.sum()
-
-            loss.backward()
-
-            with torch.amp.autocast(device_type="cpu", dtype=torch.bfloat16):
                 y = boo_conv(x, w)
                 loss = y.sum()
 
@@ -100,10 +96,45 @@ class BooConvTest(unittest.TestCase):
                 f"conv_2d_{expected_dtype_str}_input_backward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g",
                 items,
             )
-            # Make sure we got back the correct original dtypes.
+
             self.assertEqual(y.dtype, torch.float32)
             self.assertEqual(x.grad.dtype, torch.float32)
             self.assertEqual(w.grad.dtype, torch.float32)
+            self.assertEqual(w.dtype, torch.float32)
+
+        with tempfile.TemporaryDirectory() as td_0:
+            set_boo_cache(Path(td_0))
+
+            with torch.amp.autocast(device_type="cpu", dtype=torch.bfloat16):
+                y = boo_conv(x, w)
+                loss = y.sum()
+
+            loss.backward()
+
+            items = [x.name for x in Path(td_0).glob("*/")]
+            expected_dtype_str = "bfloat16"
+            unexpected_dtype_str = "float32"
+            self.assertNotIn(
+                f"conv_2d_{unexpected_dtype_str}_forward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                items,
+            )
+            self.assertIn(
+                f"conv_2d_{expected_dtype_str}_forward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                items,
+            )
+            self.assertIn(
+                f"conv_2d_{expected_dtype_str}_weight_backward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                items,
+            )
+            self.assertIn(
+                f"conv_2d_{expected_dtype_str}_input_backward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+                items,
+            )
+            # Make sure we got back the correct original dtypes.
+            self.assertEqual(y.dtype, torch.bfloat16)
+            self.assertEqual(x.grad.dtype, torch.float32)
+            self.assertEqual(w.grad.dtype, torch.float32)
+            self.assertEqual(w.dtype, torch.float32)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU to test.")
     def testBooConvBackwardsAmpContextCUDA(self):
@@ -141,9 +172,10 @@ class BooConvTest(unittest.TestCase):
                 items,
             )
             # Make sure we got back the correct original dtypes.
-            self.assertEqual(y.dtype, torch.float32)
+            self.assertEqual(y.dtype, torch.bfloat16)
             self.assertEqual(x.grad.dtype, torch.float32)
             self.assertEqual(w.grad.dtype, torch.float32)
+            self.assertEqual(w.dtype, torch.float32)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change uses a `torch.library.custom_op` to define `boo_conv` instead of `autograd.Function`, which enables `torch.compile` for models with boo convolution. In addition, this commit factors out the autocasting logic since the decorators don't behave very well with respect to `custom_op`. It also changes the behavior slightly to mimic the functionality of `torch.convolution` under autocast contexts. 

These changes are a temporary solution, since it will be beneficial to take a more systematic approach of implementing autograd custom ops. I think this will make the most sense via implementing `iree.turbine.runtime.CustomOp` autograd support. Ideally, boo convolutions can simply be an application of `CustomOp` eager execution, in such a way that this is compatible with backward, `torch.compile`, and `torch.amp.autocast` contexts.