### PR TITLE
Reduce CPU overhead in `lookup_device_from_torch`

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -613,6 +613,8 @@ def lookup_device_from_torch(
     torch_device: torch.device, *, create: bool = True
 ) -> Optional[Device]:
     """Gets a shared Device corresponding to the given torch.device.
+    For cuda torch.device types, the returned Device will be tied to
+    the current cuda stream.
 
     This will return None if the device is wholly unsupported or if
     create=False. Otherwise, faults in setting up the device are
@@ -625,7 +627,7 @@ def lookup_device_from_torch(
     stream = (
         None
         if torch_device.type != "cuda"
-        else torch.cuda.current_stream(torch_device).cuda_stream
+        else torch._C._cuda_getCurrentRawStream(torch_device.index)
     )
     key = (torch_device, stream)
     device = mapping.get(key)


### PR DESCRIPTION
Calling `torch.cuda.current_stream(torch_device)` was taking between 15 and 50 us on the CPU for every launchable call. 

This is because it checks whether device is an `int`, or a `torch.device`, or a `str`, etc., lazy initializing cuda for no reason, and creating a `torch.cuda.Stream` just so we could get the raw stream pointer int.

This PR also fixes some tests for Device that were not running due to duplicate class name, and adds a few more checks on the GPU device tests. 