### PR TITLE
[TKW](WIP) Switch Wave iree runtime path to `turbine.runtime`

### DIFF
--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -47,8 +47,7 @@ class WaveKernel:
         if not options.wave_runtime:
 
             def loader(device):
-                rt_config = rt.Config(device)
-                vm_instance = rt_config.vm_instance
+                vm_instance = device.vm_instance
                 return rt.VmModule.copy_buffer(vm_instance, self.executable)
 
             self.launchable = Launchable.from_vm_module(

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -14,7 +14,7 @@ from .cache import (
     is_cache_enabled,
 )
 from .utils.compile_utils import compile_to_vmfb
-from .utils.run_utils import invoke_vmfb, _write_file
+from .utils.run_utils import invoke_vmfb, _write_file, invoke_with_wave_runtime
 from iree.turbine.kernel._support.context import push, pop
 
 
@@ -72,9 +72,13 @@ class WaveKernel:
 
         kernel_inputs.extend(scalar_args)
 
-        invoke_vmfb(
-            self.executable, self.options, kernel_inputs, kernel_outputs, self.gpu_func
-        )
+        if self.options.wave_runtime:
+            invoke_with_wave_runtime(
+                self.gpu_func, self.options, kernel_inputs, kernel_outputs
+            )
+            return self.asm
+
+        invoke_vmfb(self.executable, self.options, kernel_inputs, kernel_outputs)
         return self.asm
 
 

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -52,7 +52,7 @@ class WaveKernel:
 
             self.launchable = Launchable.from_vm_module(
                 loader,
-                entry_point=options.kernel_launch_info.func_name,
+                entry_point=options.func_name,
             )
 
     def __call__(self, *args):

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -96,7 +96,6 @@ class WaveKernel:
                 *kernel_inputs,
                 *kernel_outputs,
                 *list(self.options.dynamic_symbols_map.values()),
-                device=None,
             )
 
         return self.asm

--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -28,7 +28,6 @@ class WaveCompileOptions:
     # === Runtime options ===
     kernel_launch_info: KernelLaunchInfo = field(default_factory=KernelLaunchInfo)
     kernel_usages: tuple[KernelBufferUsage] = None
-    inplace: bool = True
 
     # === Backend options ===
     backend: str = "rocm"

--- a/iree/turbine/kernel/wave/iree_utils.py
+++ b/iree/turbine/kernel/wave/iree_utils.py
@@ -5,10 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import torch
-from typing import Any
-from .utils.run_utils import compile_and_invoke
 from ...support.conversions import TORCH_DTYPE_TO_IREE_TYPE_ASM
-from .compile import WaveCompileOptions
 from iree.turbine.runtime.launch import Launchable
 
 
@@ -163,7 +160,6 @@ def generate_iree_ref(
     kernel_type: str,
     kernel_inputs: list[torch.Tensor],
     kernel_outputs: list[torch.Tensor],
-    options: WaveCompileOptions,
 ):
     """
     Generate a reference output for the given kernel type and arguments.
@@ -221,13 +217,3 @@ def generate_iree_ref(
     else:
         for r, k in zip(res, kernel_outputs):
             k[:] = r
-
-    # options.func_name = kernel_type
-    # options.inplace = False
-    # options.dynamic_symbols_map = {}
-    # compile_and_invoke(
-    #     asm,
-    #     kernel_inputs,
-    #     kernel_outputs,
-    #     options,
-    # )

--- a/iree/turbine/kernel/wave/iree_utils.py
+++ b/iree/turbine/kernel/wave/iree_utils.py
@@ -9,11 +9,12 @@ from typing import Any
 from .utils.run_utils import compile_and_invoke
 from ...support.conversions import TORCH_DTYPE_TO_IREE_TYPE_ASM
 from .compile import WaveCompileOptions
+from iree.turbine.runtime.launch import Launchable
 
 
 def get_chain_mmt_asm(
     query_type: str, key_type: str, value_type: str, output_type: str
-) -> str:
+) -> tuple[str, str]:
     B, M, K1, input_dtype = query_type.split("x")
     B, K2, K1, input_dtype = key_type.split("x")
     B, N, K2, input_dtype = value_type.split("x")
@@ -22,7 +23,8 @@ def get_chain_mmt_asm(
     intermediate_cast_type = f"{B}x{K2}x{M}x{input_dtype}"
     transposed_cast_type = f"{B}x{M}x{K2}x{input_dtype}"
     transposed_output_type = f"{B}x{M}x{N}x{output_dtype}"
-    return f"""
+    return (
+        f"""
     func.func @chain_mmt(%query: tensor<{query_type}>, %key: tensor<{key_type}>, %value: tensor<{value_type}>) -> tensor<{output_type}> {{
       %c0 = arith.constant 0.0 : f32
       %init = tensor.empty() : tensor<{intermediate_output_type}>
@@ -39,12 +41,14 @@ def get_chain_mmt_asm(
       %init4 = tensor.empty() : tensor<{output_type}>
       %transpose2 = linalg.transpose ins(%result2: tensor<{transposed_output_type}>) outs(%init4: tensor<{output_type}>) permutation=[0, 2, 1]
       return %transpose2 : tensor<{output_type}>
-    }}"""
+    }}""",
+        "chain_mmt",
+    )
 
 
 def get_chain_mmt_f8_asm(
     query_type: str, key_type: str, value_type: str, output_type: str
-) -> str:
+) -> tuple[str, str]:
     B, M, K1, input_dtype = query_type.split("x")
     B, K2, K1, input_dtype = key_type.split("x")
     B, N, K2, input_dtype = value_type.split("x")
@@ -57,7 +61,8 @@ def get_chain_mmt_f8_asm(
     query_f8_type = "x".join([B, M, K1, f8_dtype])
     key_f8_type = "x".join([B, K2, K1, f8_dtype])
     value_f8_type = "x".join([B, N, K2, f8_dtype])
-    return f"""
+    return (
+        f"""
     func.func @chain_mmt_f8(%query: tensor<{query_type}>, %key: tensor<{key_type}>, %value: tensor<{value_type}>) -> tensor<{output_type}> {{
       %c0 = arith.constant 0.0 : f32
       %init = tensor.empty() : tensor<{intermediate_output_type}>
@@ -77,7 +82,9 @@ def get_chain_mmt_f8_asm(
       %init4 = tensor.empty() : tensor<{output_type}>
       %transpose2 = linalg.transpose ins(%result2: tensor<{transposed_output_type}>) outs(%init4: tensor<{output_type}>) permutation=[0, 2, 1]
       return %transpose2 : tensor<{output_type}>
-    }}"""
+    }}""",
+        "chain_mmt_f8",
+    )
 
 
 def get_mmt_asm(
@@ -86,7 +93,7 @@ def get_mmt_asm(
     acc_type: str,
     batch: bool = False,
     cast_fp8: bool = False,
-) -> str:
+) -> tuple[str, str]:
     acc_dtype = acc_type.split("x")[-1]
     operator = "batch_matmul_transpose_b" if batch else "matmul_transpose_b"
     func_name = "bmmt" if batch else "mmt"
@@ -118,14 +125,15 @@ def get_mmt_asm(
                      outs(%inital_result: tensor<{acc_type}>) -> tensor<{acc_type}>
           return %result : tensor<{acc_type}>
         }}"""
-    return matmul_function
+    return matmul_function, func_name
 
 
 def get_conv_asm(
     conv_type: str, lhs_type: str, rhs_type: str, res_type: str, stride: int
-) -> str:
+) -> tuple[str, str]:
     res_dtype = res_type.split("x")[-1]
-    return f"""
+    return (
+        f"""
     func.func @conv_{conv_type}(%lhs: tensor<{lhs_type}>, %rhs: tensor<{rhs_type}>) -> tensor<{res_type}> {{
       %c0 = arith.constant 0.0 : {res_dtype}
       %init = tensor.empty() : tensor<{res_type}>
@@ -135,7 +143,9 @@ def get_conv_asm(
                 ins(%lhs, %rhs : tensor<{lhs_type}>, tensor<{rhs_type}>)
                 outs(%inital_result : tensor<{res_type}>) -> tensor<{res_type}>
       return %result : tensor<{res_type}>
-    }}"""
+    }}""",
+        f"conv_{conv_type}",
+    )
 
 
 def dtype_str(dtype: torch.dtype) -> str:
@@ -165,7 +175,7 @@ def generate_iree_ref(
         lhs_type = get_type_str(kernel_inputs[0].shape, kernel_inputs[0].dtype)
         rhs_type = get_type_str(kernel_inputs[1].shape, kernel_inputs[1].dtype)
         acc_type = get_type_str(kernel_outputs[0].shape, kernel_outputs[0].dtype)
-        asm = get_mmt_asm(
+        asm, func_name = get_mmt_asm(
             lhs_type,
             rhs_type,
             acc_type,
@@ -176,36 +186,48 @@ def generate_iree_ref(
         lhs_type = get_type_str(kernel_inputs[0].shape, kernel_inputs[0].dtype)
         rhs_type = get_type_str(kernel_inputs[1].shape, kernel_inputs[1].dtype)
         acc_type = get_type_str(kernel_outputs[0].shape, kernel_outputs[0].dtype)
-        asm = get_mmt_asm(lhs_type, rhs_type, acc_type, batch=True)
+        asm, func_name = get_mmt_asm(lhs_type, rhs_type, acc_type, batch=True)
     elif kernel_type == "chain_mmt":
         query_type = get_type_str(kernel_inputs[0].shape, kernel_inputs[0].dtype)
         key_type = get_type_str(kernel_inputs[1].shape, kernel_inputs[1].dtype)
         value_type = get_type_str(kernel_inputs[2].shape, kernel_inputs[2].dtype)
         output_type = get_type_str(kernel_outputs[0].shape, kernel_outputs[0].dtype)
-        asm = get_chain_mmt_asm(query_type, key_type, value_type, output_type)
+        asm, func_name = get_chain_mmt_asm(
+            query_type, key_type, value_type, output_type
+        )
     elif kernel_type == "chain_mmt_f8":
         query_type = get_type_str(kernel_inputs[0].shape, kernel_inputs[0].dtype)
         key_type = get_type_str(kernel_inputs[1].shape, kernel_inputs[1].dtype)
         value_type = get_type_str(kernel_inputs[2].shape, kernel_inputs[2].dtype)
         output_type = get_type_str(kernel_outputs[0].shape, kernel_outputs[0].dtype)
-        asm = get_chain_mmt_f8_asm(query_type, key_type, value_type, output_type)
+        asm, func_name = get_chain_mmt_f8_asm(
+            query_type, key_type, value_type, output_type
+        )
     elif kernel_type.startswith(conv_str):
         lhs_type = get_type_str(kernel_inputs[0].shape, kernel_inputs[0].dtype)
         rhs_type = get_type_str(kernel_inputs[1].shape, kernel_inputs[1].dtype)
         acc_type = get_type_str(kernel_outputs[0].shape, kernel_outputs[0].dtype)
         conv_type = kernel_type[len(conv_str) :]
-        asm = get_conv_asm(
+        asm, func_name = get_conv_asm(
             conv_type, lhs_type, rhs_type, acc_type, int(kwargs["stride"])
         )
     else:
         raise ValueError(f"Unknown kernel type: {kernel_type}")
 
-    options.func_name = kernel_type
-    options.inplace = False
-    options.dynamic_symbols_map = {}
-    compile_and_invoke(
-        asm,
-        kernel_inputs,
-        kernel_outputs,
-        options,
-    )
+    launchable = Launchable.jit_compile(asm, entry_point=func_name)
+    res = launchable(*kernel_inputs, outputs=kernel_outputs)
+    if len(kernel_outputs) == 1:
+        kernel_outputs[0][:] = res
+    else:
+        for r, k in zip(res, kernel_outputs):
+            k[:] = r
+
+    # options.func_name = kernel_type
+    # options.inplace = False
+    # options.dynamic_symbols_map = {}
+    # compile_and_invoke(
+    #     asm,
+    #     kernel_inputs,
+    #     kernel_outputs,
+    #     options,
+    # )

--- a/iree/turbine/kernel/wave/profiling.py
+++ b/iree/turbine/kernel/wave/profiling.py
@@ -31,7 +31,7 @@ def construct_inputs(
     bench_with_constant_weights = options.bench_with_constant_weights
     tempfiles = []
     inputs = []
-    all_inputs = kernel_inputs + kernel_outputs if options.inplace else kernel_inputs
+    all_inputs = kernel_inputs + kernel_outputs
     all_inputs += options.dynamic_symbols_map.values()
     if bench_with_constant_weights:
         for inp in all_inputs:

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -228,6 +228,14 @@ def invoke_vmfb(
         _print_bench_result(benchmark_results, options.bench_file)
 
 
+def invoke_with_iree_runtime(
+    options: WaveCompileOptions,
+    kernel_inputs: list[torch.Tensor],
+    kernel_outputs: list[torch.Tensor],
+):
+    pass
+
+
 def invoke_with_wave_runtime(
     gpu_func: Any,
     options: WaveCompileOptions,
@@ -263,8 +271,6 @@ def invoke_with_wave_runtime(
         if isinstance(arg_tensor, (float, int)):
             scalar_args.append(arg_tensor)
             continue
-        if not arg_tensor.is_contiguous():
-            arg_tensor = arg_tensor.contiguous()
         kern_args.append(arg_tensor.data_ptr())
 
     kernel_args = wave_runtime.Int64Vector(kern_args)

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -228,14 +228,6 @@ def invoke_vmfb(
         _print_bench_result(benchmark_results, options.bench_file)
 
 
-def invoke_with_iree_runtime(
-    options: WaveCompileOptions,
-    kernel_inputs: list[torch.Tensor],
-    kernel_outputs: list[torch.Tensor],
-):
-    pass
-
-
 def invoke_with_wave_runtime(
     gpu_func: Any,
     options: WaveCompileOptions,
@@ -271,6 +263,10 @@ def invoke_with_wave_runtime(
         if isinstance(arg_tensor, (float, int)):
             scalar_args.append(arg_tensor)
             continue
+
+        if not arg_tensor.is_contiguous():
+            arg_tensor = arg_tensor.contiguous()
+
         kern_args.append(arg_tensor.data_ptr())
 
     kernel_args = wave_runtime.Int64Vector(kern_args)

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -10,13 +10,8 @@ import iree.runtime as rt
 from typing import Callable, Optional, Any
 import ctypes
 from ..compile_options import WaveCompileOptions
-from .compile_utils import compile_to_vmfb
 from .classes import KernelLaunchInfo
 from ..profiling import benchmark_module
-
-
-# Cache for the system context and vm function.
-RUNTIME_CACHE: dict[str, tuple[rt.SystemContext, rt.VmFunction]] = {}
 
 
 @functools.lru_cache
@@ -24,30 +19,9 @@ def compute_grid(kernel_dynamic_dims: tuple[int], grid_fn: Callable):
     return [int(x) for x in grid_fn(list(kernel_dynamic_dims))]
 
 
-def _read_file(name, mode):
-    with open(name, mode) as file:
-        data = file.read()
-    return data
-
-
 def _write_file(name, mode, data):
     with open(name, mode) as file:
         file.write(data)
-
-
-@functools.lru_cache
-def get_device_uuid(device_list: list[str], device_str: str) -> tuple[int, str]:
-    """
-    Checks all torch.Tensor are on the same device, and get UUID from Torch device.
-    """
-    if len(set(device_list)) != 1:
-        raise ValueError(f"Found multiple device on input tensors:{set(device_list)}")
-    device = device_list[0]
-    if device.type != "cuda":
-        raise ValueError("Expected all argument tensors to be in GPU.")
-    uuid = str(torch.cuda.get_device_properties(device).uuid)
-    device_str = f"{device_str}://GPU-{uuid}"
-    return device_str
 
 
 def _invoke(vm_context, device, entry_function, inputs, outputs, dynamic_dims):
@@ -81,66 +55,7 @@ def _invoke(vm_context, device, entry_function, inputs, outputs, dynamic_dims):
         ret[:] = type(ret)(host_array)
 
 
-_dl_tensor_name = ctypes.create_string_buffer(b"dltensor")
-_set_capsule_name = ctypes.pythonapi.PyCapsule_SetName
-
-
-def _inplace_invoke(vm_context, device, entry_function, inputs, outputs, dynamic_dims):
-    linearized_arg_len = len(inputs) + len(outputs) + len(dynamic_dims)
-    # ret_list is 0 because we modify/write result in place.
-    arg_list = rt.VmVariantList(linearized_arg_len)
-    ret_list = rt.VmVariantList(0)
-
-    def push_tensor_to_arg_list(arg_tensor: torch.Tensor):
-        if not arg_tensor.is_contiguous():
-            arg_tensor = arg_tensor.contiguous()
-        capsule = torch.to_dlpack(arg_tensor)
-        arg_tensor_bv = device.from_dlpack_capsule(capsule)
-
-        # IREE runtime renames capsule to "dltensor_used" for some reason, but
-        # only deletes capsules with "dltensor" name, which is causing a memory
-        # leak.
-        _set_capsule_name(ctypes.py_object(capsule), _dl_tensor_name)
-        arg_list.push_ref(arg_tensor_bv)
-
-    # Linearize arguments, In linearized arg_list, we first push in all inputs,
-    # then all the outputs, and lastly all the dynamic dims.
-    for input in inputs:
-        if isinstance(input, torch.Tensor):
-            push_tensor_to_arg_list(input)
-        else:
-            raise ValueError(f"Unsupported input type: {type(input)}")
-    for output in outputs:
-        if isinstance(output, torch.Tensor):
-            push_tensor_to_arg_list(output)
-        else:
-            raise ValueError(f"Unsupported output type: {type(output)}")
-    # we want scalars to be at the end during codegen/dispatch to iree
-    # to maintain the consistency.
-    for input in inputs:
-        if isinstance(input, (float, int)):
-            # arg_list.push_float(input)
-            # Currently, `push_float` is not working on the iree side.
-            raise NotImplementedError("Float inputs are not supported.")
-
-    for dynamic_dim in dynamic_dims:
-        if isinstance(dynamic_dim, int):
-            arg_list.push_int(dynamic_dim)
-        else:
-            raise ValueError(f"Unsupported dynamic dim type: {type(dynamic_dim)}")
-
-    try:
-        vm_context.invoke(entry_function, arg_list, ret_list)
-    except ValueError as e:
-        raise RuntimeError(
-            f"Error invoking IREE\n{entry_function}\n"
-            f"{arg_list=}\n"
-            f"inputs: {', '.join([str(i.shape) for i in inputs])}\n"
-            f"outputs: {', '.join([str(o.shape) for o in outputs])}"
-        ) from e
-
-
-def _print_bench_result(result, filename):
+def print_bench_result(result, filename):
     import json
 
     res = json.dumps(result, sort_keys=True, indent=4)
@@ -148,84 +63,6 @@ def _print_bench_result(result, filename):
         _write_file(filename, "w", res)
     else:
         print(res)
-
-
-def invoke_vmfb(
-    vmfb: bytes,
-    options: WaveCompileOptions,
-    kernel_inputs: list[torch.Tensor],
-    kernel_outputs: list[torch.Tensor],
-):
-    device = options.device
-    if options.run_bench:
-        benchmark_flags = {}
-        # If we use 1000 for bench_batch_size during compilation, and set this batch size to 1,
-        # then the latency is in milliseconds.
-        benchmark_flags["batch_size"] = 1
-
-        if options.benchmark_repetitions is not None:
-            benchmark_flags["benchmark_repetitions"] = int(
-                options.benchmark_repetitions
-            )
-
-    if options.inplace:
-        # Select device as the GPU, where input tensors are coming from.
-        device_list = tuple(
-            input.device
-            for input in kernel_inputs + kernel_outputs
-            if isinstance(input, torch.Tensor)
-        )
-        device = get_device_uuid(device_list, device)
-
-    rt_config = rt.Config(device)
-    device = rt_config.device
-    vm_instance = rt_config.vm_instance
-
-    if options.kernel_hash and options.kernel_hash in RUNTIME_CACHE:
-        ctx, func = RUNTIME_CACHE[options.kernel_hash]
-    else:
-        mod = rt.VmModule.copy_buffer(vm_instance, vmfb)
-        vm_modules = [
-            mod,
-            rt.create_hal_module(vm_instance, device),
-        ]
-        ctx = rt.SystemContext(
-            vm_modules=vm_modules,
-            config=rt_config,
-        )
-        func = mod.lookup_function(options.func_name)
-        if options.kernel_hash:
-            RUNTIME_CACHE[options.kernel_hash] = (ctx, func)
-
-    if options.inplace:
-        _inplace_invoke(
-            ctx.vm_context,
-            device,
-            func,
-            kernel_inputs,
-            kernel_outputs,
-            options.dynamic_symbols_map.values(),
-        )
-    else:
-        _invoke(
-            ctx.vm_context,
-            device,
-            func,
-            kernel_inputs,
-            kernel_outputs,
-            options.dynamic_symbols_map.values(),
-        )
-
-    if options.run_bench:
-        benchmark_results = benchmark_module(
-            options,
-            kernel_inputs,
-            kernel_outputs,
-            vmfb,
-            options.func_name,
-            **benchmark_flags,
-        )
-        _print_bench_result(benchmark_results, options.bench_file)
 
 
 def invoke_with_wave_runtime(
@@ -273,21 +110,6 @@ def invoke_with_wave_runtime(
     dyn_dims = wave_runtime.Int64Vector(dynamic_dims)
     # Launch the kernel.
     wave_runtime.launch(kernel_launch_info, kernel_args, dyn_dims, scalar_args)
-
-
-def compile_and_invoke(
-    asm: str,
-    kernel_inputs: list[torch.Tensor],
-    kernel_outputs: list[torch.Tensor],
-    options: WaveCompileOptions,
-):
-    compiled_wave_vmfb = compile_to_vmfb(asm, options)
-    invoke_vmfb(
-        compiled_wave_vmfb,
-        options,
-        kernel_inputs,
-        kernel_outputs,
-    )
 
 
 def get_default_arch() -> str:

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -155,12 +155,7 @@ def invoke_vmfb(
     options: WaveCompileOptions,
     kernel_inputs: list[torch.Tensor],
     kernel_outputs: list[torch.Tensor],
-    gpu_func: Optional[Any] = None,
 ):
-    if options.wave_runtime:
-        invoke_with_wave_runtime(options, kernel_inputs, kernel_outputs, gpu_func)
-        return
-
     device = options.device
     if options.run_bench:
         benchmark_flags = {}
@@ -234,10 +229,10 @@ def invoke_vmfb(
 
 
 def invoke_with_wave_runtime(
+    gpu_func: Any,
     options: WaveCompileOptions,
     kernel_inputs: list[torch.Tensor],
     kernel_outputs: list[torch.Tensor],
-    gpu_func: Any,
 ):
     """
     Invokes the kernel with the wave runtime.

--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -523,7 +523,8 @@ def _device_import_torch_tensor_cuda_hip(
     # TODO: The 'None' here tells the producer to synchronize on the default
     # stream. For async, we should advance our timeline and signal when an
     # event is raised on Torch's stream at the current position.
-    capsule = t.__dlpack__(None)
+    # capsule = t.__dlpack__(None)
+    capsule = torch.to_dlpack(t)
     bv = device.hal_device.from_dlpack_capsule(capsule)
     # TODO: iree runtime renames the capsule to `dltensor_used`, but doesn't free up the renamed capsule.
     # Instead of renaming the capsule so it gets freed, we should address the bug in iree-runtime.

--- a/tests/kernel/wave/attention/chained_gemm_test.py
+++ b/tests/kernel/wave/attention/chained_gemm_test.py
@@ -171,7 +171,7 @@ def testChainedGemm(
             print(f"IR dumped to {filename}")
 
     iree_ref = device_zeros(batch, v_head_dim, q_seq_len, dtype=torch.float32)
-    generate_iree_ref("chain_mmt", [q, k, v], [iree_ref], options)
+    generate_iree_ref("chain_mmt", [q, k, v], [iree_ref])
     assert_close(output, iree_ref, check_device=False, atol=0, rtol=0)
 
     torch_qk = torch.matmul(q, k.transpose(-1, -2))
@@ -322,5 +322,5 @@ def testChainedGemmF8(
             f.write(asm)
 
     iree_ref = device_zeros(batch, v_head_dim, q_seq_len, dtype=torch.float32)
-    generate_iree_ref("chain_mmt_f8", [q, k, v], [iree_ref], options)
+    generate_iree_ref("chain_mmt_f8", [q, k, v], [iree_ref])
     assert_close(output, iree_ref, atol=7e-5, rtol=2e-3, check_device=False)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1680,7 +1680,6 @@ def test_scalar_codegen(shape, tkl_dtype, torch_dtype, arg_vals, request):
         },
         canonicalize=True,
         run_bench=run_bench,
-        inplace=False,
         wave_runtime=True,
     )
     test = wave_compile(options, test)

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1557,9 +1557,6 @@ def test_igemm_conv(
             "conv_2d_" + layout,
             [x, we],
             [iree_ref],
-            options,
-            stride=stride,
-            run_bench=True,
         )
 
 

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -210,7 +210,7 @@ def testPureGemm(
                 dump_perf, "iree_" + perf_filename
             )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
-    generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
 
 
@@ -328,7 +328,7 @@ def testPingPongGemm(
                 dump_perf, "iree_" + perf_filename
             )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
-    generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
 
 
@@ -478,7 +478,7 @@ def testGemmDot(
                 dump_perf, "iree_" + perf_filename
             )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
-    generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False, atol=1e-3, rtol=1e-3)
 
 
@@ -621,7 +621,7 @@ def testVMFMAGemm(
             dump_perf, "iree_" + request.node.name + ".json"
         )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
-    generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, atol=2e-4, rtol=3e-4, check_device=False)
 
 
@@ -766,7 +766,7 @@ def testCDNA2IntGemm(
             dump_perf, "iree_" + request.node.name + ".json"
         )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.int32)
-    generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
 
 
@@ -879,7 +879,7 @@ def testCDNA3IntGemm(
             dump_perf, "iree_" + request.node.name + ".json"
         )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.int32)
-    generate_iree_ref("mmt", [a, b], [iree_ref], options)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
 
 
@@ -989,7 +989,7 @@ def testF8Gemm(
             dump_perf, "iree_" + request.node.name + ".json"
         )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
-    generate_iree_ref("mmt_f8", [a, b], [iree_ref], options)
+    generate_iree_ref("mmt_f8", [a, b], [iree_ref])
     assert_close(c, iree_ref, atol=3e-5, rtol=3e-4, check_device=False)
 
 
@@ -1094,7 +1094,7 @@ def testBatchedGemm(shape: tuple[int], enable_scheduling: SchedulingType, reques
             dump_perf, "iree_" + request.node.name + ".json"
         )
     iree_ref = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-    generate_iree_ref("bmmt", [a, b], [iree_ref], options)
+    generate_iree_ref("bmmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
 
     torch_ref = torch.matmul(a, b.transpose(-2, -1))
@@ -1206,7 +1206,7 @@ def testSequentialBatchedGemm(
             dump_perf, "iree_" + request.node.name + ".json"
         )
     iree_ref = device_zeros(shape[0], shape[1], shape[2], dtype=torch.float32)
-    generate_iree_ref("bmmt", [a, b], [iree_ref], options)
+    generate_iree_ref("bmmt", [a, b], [iree_ref])
     assert_close(c, iree_ref, check_device=False)
 
     torch_ref = torch.matmul(a, b.transpose(-2, -1))


### PR DESCRIPTION
An experiment to switch Wave to `turbine.runtime` instead of half-baked homemade iree wrappers. Surprisingly, mostly worked out of the box. Didn't test async path yet. Didn't test call overhead yet either, but amount of python code doesn't give much optimism.