### PR TITLE
Update IREE deps

### DIFF
--- a/iree/turbine/kernel/wave/runtime/runtime.cpp
+++ b/iree/turbine/kernel/wave/runtime/runtime.cpp
@@ -88,7 +88,7 @@ static int launch(const KernelLaunchInfo &info, const Int64Vector &tensors,
         HIP_LAUNCH_PARAM_END};
 
     HIP_CHECK_RETURN(hipModuleLaunchKernel(function, info.gridX, info.gridY, info.gridZ,
-                                           info.blockX, info.blockY, info.blockZ, info.sharedMemoryBytes,
+                                           info.blockX, info.blockY, info.blockZ, 0,
                                            stream, nullptr, (void **)&hipLaunchParams));
 
     return hipSuccess;

--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -7,7 +7,5 @@
 # Uncomment to skip versions from PyPI (so _only_ nightly versions).
 # --no-index
 
-# TODO: We have a pretty bad regression in Wave between 3.5.0rc20250516 and
-# 3.5.0rc20250517. I'm locking to 3.5.0rc20250516 until further investigation.
 iree-base-compiler==3.5.0rc20250530
 iree-base-runtime==3.5.0rc20250530

--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -9,5 +9,5 @@
 
 # TODO: We have a pretty bad regression in Wave between 3.5.0rc20250516 and
 # 3.5.0rc20250517. I'm locking to 3.5.0rc20250516 until further investigation.
-iree-base-compiler==3.5.0rc20250516
-iree-base-runtime==3.5.0rc20250516
+iree-base-compiler==3.5.0rc20250530
+iree-base-runtime==3.5.0rc20250530


### PR DESCRIPTION
IREE deps were previously pinned to `3.5.0rc20250516` as `3.5.0rc20250517` introduced regressions. There were 2 issues:
* Shared memory handling changes in IREE were causing the crash as we are were trying to allocate too much shared mem. IREE doesn't use dynamic shared mem anymore so we need to pass 0 now in wave runtime (test https://github.com/iree-org/iree-turbine/pull/855).
* 40% perf regression in extend attention caused by some changes in llvm AMDGPU backend. These seems to went away after the recent IREE llvm intergrate. I didn't dig too deep on them but I suspect https://github.com/llvm/llvm-project/pull/137807 was the issue (fixed by https://github.com/llvm/llvm-project/pull/140921).