### PR TITLE
[Wave] Hide APLP warning

### DIFF
--- a/iree/turbine/kernel/wave/scheduling/graph_utils.py
+++ b/iree/turbine/kernel/wave/scheduling/graph_utils.py
@@ -19,11 +19,6 @@ from typing import Optional, Callable
 
 T = index_symbol("$INITIATION_INTERVAL")
 
-try:
-    from aplp_lib import perform_aplp_pyo3 as compute_aplp
-except ImportError as e:
-    print(f"Could not import Rust APLP module 'aplp_lib.perform_aplp_pyo3': {e}")
-
 
 @dataclass
 class EdgeWeight:
@@ -281,6 +276,7 @@ def all_pairs_longest_paths_unevaluated(
     by parallelizing across the start nodes.
 
     """
+    from aplp_lib import perform_aplp_pyo3 as compute_aplp
 
     N = len(graph.nodes)
 


### PR DESCRIPTION
Make `aplp_lib` lib import local.

It is optional in current scheme of things and we shouldn't emit warning if user is not using it, with local import is it will be imported only if it actually being used.
(Also, users will get a proper import error instead of warning + random "unknown symbol `compute_aplp`")

Fixes https://github.com/iree-org/iree-turbine/issues/897