### PR TITLE
[TKW] Update decode

### DIFF
--- a/iree/turbine/kernel/lang/wave_types.py
+++ b/iree/turbine/kernel/lang/wave_types.py
@@ -208,9 +208,9 @@ class IndexMapping:
                 continue
 
             current = iter_shape[i]
-            # assert (
-            #     current is None or current == sym
-            # ), f"Iterator conflict: {current} and {sym}"
+            assert (
+                current is None or current == sym
+            ), f"Iterator conflict: {current} and {sym}"
             iter_shape[i] = sym
 
         assert all(

--- a/iree/turbine/kernel/lang/wave_types.py
+++ b/iree/turbine/kernel/lang/wave_types.py
@@ -208,9 +208,9 @@ class IndexMapping:
                 continue
 
             current = iter_shape[i]
-            assert (
-                current is None or current == sym
-            ), f"Iterator conflict: {current} and {sym}"
+            # assert (
+            #     current is None or current == sym
+            # ), f"Iterator conflict: {current} and {sym}"
             iter_shape[i] = sym
 
         assert all(

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -235,13 +235,6 @@ def get_paged_decode_attention_kernels(
         dynamic_val_mappings={SPLIT_ITER: l},
     )
 
-    # Returns token indices into the k-v cache for the given sequence (d0).
-    kv_indices_mapping = tkw.IndexMapping(
-        num_iterators=1,
-        inputs={SPLIT_ITER: i},
-        outputs={SPLIT_ITER: i},
-    )
-
     # The kv-cache layout here is (SEQ, HEADS, HEAD_DIM).
     @tkw.wave(get_constraints(Phase.PHASE_0))
     def phase_0(
@@ -306,14 +299,8 @@ def get_paged_decode_attention_kernels(
             acc: tkl.Register[S, N, B, tkl.f32],
         ):
             q_reg = tkw.read(q)  # [S, B, K1] NxK
-            block_indices_v = tkw.read(
-                kv_indices,
-                mapping=kv_indices_mapping,
-            )
-            block_indices_k = tkw.read(
-                kv_indices,
-                mapping=kv_indices_mapping,
-            )
+            block_indices_v = tkw.read(kv_indices)
+            block_indices_k = tkw.read(kv_indices)
             k_reg = tkw.read(
                 k,
                 mapping=k_mapping,

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -290,6 +290,7 @@ def get_paged_decode_attention_kernels(
             lambda x, y, z: sympy.Min(x, sympy.Max(y - z, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
+        tkw.set_symbol(K2, seq_length_per_split)
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(
@@ -423,7 +424,7 @@ def get_paged_decode_attention_kernels(
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
     dynamic_symbols = [K2, S]
     dynamic_symbols_map = {
-        K2: shape.kv_lens,
+        # K2: shape.kv_lens,
         S: shape.num_seqs,
     }
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -8,7 +8,7 @@ import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel.wave.constraints import MMAType
-from iree.turbine.kernel.wave.utils.general_utils import torch_dtype_to_wave
+from iree.turbine.kernel.wave.utils.general_utils import clamp, torch_dtype_to_wave
 import sympy
 from enum import Enum
 from collections import namedtuple

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -290,9 +290,7 @@ def get_paged_decode_attention_kernels(
             lambda x, y, z: sympy.Min(x, sympy.Max(y - z, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
-
-        seq_length_per_split = tkw.cast(seq_length_per_split, tkl.i32)
-        tkw.set_symbol(K2, split_offset + seq_length_per_split)
+        tkw.set_symbol(K2, seq_length_per_split)
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(
@@ -426,7 +424,7 @@ def get_paged_decode_attention_kernels(
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
     dynamic_symbols = [K2, S]
     dynamic_symbols_map = {
-        # K2: shape.kv_lens,
+        K2: shape.kv_lens,
         S: shape.num_seqs,
     }
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -49,7 +49,7 @@ def get_paged_decode_attention_kernels(
     N = tkl.sym.N
     K1 = tkl.sym.K1
     K2 = tkl.sym.K2
-    K3 = tkl.sym.K3
+    KV_LENS = tkl.sym.KV_LENS
     SEQ_LEN = tkl.sym.SEQ_LEN
     KV_START_IDX = tkl.sym.KV_START_IDX
     SPLIT_OFF = tkl.sym.SPLIT_OFF
@@ -222,7 +222,7 @@ def get_paged_decode_attention_kernels(
     # Returns the key for the given token index.
     k_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // K3, BH: j, K2: d0 % K3, K1: l},
+        inputs={S: d0 // KV_LENS, BH: j, K2: d0 % KV_LENS, K1: l},
         outputs={S: i, BH: j, K2: k, K1: l},
         dynamic_val_mappings={K2: k},
     )
@@ -230,7 +230,7 @@ def get_paged_decode_attention_kernels(
     # Returns the value for the given token index.
     v_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // K3, BH: j, N: k, K2: d0 % K3},
+        inputs={S: d0 // KV_LENS, BH: j, N: k, K2: d0 % KV_LENS},
         outputs={S: i, BH: j, N: k, K2: l},
         dynamic_val_mappings={K2: l},
     )
@@ -431,10 +431,10 @@ def get_paged_decode_attention_kernels(
     symbols_1 = dict(symbols_0)
     symbols_1[BLOCK_B] = PHASE_1_BLOCK_B
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
-    dynamic_symbols = [K2, K3, S]
+    dynamic_symbols = [K2, KV_LENS, S]
     dynamic_symbols_map = {
         K2: shape.kv_lens,
-        K3: shape.kv_lens,
+        KV_LENS: shape.kv_lens,
         S: shape.num_seqs,
     }
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -324,7 +324,9 @@ def get_paged_decode_attention_kernels(
             x_j = tkw.permute(inner_acc, target_shape=[S, B, K2])
             x_j = x_j * layer_scale_reg
             k2_index = tkw.self_index(K2, tkl.i32)
-            mask = tkw.apply_expr(k2_index, lambda x: x < (SPLIT_OFF + SPLIT_LEN))
+            mask = tkw.apply_expr(
+                k2_index, lambda x: x < (SPLIT_OFF + SPLIT_LEN + KV_START_IDX)
+            )
             mask = tkw.broadcast(mask, target_shape=[B, K2])
             mask = tkw.cast(mask, tkw.i1)
             bias = tkw.select(mask, zero, neg_infinity)

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -48,8 +48,8 @@ def get_paged_decode_attention_kernels(
     B = tkl.sym.B
     N = tkl.sym.N
     K1 = tkl.sym.K1
+    K2 = tkl.sym.K2
     SPLIT_ITER = tkl.sym.SPLIT_ITER
-    KV_LENS = tkl.sym.KV_LENS
     SEQ_LEN = tkl.sym.SEQ_LEN
     KV_START_IDX = tkl.sym.KV_START_IDX
     SPLIT_OFF = tkl.sym.SPLIT_OFF
@@ -222,7 +222,7 @@ def get_paged_decode_attention_kernels(
     # Returns the key for the given token index.
     k_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // KV_LENS, BH: j, SPLIT_ITER: d0 % KV_LENS, K1: l},
+        inputs={S: d0 // K2, BH: j, SPLIT_ITER: d0 % K2, K1: l},
         outputs={S: i, BH: j, SPLIT_ITER: k, K1: l},
         dynamic_val_mappings={SPLIT_ITER: k},
     )
@@ -230,7 +230,7 @@ def get_paged_decode_attention_kernels(
     # Returns the value for the given token index.
     v_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // KV_LENS, BH: j, N: k, SPLIT_ITER: d0 % KV_LENS},
+        inputs={S: d0 // K2, BH: j, N: k, SPLIT_ITER: d0 % K2},
         outputs={S: i, BH: j, N: k, SPLIT_ITER: l},
         dynamic_val_mappings={SPLIT_ITER: l},
     )
@@ -431,10 +431,10 @@ def get_paged_decode_attention_kernels(
     symbols_1 = dict(symbols_0)
     symbols_1[BLOCK_B] = PHASE_1_BLOCK_B
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
-    dynamic_symbols = [SPLIT_ITER, KV_LENS, S]
+    dynamic_symbols = [SPLIT_ITER, K2, S]
     dynamic_symbols_map = {
         SPLIT_ITER: shape.kv_lens,
-        KV_LENS: shape.kv_lens,
+        K2: shape.kv_lens,
         S: shape.num_seqs,
     }
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -83,7 +83,7 @@ def get_paged_decode_attention_kernels(
     if mha:
         B_WAVES = 1
     else:
-        B_WAVES = clamp(1, head_ratio // MMA_VEC_SIZE, 4)
+        B_WAVES = clamp(head_ratio // MMA_VEC_SIZE, 1, 4)
     HEAD_BLOCK_SIZE = min(MMA_VEC_SIZE * B_WAVES, head_ratio)
 
     LOG2E = 1.44269504089

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -271,6 +271,7 @@ def get_paged_decode_attention_kernels(
         req_index = tkw.read(request_indices)
         # The sequence length is used to control the bounds of the loop over K2.
         seq_length = tkw.read(request_indices, mapping=seq_len_mapping)
+        tkw.set_symbol(K2, seq_length)
         seq_length = seq_length - req_index
         tkw.set_symbol(KV_START_IDX, req_index)
         tkw.set_symbol(SEQ_LEN, seq_length)
@@ -292,8 +293,6 @@ def get_paged_decode_attention_kernels(
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
 
-        seq_length_per_split = tkw.cast(seq_length_per_split, tkl.i32)
-        tkw.set_symbol(K2, req_index + seq_length_per_split)
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -273,7 +273,6 @@ def get_paged_decode_attention_kernels(
         seq_length = seq_length - req_index
         tkw.set_symbol(KV_START_IDX, req_index)
         tkw.set_symbol(SEQ_LEN, seq_length)
-        tkw.set_symbol(K2, seq_length)
 
         seq_length_per_split = tkw.apply_expr(
             seq_length, lambda x: sympy.ceiling(x / U)
@@ -283,6 +282,7 @@ def get_paged_decode_attention_kernels(
         split_offset = tkw.broadcast(split_offset, target_shape=[S, U])
         split_offset = split_offset * seq_length_per_split
         tkw.set_symbol(SPLIT_OFF, split_offset)
+        tkw.set_symbol(K2, split_offset + seq_length_per_split)
 
         seq_length_per_split = tkw.broadcast(seq_length_per_split, target_shape=[S, U])
         seq_length = tkw.broadcast(seq_length, target_shape=[S, U])

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -222,7 +222,7 @@ def get_paged_decode_attention_kernels(
     # Returns the key for the given token index.
     k_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // KV_LENS, BH: j, K2: d0 % KV_LENS, K1: l},
+        inputs={S: d0 // KV_LENS, BH: j, KV_LENS: d0 % KV_LENS, K1: l},
         outputs={S: i, BH: j, K2: k, K1: l},
         dynamic_val_mappings={K2: k},
     )
@@ -230,7 +230,7 @@ def get_paged_decode_attention_kernels(
     # Returns the value for the given token index.
     v_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // KV_LENS, BH: j, N: k, K2: d0 % KV_LENS},
+        inputs={S: d0 // KV_LENS, BH: j, N: k, KV_LENS: d0 % KV_LENS},
         outputs={S: i, BH: j, N: k, K2: l},
         dynamic_val_mappings={K2: l},
     )
@@ -238,7 +238,7 @@ def get_paged_decode_attention_kernels(
     # Returns token indices into the k-v cache for the given sequence (d0).
     kv_indices_mapping = tkw.IndexMapping(
         num_iterators=1,
-        inputs={K2: i},
+        inputs={KV_LENS: i},
         outputs={K2: i},
     )
 
@@ -246,10 +246,10 @@ def get_paged_decode_attention_kernels(
     @tkw.wave(get_constraints(Phase.PHASE_0))
     def phase_0(
         q: tkl.Memory[S, B, K1, GLOBAL_ADDRESS_SPACE, wave_input_dtype],
-        k: tkl.Memory[S, K2, BH, K1, ADDRESS_SPACE, wave_input_dtype],
-        v: tkl.Memory[S, K2, BH, N, ADDRESS_SPACE, wave_input_dtype],
+        k: tkl.Memory[S, KV_LENS, BH, K1, ADDRESS_SPACE, wave_input_dtype],
+        v: tkl.Memory[S, KV_LENS, BH, N, ADDRESS_SPACE, wave_input_dtype],
         request_indices: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32],
-        kv_indices: tkl.Memory[K2, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        kv_indices: tkl.Memory[KV_LENS, GLOBAL_ADDRESS_SPACE, tkl.i32],
         output: tkl.Memory[U, S, N, B, GLOBAL_ADDRESS_SPACE, tkl.f32],
         output_max: tkl.Memory[U, S, B, GLOBAL_ADDRESS_SPACE, tkl.f32],
     ):

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -49,6 +49,7 @@ def get_paged_decode_attention_kernels(
     N = tkl.sym.N
     K1 = tkl.sym.K1
     K2 = tkl.sym.K2
+    K3 = tkl.sym.K3
     SEQ_LEN = tkl.sym.SEQ_LEN
     KV_START_IDX = tkl.sym.KV_START_IDX
     SPLIT_OFF = tkl.sym.SPLIT_OFF
@@ -215,7 +216,7 @@ def get_paged_decode_attention_kernels(
     # Returns the key for the given token index.
     k_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // K2, BH: j, K2: d0 % K2, K1: l},
+        inputs={S: d0 // K3, BH: j, K2: d0 % K3, K1: l},
         outputs={S: i, BH: j, K2: k, K1: l},
         dynamic_val_mappings={K2: k},
     )
@@ -223,7 +224,7 @@ def get_paged_decode_attention_kernels(
     # Returns the value for the given token index.
     v_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={S: d0 // K2, BH: j, N: k, K2: d0 % K2},
+        inputs={S: d0 // K3, BH: j, N: k, K2: d0 % K3},
         outputs={S: i, BH: j, N: k, K2: l},
         dynamic_val_mappings={K2: l},
     )
@@ -427,6 +428,7 @@ def get_paged_decode_attention_kernels(
     dynamic_symbols = [K2, S]
     dynamic_symbols_map = {
         K2: shape.kv_lens,
+        K3: shape.kv_lens,
         S: shape.num_seqs,
     }
 

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -290,7 +290,9 @@ def get_paged_decode_attention_kernels(
             lambda x, y, z: sympy.Min(x, sympy.Max(y - z, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
-        tkw.set_symbol(K2, seq_length_per_split)
+
+        seq_length_per_split = tkw.cast(seq_length_per_split, tkl.i32)
+        tkw.set_symbol(K2, req_index + seq_length_per_split)
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -273,6 +273,7 @@ def get_paged_decode_attention_kernels(
         seq_length = seq_length - req_index
         tkw.set_symbol(KV_START_IDX, req_index)
         tkw.set_symbol(SEQ_LEN, seq_length)
+        tkw.set_symbol(K2, seq_length)
 
         seq_length_per_split = tkw.apply_expr(
             seq_length, lambda x: sympy.ceiling(x / U)
@@ -290,7 +291,6 @@ def get_paged_decode_attention_kernels(
             lambda x, y, z: sympy.Min(x, sympy.Max(y - z, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
-        tkw.set_symbol(K2, seq_length_per_split)
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -65,7 +65,7 @@ def get_paged_decode_attention_kernels(
     BLOCK_BH = tkl.sym.BLOCK_BH
     BLOCK_N = tkl.sym.BLOCK_N
     BLOCK_U = tkl.sym.BLOCK_U
-    BLOCK_K2 = tkl.sym.BLOCK_K2
+    BLOCK_SPLIT = tkl.sym.BLOCK_SPLIT
     BLOCK_S = tkl.sym.BLOCK_S
     # Address space (for GPU, shared(1) or global(0))
     ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
@@ -97,8 +97,8 @@ def get_paged_decode_attention_kernels(
         constraints += [
             tkw.TilingConstraint(
                 K2,
-                BLOCK_K2,
-                iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2),
+                BLOCK_SPLIT,
+                iters=sympy.ceiling(SPLIT_LEN / BLOCK_SPLIT),
                 start=SPLIT_OFF + KV_START_IDX,
             )
         ]
@@ -144,8 +144,8 @@ def get_paged_decode_attention_kernels(
         constraints += [
             tkw.TilingConstraint(
                 K2,
-                BLOCK_K2,
-                iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2),
+                BLOCK_SPLIT,
+                iters=sympy.ceiling(SPLIT_LEN / BLOCK_SPLIT),
                 start=SPLIT_OFF + KV_START_IDX,
             )
         ]
@@ -408,7 +408,7 @@ def get_paged_decode_attention_kernels(
             BLOCK_B: 1,
             BLOCK_S: 1,
             BLOCK_U: 1,
-            BLOCK_K2: 64,
+            BLOCK_SPLIT: 64,
             B: shape.num_query_heads,
             N: shape.head_size_kv,
             K1: shape.head_size,
@@ -421,7 +421,7 @@ def get_paged_decode_attention_kernels(
             BLOCK_B: HEAD_BLOCK_SIZE,
             BLOCK_S: 1,
             BLOCK_U: 1,
-            BLOCK_K2: 16,
+            BLOCK_SPLIT: 16,
             B: shape.num_query_heads,
             N: shape.head_size_kv,
             K1: shape.head_size,

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -96,7 +96,10 @@ def get_paged_decode_attention_kernels(
         constraints += [tkw.WorkgroupConstraint(U, BLOCK_U, 2)]
         constraints += [
             tkw.TilingConstraint(
-                K2, BLOCK_K2, iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2), start=SPLIT_OFF
+                K2,
+                BLOCK_K2,
+                iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2),
+                start=SPLIT_OFF + KV_START_IDX,
             )
         ]
 
@@ -140,7 +143,10 @@ def get_paged_decode_attention_kernels(
         constraints += [tkw.WorkgroupConstraint(U, BLOCK_U, 2)]
         constraints += [
             tkw.TilingConstraint(
-                K2, BLOCK_K2, iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2), start=SPLIT_OFF
+                K2,
+                BLOCK_K2,
+                iters=sympy.ceiling(SPLIT_LEN / BLOCK_K2),
+                start=SPLIT_OFF + KV_START_IDX,
             )
         ]
 
@@ -232,7 +238,7 @@ def get_paged_decode_attention_kernels(
     # Returns token indices into the k-v cache for the given sequence (d0).
     kv_indices_mapping = tkw.IndexMapping(
         num_iterators=1,
-        inputs={K2: i + KV_START_IDX},
+        inputs={K2: i},
         outputs={K2: i},
     )
 
@@ -292,7 +298,6 @@ def get_paged_decode_attention_kernels(
             lambda x, y, z: sympy.Min(x, sympy.Max(y - z, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
-
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -50,7 +50,6 @@ def get_paged_decode_attention_kernels(
     K1 = tkl.sym.K1
     K2 = tkl.sym.K2
     K3 = tkl.sym.K3
-    SK2 = tkl.sym.SK2
     SEQ_LEN = tkl.sym.SEQ_LEN
     KV_START_IDX = tkl.sym.KV_START_IDX
     SPLIT_OFF = tkl.sym.SPLIT_OFF
@@ -217,7 +216,7 @@ def get_paged_decode_attention_kernels(
     # Returns the key for the given token index.
     k_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={SK2: d0, BH: j, K1: l},
+        inputs={S: d0 // K3, BH: j, K2: d0 % K3, K1: l},
         outputs={S: i, BH: j, K2: k, K1: l},
         dynamic_val_mappings={K2: k},
     )
@@ -225,7 +224,7 @@ def get_paged_decode_attention_kernels(
     # Returns the value for the given token index.
     v_mapping = tkw.IndexMapping(
         num_iterators=4,
-        inputs={SK2: d0, BH: j, N: k},
+        inputs={S: d0 // K3, BH: j, N: k, K2: d0 % K3},
         outputs={S: i, BH: j, N: k, K2: l},
         dynamic_val_mappings={K2: l},
     )
@@ -241,8 +240,8 @@ def get_paged_decode_attention_kernels(
     @tkw.wave(get_constraints(Phase.PHASE_0))
     def phase_0(
         q: tkl.Memory[S, B, K1, GLOBAL_ADDRESS_SPACE, wave_input_dtype],
-        k: tkl.Memory[SK2, BH, K1, ADDRESS_SPACE, wave_input_dtype],
-        v: tkl.Memory[SK2, BH, N, ADDRESS_SPACE, wave_input_dtype],
+        k: tkl.Memory[S, K2, BH, K1, ADDRESS_SPACE, wave_input_dtype],
+        v: tkl.Memory[S, K2, BH, N, ADDRESS_SPACE, wave_input_dtype],
         request_indices: tkl.Memory[S, GLOBAL_ADDRESS_SPACE, tkl.i32],
         kv_indices: tkl.Memory[K2, GLOBAL_ADDRESS_SPACE, tkl.i32],
         output: tkl.Memory[U, S, N, B, GLOBAL_ADDRESS_SPACE, tkl.f32],
@@ -293,6 +292,7 @@ def get_paged_decode_attention_kernels(
             lambda x, y, z: sympy.Min(x, sympy.Max(y - z, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
+
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(
@@ -424,12 +424,11 @@ def get_paged_decode_attention_kernels(
     symbols_1 = dict(symbols_0)
     symbols_1[BLOCK_B] = PHASE_1_BLOCK_B
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
-    dynamic_symbols = [K2, K3, S, SK2]
+    dynamic_symbols = [K2, K3, S]
     dynamic_symbols_map = {
         K2: shape.kv_lens,
         K3: shape.kv_lens,
         S: shape.num_seqs,
-        SK2: shape.num_seqs * shape.kv_lens,
     }
 
     return (

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -282,7 +282,6 @@ def get_paged_decode_attention_kernels(
         split_offset = tkw.broadcast(split_offset, target_shape=[S, U])
         split_offset = split_offset * seq_length_per_split
         tkw.set_symbol(SPLIT_OFF, split_offset)
-        tkw.set_symbol(K2, split_offset + seq_length_per_split)
 
         seq_length_per_split = tkw.broadcast(seq_length_per_split, target_shape=[S, U])
         seq_length = tkw.broadcast(seq_length, target_shape=[S, U])
@@ -291,6 +290,9 @@ def get_paged_decode_attention_kernels(
             lambda x, y, z: sympy.Min(x, sympy.Max(y - z, 0)),
         )
         tkw.set_symbol(SPLIT_LEN, seq_length_per_split)
+
+        seq_length_per_split = tkw.cast(seq_length_per_split, tkl.i32)
+        tkw.set_symbol(K2, split_offset + seq_length_per_split)
 
         @tkw.iterate(K2, init_args=[init_max, init_sum, new_acc])
         def loop(

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -78,9 +78,13 @@ def get_paged_decode_attention_kernels(
     PHASE_1_BLOCK_B_WAVES = 1
     PHASE_1_BLOCK_B = 64 * PHASE_1_BLOCK_B_WAVES
     PHASE_1_BLOCK_N = 16
-    B_WAVES = 1 if mha else 4
-    HEAD_BLOCK_SIZE = 16 * B_WAVES
     head_ratio = shape.num_query_heads // shape.num_kv_heads
+    B_SIZE = 16  # TODO: Actual value depends in mma type
+    if mha:
+        B_WAVES = 1
+    else:
+        B_WAVES = max(min(4, head_ratio // B_SIZE), 1)
+    HEAD_BLOCK_SIZE = min(B_SIZE * B_WAVES, head_ratio)
 
     LOG2E = 1.44269504089
     dk_sqrt = math.sqrt(1.0 / shape.head_size)

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -83,7 +83,7 @@ def get_paged_decode_attention_kernels(
     if mha:
         B_WAVES = 1
     else:
-        B_WAVES = min(max(head_ratio // MMA_VEC_SIZE, 1), 4)
+        B_WAVES = clamp(1, head_ratio // MMA_VEC_SIZE, 4)
     HEAD_BLOCK_SIZE = min(MMA_VEC_SIZE * B_WAVES, head_ratio)
 
     LOG2E = 1.44269504089

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -425,7 +425,7 @@ def get_paged_decode_attention_kernels(
     symbols_1 = dict(symbols_0)
     symbols_1[BLOCK_B] = PHASE_1_BLOCK_B
     symbols_1[BLOCK_N] = PHASE_1_BLOCK_N
-    dynamic_symbols = [K2, S]
+    dynamic_symbols = [K2, K3, S]
     dynamic_symbols_map = {
         K2: shape.kv_lens,
         K3: shape.kv_lens,

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -221,7 +221,7 @@ def ceildiv(a: int, b: int) -> int:
     return -(a // -b)
 
 
-def clamp(min_val: int, x: int, max_val: int) -> int:
+def clamp(x: int, min_val: int, max_val: int) -> int:
     return max(min_val, min(x, max_val))
 
 

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -221,6 +221,10 @@ def ceildiv(a: int, b: int) -> int:
     return -(a // -b)
 
 
+def clamp(min_val: int, x: int, max_val: int) -> int:
+    return max(min_val, min(x, max_val))
+
+
 def all_equal(input_list: list[Any]) -> bool:
     if len(input_list) == 0:
         return True

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -141,6 +141,7 @@ def create_inputs(
         request_indices[1:num_seqs] += device_randint(
             -d, d, (num_seqs - 1,), dtype=torch.int32
         )
+        kv_lens_tensor = request_indices[1:] - request_indices[:-1]
     return (
         query,
         key_cache,
@@ -170,6 +171,7 @@ def create_mha_inputs(
         request_indices[1:num_seqs] += device_randint(
             -d, d, (num_seqs - 1,), dtype=torch.int32
         )
+        kv_lens_tensor = request_indices[1:] - request_indices[:-1]
     return query, key_cache, value_cache, block_table, request_indices, kv_lens_tensor
 
 

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -6,8 +6,6 @@
 
 import pytest
 import torch
-import math
-import iree.turbine.kernel as tk
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.kernel.wave.utils.general_utils import (
     get_default_scheduling_params,
@@ -38,8 +36,9 @@ from ..common.utils import (
     dump_generated_mlir,
     param_bool,
 )
-from ..common.shapes import get_test_shapes
 from typing import List, Optional
+
+xfail = lambda *a: pytest.param(*a, marks=pytest.mark.xfail)
 
 # Reference paged attention implementation from vLLM and sglang.
 # (NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, BLOCK_SIZE, NUM_SEQS, SEQ_LEN)
@@ -48,7 +47,7 @@ shapes += [(16, 1, 64, 64, 32, 2, 3)]  # small SEQ_LEN test
 shapes += [(64, 1, 80, 80, 32, 2, 128)]
 shapes += [(128, 2, 80, 80, 32, 2, 500)]
 shapes += [(128, 2, 512, 512, 32, 32, 500)]
-shapes += [(32, 8, 128, 128, 32, 1319, 1018)]
+shapes += [xfail((32, 8, 128, 128, 32, 1319, 1018))]
 
 # Test shapes for MHA paged attention
 # (NUM_HEADS, HEAD_SIZE, HEAD_SIZE_KV, BLOCK_SIZE, NUM_SEQS, SEQ_LEN)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -133,15 +133,14 @@ def create_inputs(
     block_table = device_arange(num_seqs * kv_lens, dtype=torch.int32).reshape(
         num_seqs, kv_lens
     )
-    d = kv_lens // 10
-    if d > 0:
-        kv_lens_tensor = device_randint(
-            kv_lens - d, kv_lens + d, (num_seqs,), dtype=torch.int32
-        )
-    else:
-        kv_lens_tensor = device_full((num_seqs,), kv_lens, dtype=torch.int32)
+    kv_lens_tensor = device_full((num_seqs,), kv_lens, dtype=torch.int32)
     request_indices = device_zeros(num_seqs + 1, dtype=torch.int32)
     request_indices[1 : num_seqs + 1] = torch.cumsum(kv_lens_tensor, dim=0)
+    d = kv_lens // 10
+    if d > 0:
+        request_indices[1:num_seqs] += device_randint(
+            -d, d, (num_seqs - 1,), dtype=torch.int32
+        )
     return (
         query,
         key_cache,
@@ -163,15 +162,14 @@ def create_mha_inputs(
     key_cache = device_randn(num_seqs, kv_lens, num_heads, head_size, dtype=dtype)
     value_cache = device_randn(num_seqs, kv_lens, num_heads, head_size, dtype=dtype)
     block_table = device_arange(num_seqs, kv_lens, dtype=torch.int32)
-    d = kv_lens // 10
-    if d > 0:
-        kv_lens_tensor = device_randint(
-            kv_lens - d, kv_lens + d, (num_seqs,), dtype=torch.int32
-        )
-    else:
-        kv_lens_tensor = device_full((num_seqs,), kv_lens, dtype=torch.int32)
+    kv_lens_tensor = device_full((num_seqs,), kv_lens, dtype=torch.int32)
     request_indices = device_zeros(num_seqs + 1, dtype=torch.int32)
     request_indices[1 : num_seqs + 1] = torch.cumsum(kv_lens_tensor, dim=0)
+    d = kv_lens // 10
+    if d > 0:
+        request_indices[1:num_seqs] += device_randint(
+            -d, d, (num_seqs - 1,), dtype=torch.int32
+        )
     return query, key_cache, value_cache, block_table, request_indices, kv_lens_tensor
 
 

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -134,9 +134,12 @@ def create_inputs(
         num_seqs, kv_lens
     )
     d = kv_lens // 10
-    kv_lens_tensor = device_randint(
-        kv_lens - d, kv_lens + d, (num_seqs,), dtype=torch.int32
-    )
+    if d > 0:
+        kv_lens_tensor = device_randint(
+            kv_lens - d, kv_lens + d, (num_seqs,), dtype=torch.int32
+        )
+    else:
+        kv_lens_tensor = device_full((num_seqs,), kv_lens, dtype=torch.int32)
     request_indices = device_zeros(num_seqs + 1, dtype=torch.int32)
     request_indices[1 : num_seqs + 1] = torch.cumsum(kv_lens_tensor, dim=0)
     return (
@@ -161,9 +164,12 @@ def create_mha_inputs(
     value_cache = device_randn(num_seqs, kv_lens, num_heads, head_size, dtype=dtype)
     block_table = device_arange(num_seqs, kv_lens, dtype=torch.int32)
     d = kv_lens // 10
-    kv_lens_tensor = device_randint(
-        kv_lens - d, kv_lens + d, (num_seqs,), dtype=torch.int32
-    )
+    if d > 0:
+        kv_lens_tensor = device_randint(
+            kv_lens - d, kv_lens + d, (num_seqs,), dtype=torch.int32
+        )
+    else:
+        kv_lens_tensor = device_full((num_seqs,), kv_lens, dtype=torch.int32)
     request_indices = device_zeros(num_seqs + 1, dtype=torch.int32)
     request_indices[1 : num_seqs + 1] = torch.cumsum(kv_lens_tensor, dim=0)
     return query, key_cache, value_cache, block_table, request_indices, kv_lens_tensor

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -30,24 +30,24 @@ from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
 import os
 from torch.testing import assert_close
 from ..common.utils import (
-    require_e2e,
-    require_cdna3,
-    enable_scheduling_barriers,
     dump_generated_mlir,
+    enable_scheduling_barriers,
+    expensive_test_param,
     param_bool,
+    require_cdna3,
+    require_e2e,
 )
 from typing import List, Optional
-
-xfail = lambda *a: pytest.param(*a, marks=pytest.mark.xfail)
 
 # Reference paged attention implementation from vLLM and sglang.
 # (NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, BLOCK_SIZE, NUM_SEQS, SEQ_LEN)
 shapes = [(16, 1, 64, 64, 32, 2, 100)]
+shapes += [(16, 2, 64, 64, 32, 1, 100)]  # (16 // 2) < 16
 shapes += [(16, 1, 64, 64, 32, 2, 3)]  # small SEQ_LEN test
 shapes += [(64, 1, 80, 80, 32, 2, 128)]
 shapes += [(128, 2, 80, 80, 32, 2, 500)]
 shapes += [(128, 2, 512, 512, 32, 32, 500)]
-shapes += [xfail((32, 8, 128, 128, 32, 1319, 1018))]
+shapes += [expensive_test_param((32, 8, 128, 128, 32, 1319, 1018))]
 
 # Test shapes for MHA paged attention
 # (NUM_HEADS, HEAD_SIZE, HEAD_SIZE_KV, BLOCK_SIZE, NUM_SEQS, SEQ_LEN)


### PR DESCRIPTION
* Separate `K2` symbol into  `SPLIT_ITER` and `KV_LENS`, `SPLIT_ITER` is used for reduction iter and masking calculation and `KV_LENS` is actual input tensor size.
* Move `KV_START_IDX` inside the masking constraint and set `tkw.set_symbol(SPLIT_ITER, seq_length)` inside the kernel to properly update masking bounds for current split.
* Update tests and ref code to test non-uniform `kv_lens_tensor`/`request_indices` sizes.
* Depends on https://github.com/iree-org/iree-turbine/pull/906 for the  case `NUM_Q_HEADS / NUM_KV_HEADS < 16`