### PR TITLE
[BOO] don't permute `None` in pytorch convolution backward

### DIFF
--- a/iree/turbine/kernel/boo/ops/conv.py
+++ b/iree/turbine/kernel/boo/ops/conv.py
@@ -196,9 +196,9 @@ def pytorch_convolution_backward(ctx, grad_output):
         mask,
     )
 
-    if ctx.input_layout.endswith("C"):
+    if ctx.input_layout.endswith("C") and mask[0]:
         input_grad = input_grad.permute(inv_perm)
-    if ctx.kernel_layout.endswith("C"):
+    if ctx.kernel_layout.endswith("C") and mask[1]:
         weight_grad = weight_grad.permute(inv_perm)
     # return `None` for attribute args
     return input_grad, weight_grad, bias_grad, None, None, None, None, None, None, None

--- a/tests/kernel/boo/modeling/boo_conv_2d_test.py
+++ b/tests/kernel/boo/modeling/boo_conv_2d_test.py
@@ -4,11 +4,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import os
-
-# enable backward boo kernels for testing
-os.environ["BOO_USE_BACKWARD_KERNELS"] = "1"
-
 import unittest
 import tempfile
 from pathlib import Path
@@ -17,12 +12,21 @@ import pytest
 import torch
 
 from iree.turbine.kernel.boo.modeling import BooConv2d, replace_conv2d_with_boo_conv
+from iree.turbine.kernel.boo.ops import enable_backward, disable_backward
 from iree.turbine.kernel.boo.conv_exports import (
     set_boo_cache,
     ConvLaunchableRuntimeCache,
 )
 
 
+@pytest.fixture(scope="class")
+def use_backward():
+    enable_backward()
+    yield
+    disable_backward()
+
+
+@pytest.mark.usefixtures("use_backward")
 class BooConv2dTest(unittest.TestCase):
     def setUp(self):
         ConvLaunchableRuntimeCache.set_cache_limit(0)

--- a/tests/kernel/boo/ops/boo_conv_test.py
+++ b/tests/kernel/boo/ops/boo_conv_test.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import contextlib
 import unittest
 import pytest
 import tempfile
@@ -42,16 +43,14 @@ def testBackwardCachePytorch(x_grad, w_grad):
         )
         y = boo_conv(x, w)
 
-        if not x_grad and not w_grad:
-            try:
-                y.sum().backward()
-            except RuntimeError as e:
-                return
-            except:
-                raise
-            assert False, "Expected a RuntimeError calling backwards."
+        context = (
+            contextlib.nullcontext()
+            if x_grad or w_grad
+            else pytest.raises(RuntimeError)
+        )
+        with context:
+            y.sum().backward()
 
-        y.sum().backward()
         items = [x.name for x in Path(td).glob("*/")]
 
         assert (
@@ -85,16 +84,14 @@ def testBackwardCacheBoo(x_grad, w_grad):
         )
         y = boo_conv(x, w)
 
-        if not x_grad and not w_grad:
-            try:
-                y.sum().backward()
-            except RuntimeError as e:
-                return
-            except:
-                raise
-            assert False, "Expected a RuntimeError calling backwards."
+        context = (
+            contextlib.nullcontext()
+            if x_grad or w_grad
+            else pytest.raises(RuntimeError)
+        )
+        with context:
+            y.sum().backward()
 
-        y.sum().backward()
         items = [x.name for x in Path(td).glob("*/")]
 
         assert (


### PR DESCRIPTION
Small bugfix for the case when a channels-last conv doesn't need one of input/weight gradients computed.

Also adds setter functions for turning on and off boo backward convolution kernels from python to enable testing both paths.