### PR TITLE
[Wave] Fix IREE reference failing with wrong signature

### DIFF
--- a/iree/turbine/kernel/wave/iree_utils.py
+++ b/iree/turbine/kernel/wave/iree_utils.py
@@ -202,6 +202,7 @@ def generate_iree_ref(
 
     options.func_name = kernel_type
     options.inplace = False
+    options.kernel_hash = None
     options.dynamic_symbols_map = {}
     compile_and_invoke(
         asm,


### PR DESCRIPTION
Sometime on new machine kernel hashes set for the Wave kernel bleeds into the kernel has option for the iree reference. This makes our pipeline try to call th Wave kernel again instead of the IREE reference vmfb. This shows up as invalid signature, since we are trying to call a inplace vmfb on a non inplace invoke. We can also see that the function name instead of the iree kernel_type will be `isolated_benchmark`

entry_function = <VmFunction isolated_benchmark(0rrrIII_r), reflection = {'iree.abi.declaration': 'sync func @isolated_benchmark(%input...r<?x?xf16>, %input2: tensor<?x?xf32>, %input3: index, %input4: index, %input5: index) -> (%output0: tensor<?x?xf32>)'}>

>       vm_context.invoke(entry_function, arg_list, ret_list)
E       ValueError: Error invoking function: c/runtime/src/iree/vm/invocation.c:95: INVALID_ARGUMENT; input list and function mismatch; expected 6 arguments but passed 2