### PR TITLE
[Wave] Align variable names in speculative decode kernel

### DIFF
--- a/iree/turbine/kernel/wave/templates/speculative_decoding.py
+++ b/iree/turbine/kernel/wave/templates/speculative_decoding.py
@@ -7,39 +7,49 @@
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.constraints import MMAType
-from .attention_common import AttentionShape
-from dataclasses import dataclass
-import math
 import sympy
 
 
 def get_speculative_decoding_kernel(
     batch_size: int,
     num_draft_tokens: int,
-    d: int,
+    vocab_size: int,
     seq_len: int,
 ):
-
-    B = tkl.sym.B
-    N = tkl.sym.N
-    D = tkl.sym.D
-    S = tkl.sym.S
-    BLOCK_D = tkl.sym.BLOCK_D
-    BLOCK_B = tkl.sym.BLOCK_B
-    BLOCK_N = tkl.sym.BLOCK_N
+    BATCH_SIZE = tkl.sym.BATCH_SIZE
+    NUM_DRAFT_TOKENS = tkl.sym.NUM_DRAFT_TOKENS
+    VOCAB_SIZE = tkl.sym.VOCAB_SIZE
+    SEQ_LEN = tkl.sym.SEQ_LEN
+    BLOCK_BATCH_SIZE = tkl.sym.BLOCK_BATCH_SIZE
+    BLOCK_NUM_DRAFT_TOK = tkl.sym.BLOCK_NUM_DRAFT_TOK
+    BLOCK_VOCAB_SIZE = tkl.sym.BLOCK_VOCAB_SIZE
     LAST_OFFSET = tkl.sym.LAST_OFFSET
     LAST_IDX = tkl.sym.LAST_IDX
 
-    constraints = [tkw.WorkgroupConstraint(D, BLOCK_D, 0)]
-    constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 1)]
-    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1, primary=False)]
-    constraints += [tkw.WaveConstraint(D, BLOCK_D)]
+    hyperparams = {
+        BATCH_SIZE: batch_size,
+        NUM_DRAFT_TOKENS: num_draft_tokens,
+        VOCAB_SIZE: vocab_size,
+        SEQ_LEN: seq_len,
+        BLOCK_BATCH_SIZE: 1,
+        BLOCK_NUM_DRAFT_TOK: 1,
+        BLOCK_VOCAB_SIZE: 64,
+    }
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+
+    constraints = [tkw.WorkgroupConstraint(VOCAB_SIZE, BLOCK_VOCAB_SIZE, 0)]
+    constraints += [tkw.WorkgroupConstraint(BATCH_SIZE, BLOCK_BATCH_SIZE, 1)]
+    constraints += [
+        tkw.WorkgroupConstraint(NUM_DRAFT_TOKENS, BLOCK_NUM_DRAFT_TOK, 1, primary=False)
+    ]
+    constraints += [tkw.WaveConstraint(VOCAB_SIZE, BLOCK_VOCAB_SIZE)]
     constraints += [
         tkw.HardwareConstraint(
             threads_per_wave=64,
             waves_per_block=(1, 1, 1),
-            vector_shapes={B: 0, N: 0, D: 64},
+            vector_shapes={BATCH_SIZE: 0, NUM_DRAFT_TOKENS: 0, VOCAB_SIZE: 64},
         )
     ]
 
@@ -48,36 +58,44 @@ def get_speculative_decoding_kernel(
     k = tkw.IndexMapping.iterator(2)
     q_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={B: i, N: LAST_OFFSET, D: k},
-        outputs={B: i, N: j, D: k},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: LAST_OFFSET, VOCAB_SIZE: k},
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j, VOCAB_SIZE: k},
     )
 
     p_mapping = tkw.IndexMapping(
         num_iterators=3,
-        inputs={B: i, N: LAST_OFFSET, D: k},
-        outputs={B: i, N: j, D: k},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: LAST_OFFSET, VOCAB_SIZE: k},
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j, VOCAB_SIZE: k},
     )
 
     uniform_mapping = tkw.IndexMapping(
         num_iterators=2,
-        inputs={B: i, D: sympy.Integer(0)},
-        outputs={B: i, D: j},
+        inputs={BATCH_SIZE: i, VOCAB_SIZE: sympy.Integer(0)},
+        outputs={BATCH_SIZE: i, VOCAB_SIZE: j},
     )
 
     o_mapping = tkw.IndexMapping(
         num_iterators=2,
-        inputs={B: i, N: j},
-        outputs={S: LAST_IDX},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j},
+        outputs={SEQ_LEN: LAST_IDX},
     )
 
     @tkw.wave(constraints)
     def tree_speculative_sampling(
-        q: tkl.Memory[B, N, D, GLOBAL_ADDRESS_SPACE, tkl.f32],
-        p: tkl.Memory[B, N, D, GLOBAL_ADDRESS_SPACE, tkl.f32],
-        cur_prob_offset: tkl.Memory[B, GLOBAL_ADDRESS_SPACE, tkl.i32],
-        uniform_sample: tkl.Memory[B, D, GLOBAL_ADDRESS_SPACE, tkl.f32],
-        last_accepted_retrive_idx_vec: tkl.Memory[B, GLOBAL_ADDRESS_SPACE, tkl.i32],
-        predicts: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        q: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, GLOBAL_ADDRESS_SPACE, tkl.f32
+        ],
+        p: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, GLOBAL_ADDRESS_SPACE, tkl.f32
+        ],
+        cur_prob_offset: tkl.Memory[BATCH_SIZE, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        uniform_sample: tkl.Memory[
+            BATCH_SIZE, VOCAB_SIZE, GLOBAL_ADDRESS_SPACE, tkl.f32
+        ],
+        last_accepted_retrive_idx_vec: tkl.Memory[
+            BATCH_SIZE, GLOBAL_ADDRESS_SPACE, tkl.i32
+        ],
+        predicts: tkl.Memory[SEQ_LEN, GLOBAL_ADDRESS_SPACE, tkl.i32],
     ):
         last_offset = tkw.read(cur_prob_offset, elements_per_thread=1)
         tkw.set_symbol(LAST_OFFSET, last_offset)
@@ -96,35 +114,26 @@ def get_speculative_decoding_kernel(
         coin = tkw.read(uniform_sample, mapping=uniform_mapping)
         diff = q_reg - p_reg
 
-        zero = tkl.Register[D, tkl.f32](0.0)
+        zero = tkl.Register[VOCAB_SIZE, tkl.f32](0.0)
         relu_diff = tkw.maximum(diff, zero)
-        sum_relu = tkw.sum(relu_diff, dim=D)
-        cdf = tkw.cumsum(relu_diff, dim=D)
+        sum_relu = tkw.sum(relu_diff, dim=VOCAB_SIZE)
+        cdf = tkw.cumsum(relu_diff, dim=VOCAB_SIZE)
 
-        u = tkw.broadcast(coin * sum_relu, target_shape=[B, N, D])
+        u = tkw.broadcast(
+            coin * sum_relu, target_shape=[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE]
+        )
         greater_than_u = cdf > u
-        pad_token = tkl.Register[B, N, D, tkl.i32](1e6)
-        token_idx = tkl.Register[B, N, D, tkl.i32](THREAD_0)
+        pad_token = tkl.Register[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.i32](1e6)
+        token_idx = tkl.Register[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.i32](
+            THREAD_0
+        )
 
         # TODO: Set default sampled_id = d - 1, if no valid token can be found
         #       We can implement with `ballot(greater_than_u)` and early exit
         #       /return d-1 if output are all zeros.
         valid_lane_token_idx = tkw.select(greater_than_u, token_idx, pad_token)
-        min_valid_token_idx = tkw.min(valid_lane_token_idx, dim=D)
+        min_valid_token_idx = tkw.min(valid_lane_token_idx, dim=VOCAB_SIZE)
         tkw.write(min_valid_token_idx, predicts, mapping=o_mapping)
-
-    hyperparams = {
-        BLOCK_B: 1,
-        BLOCK_N: 1,
-        BLOCK_D: 64,
-        B: batch_size,
-        N: num_draft_tokens,
-        D: d,
-        S: seq_len,
-    }
-
-    dynamic_symbols = []
-    dynamic_symbols_map = {}
 
     return tree_speculative_sampling, hyperparams, dynamic_symbols, dynamic_symbols_map
 
@@ -135,98 +144,115 @@ def get_speculative_sampling_kernel(
     threshold_acc: float,
     threshold_single: float,
     num_draft_tokens: int,
-    d: int,
+    vocab_size: int,
 ):
     CUR_INDEX = sympy.Symbol("CUR_INDEX")
     J = sympy.Symbol("J")
-    B = tkl.sym.B
-    S = tkl.sym.S
-    D = tkl.sym.D
-    BLOCK_B = tkl.sym.BLOCK_B
-    BLOCK_S = tkl.sym.BLOCK_S
+    BATCH_SIZE = tkl.sym.BATCH_SIZE
+    NUM_DRAFT_TOKENS = tkl.sym.NUM_DRAFT_TOKENS
+    VOCAB_SIZE = tkl.sym.VOCAB_SIZE
+    BLOCK_BATCH_SIZE = tkl.sym.BLOCK_BATCH_SIZE
+    BLOCK_NUM_DRAFT_TOK = tkl.sym.BLOCK_NUM_DRAFT_TOK
     ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
     ADDRESS_SPACE_0 = tkl.sym.ADDRESS_SPACE_0
+
+    hyperparams = {
+        BLOCK_NUM_DRAFT_TOK: 1,
+        NUM_DRAFT_TOKENS: num_draft_tokens,
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        BATCH_SIZE: batch_size,
+        BLOCK_BATCH_SIZE: 1,
+        VOCAB_SIZE: vocab_size,
+    }
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
 
     constraints: list[tkw.Constraint] = [
         tkw.HardwareConstraint(
             threads_per_wave=64,
             waves_per_block=(1, 1, 1),
-            vector_shapes={B: num_draft_tokens, J: 0, CUR_INDEX: 0, S: 0, D: d},
+            vector_shapes={
+                NUM_DRAFT_TOKENS: num_draft_tokens,
+                J: 0,
+                CUR_INDEX: 0,
+                BATCH_SIZE: 0,
+                VOCAB_SIZE: vocab_size,
+            },
         )
     ]
-    constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 0)]
+    constraints += [tkw.WorkgroupConstraint(BATCH_SIZE, BLOCK_BATCH_SIZE, 0)]
     constraints += [tkw.TilingConstraint(CUR_INDEX)]
     constraints += [tkw.TilingConstraint(J)]
-
-    hyperparams = {
-        BLOCK_B: 1,
-        B: num_draft_tokens,
-        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
-        ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
-        S: batch_size,
-        BLOCK_S: 1,
-        D: d,
-    }
-    dynamic_symbols = []
-    dynamic_symbols_map = {}
 
     CUR_PROB_OFFSET = tkl.sym.CUR_PROB_OFFSET
     DRAFT_TOKEN_ID = tkl.sym.DRAFT_TOKEN_ID
     NUM_ACCEPTED_TOKENS = tkl.sym.NUM_ACCEPTED_TOKENS
     LAST_ACCEPTED_RETRIEVE_IDX = tkl.sym.LAST_ACCEPTED_RETRIEVE_IDX
+
     i = tkw.IndexMapping.iterator(0)
     j = tkw.IndexMapping.iterator(1)
     k = tkw.IndexMapping.iterator(2)
+
     mapping_2d = tkw.IndexMapping(
         num_iterators=2,
-        inputs={S: i, B: CUR_INDEX},
-        outputs={S: i, B: j},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: CUR_INDEX},
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j},
     )
 
     mapping_3d = tkw.IndexMapping(
         num_iterators=3,
-        inputs={S: i, B: CUR_PROB_OFFSET, D: DRAFT_TOKEN_ID},
-        outputs={S: i, B: j, D: k},
+        inputs={
+            BATCH_SIZE: i,
+            NUM_DRAFT_TOKENS: CUR_PROB_OFFSET,
+            VOCAB_SIZE: DRAFT_TOKEN_ID,
+        },
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j, VOCAB_SIZE: k},
     )
 
     mapping_3d_2 = tkw.IndexMapping(
         num_iterators=3,
-        inputs={S: i, B: CUR_INDEX, D: DRAFT_TOKEN_ID},
-        outputs={S: i, B: j, D: k},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: CUR_INDEX, VOCAB_SIZE: DRAFT_TOKEN_ID},
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j, VOCAB_SIZE: k},
     )
 
     read_zero_offset_2d_mapping = tkw.IndexMapping(
         num_iterators=2,
-        inputs={S: i, B: sympy.Integer(0)},
-        outputs={S: i, B: j},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: sympy.Integer(0)},
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j},
     )
 
     write_mapping_2d = tkw.IndexMapping(
         num_iterators=2,
-        inputs={S: i, B: j},
-        outputs={S: i, B: NUM_ACCEPTED_TOKENS},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j},
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: NUM_ACCEPTED_TOKENS},
     )
 
     write_mapping_1d = tkw.IndexMapping(
         num_iterators=2,
-        inputs={S: i, B: j},
-        outputs={B: LAST_ACCEPTED_RETRIEVE_IDX},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j},
+        outputs={NUM_DRAFT_TOKENS: LAST_ACCEPTED_RETRIEVE_IDX},
     )
 
     write_mapping_3d = tkw.IndexMapping(
         num_iterators=3,
-        inputs={S: i, B: j, D: k},
-        outputs={S: i, B: CUR_INDEX, D: DRAFT_TOKEN_ID},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j, VOCAB_SIZE: k},
+        outputs={
+            BATCH_SIZE: i,
+            NUM_DRAFT_TOKENS: CUR_INDEX,
+            VOCAB_SIZE: DRAFT_TOKEN_ID,
+        },
     )
 
     write_zero_offset_mapping = tkw.IndexMapping(
         num_iterators=2,
-        inputs={S: i, B: j},
-        outputs={S: i, B: sympy.Integer(0)},
+        inputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: j},
+        outputs={BATCH_SIZE: i, NUM_DRAFT_TOKENS: sympy.Integer(0)},
     )
 
     def broadcast(x):
-        return tkw.broadcast(x, target_shape=[S, B, D])
+        return tkw.broadcast(x, target_shape=[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE])
 
     def read_2d(x):
         return tkw.read(x, elements_per_thread=1, mapping=mapping_2d)
@@ -259,36 +285,72 @@ def get_speculative_sampling_kernel(
     cur_prob_offset_vec_layout = tkl.MemoryLayout(shape=[batch_size, 1, 1])
     last_accepted_retrieve_idx_vec_layout = tkl.MemoryLayout(shape=[batch_size, 1, 1])
     predict_layout = tkl.MemoryLayout(shape=[batch_size * num_draft_tokens])
+
     # Kernel.
     # =================================================================================
     @tkw.wave(constraints)
     def speculative_sampling(
-        uniform_samples: tkl.Memory[S, B, ADDRESS_SPACE_0, tkl.f32],
-        target_probs: tkl.Memory[S, B, D, ADDRESS_SPACE_0, tkl.f32],
-        draft_probs: tkl.Memory[S, B, D, ADDRESS_SPACE_0, tkl.f32],
-        candidates: tkl.Memory[S, B, ADDRESS_SPACE_0, tkl.i32],
-        retrieve_index: tkl.Memory[S, B, ADDRESS_SPACE_0, tkl.i32],
-        retrieve_next_token: tkl.Memory[S, B, ADDRESS_SPACE_0, tkl.i32],
-        retrieve_next_sibling: tkl.Memory[S, B, ADDRESS_SPACE_0, tkl.i32],
-        # Outputs
-        predicts: tkl.Memory[B, ADDRESS_SPACE_0, tkl.i32, predict_layout],
-        accept_token_num: tkl.Memory[
-            S, B, D, ADDRESS_SPACE_0, tkl.i32, accept_token_num_layout
+        uniform_samples: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, ADDRESS_SPACE_0, tkl.f32
         ],
-        accept_index: tkl.Memory[S, B, ADDRESS_SPACE_0, tkl.i32, accept_index_layout],
+        target_probs: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, ADDRESS_SPACE_0, tkl.f32
+        ],
+        draft_probs: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, ADDRESS_SPACE_0, tkl.f32
+        ],
+        candidates: tkl.Memory[BATCH_SIZE, NUM_DRAFT_TOKENS, ADDRESS_SPACE_0, tkl.i32],
+        retrieve_index: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, ADDRESS_SPACE_0, tkl.i32
+        ],
+        retrieve_next_token: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, ADDRESS_SPACE_0, tkl.i32
+        ],
+        retrieve_next_sibling: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, ADDRESS_SPACE_0, tkl.i32
+        ],
+        # Outputs
+        predicts: tkl.Memory[
+            NUM_DRAFT_TOKENS, ADDRESS_SPACE_0, tkl.i32, predict_layout
+        ],
+        accept_token_num: tkl.Memory[
+            BATCH_SIZE,
+            NUM_DRAFT_TOKENS,
+            VOCAB_SIZE,
+            ADDRESS_SPACE_0,
+            tkl.i32,
+            accept_token_num_layout,
+        ],
+        accept_index: tkl.Memory[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, ADDRESS_SPACE_0, tkl.i32, accept_index_layout
+        ],
         cur_prob_offset_vec: tkl.Memory[
-            S, B, D, ADDRESS_SPACE_0, tkl.i32, cur_prob_offset_vec_layout
+            BATCH_SIZE,
+            NUM_DRAFT_TOKENS,
+            VOCAB_SIZE,
+            ADDRESS_SPACE_0,
+            tkl.i32,
+            cur_prob_offset_vec_layout,
         ],
         last_accepted_retrieve_idx_vec: tkl.Memory[
-            S, B, D, ADDRESS_SPACE_0, tkl.i32, last_accepted_retrieve_idx_vec_layout
+            BATCH_SIZE,
+            NUM_DRAFT_TOKENS,
+            VOCAB_SIZE,
+            ADDRESS_SPACE_0,
+            tkl.i32,
+            last_accepted_retrieve_idx_vec_layout,
         ],
     ):
-        one = tkw.Register[S, B, D, tkl.i32](1)
-        zero = tkw.Register[S, B, D, tkl.i32](0)
-        zero_f32 = tkw.Register[S, B, D, tkl.f32](0.0)
+        one = tkw.Register[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.i32](1)
+        zero = tkw.Register[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.i32](0)
+        zero_f32 = tkw.Register[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.f32](0.0)
 
-        threshold_acc_reg = tkw.Register[S, B, D, tkl.f32](threshold_acc)
-        threshold_single_reg = tkw.Register[S, B, D, tkl.f32](threshold_single)
+        threshold_acc_reg = tkw.Register[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.f32
+        ](threshold_acc)
+        threshold_single_reg = tkw.Register[
+            BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.f32
+        ](threshold_single)
 
         outer_loop_condition = (J < num_speculative_tokens) & (
             sympy.Eq(GET_ITER_ARG(6), 0)
@@ -299,7 +361,8 @@ def get_speculative_sampling_kernel(
         last_accepted_retrieve_idx = read_with_zero_offset_2d(retrieve_index)
         write_with_zero_offset(last_accepted_retrieve_idx, accept_index)
         last_accepted_retrieve_idx = tkw.broadcast(
-            last_accepted_retrieve_idx, target_shape=[S, B, D]
+            last_accepted_retrieve_idx,
+            target_shape=[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE],
         )
 
         @tkw.iterate(
@@ -328,7 +391,7 @@ def get_speculative_sampling_kernel(
 
             tkw.set_symbol(CUR_INDEX, cur_index)
             cur_index = read_2d(retrieve_next_token)
-            zero = tkw.Register[S, B, D, tkl.i32](0)
+            zero = tkw.Register[BATCH_SIZE, NUM_DRAFT_TOKENS, VOCAB_SIZE, tkl.i32](0)
 
             @tkw.iterate(
                 CUR_INDEX,

--- a/lit_tests/kernel/wave/speculative_decoding.py
+++ b/lit_tests/kernel/wave/speculative_decoding.py
@@ -24,7 +24,7 @@ def test_speculative_decoding():
         threshold_single=0.01,
         threshold_acc=0.01,
         num_draft_tokens=6,
-        d=20,
+        vocab_size=20,
     )
 
     # Create the kernel with the hyperparameters


### PR DESCRIPTION
1. refactored variable names to be in sync across speculative decode and speculative sampling kernels