### PR TITLE
Pin IREE version to 3.5.0rc20250516

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -7,5 +7,7 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-iree-base-compiler==3.5.0rc20250522
-iree-base-runtime==3.5.0rc20250522
+# TODO: We have a pretty bad regression in Wave between 3.5.0rc20250516 and
+# 3.5.0rc20250517. I'm locking to 3.5.0rc20250516 until further investigation.
+iree-base-compiler==3.5.0rc20250516
+iree-base-runtime==3.5.0rc20250516


### PR DESCRIPTION
We have a bad regression in Wave between `3.5.0rc20250516` and `3.5.0rc20250517`. 40% perf drop in paged extend attention kernel and crash in paged decode (which is not reproducible in our unit tests).

I'm locking to the last known good version until further investigation.