### PR TITLE
[Wave] Add support for WG/Wave tiles smaller than vector sizes

### DIFF
--- a/iree/turbine/kernel/_support/indexing.py
+++ b/iree/turbine/kernel/_support/indexing.py
@@ -441,6 +441,13 @@ class IndexSequence:
             return value.subs(map)  # type: ignore
         return value
 
+    def has(self, symbol: IndexSymbol) -> bool:
+        return (
+            sympy.sympify(self.start).has(symbol)
+            or sympy.sympify(self.size).has(symbol)
+            or sympy.sympify(self.stride).has(symbol)
+        )
+
     def subs(self, map: dict[IndexExpr, IndexExpr]):
         start = self._subs(self.start, map)
         size = self._subs(self.size, map)

--- a/iree/turbine/kernel/_support/indexing.py
+++ b/iree/turbine/kernel/_support/indexing.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Optional, Type, TypeVar, Union
+from typing import Any, ClassVar, Optional, Type, TypeVar, Union, TypeAlias
 
 from abc import ABC
 from dataclasses import dataclass
@@ -39,8 +39,8 @@ SubtypeT = TypeVar("SubtypeT")
 # These are just light-weight helpers around sympy symbols and expressions.
 ###############################################################################
 
-IndexSymbol = sympy.Symbol
-IndexExpr = sympy.Expr
+IndexSymbol: TypeAlias = sympy.Symbol
+IndexExpr: TypeAlias = sympy.Expr
 
 
 def index_symbol(name: str) -> IndexSymbol:

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1403,7 +1403,7 @@ class MMA(CustomOp):
         # Local import to break circular dep.
         from ..wave.utils.general_utils import align_index_vars
 
-        self.index = align_index_vars(self.index, constraints)
+        self.index = align_index_vars(self.index, constraints, self.vector_shapes)
 
     @property
     def reduction_dim(self) -> IndexSymbol:
@@ -1453,7 +1453,7 @@ class Read(CustomOp):
         from ..wave.utils.general_utils import align_index_vars, is_shared_mem_access
 
         if is_shared_mem_access(self):
-            self.index = align_index_vars(self.index, constraints)
+            self.index = align_index_vars(self.index, constraints, self.vector_shapes)
 
     def transform_index_backwards(
         self, index: dict[IndexSymbol, IndexSequence], arg: fx.Node
@@ -1773,7 +1773,7 @@ class Write(CustomOp):
         from ..wave.utils.general_utils import align_index_vars, is_shared_mem_access
 
         if is_shared_mem_access(self):
-            self.index = align_index_vars(self.index, constraints)
+            self.index = align_index_vars(self.index, constraints, self.vector_shapes)
 
     def transform_index_backwards(
         self, index: dict[IndexSymbol, IndexSequence], arg: fx.Node

--- a/iree/turbine/kernel/wave/analysis/partition_strided_operators.py
+++ b/iree/turbine/kernel/wave/analysis/partition_strided_operators.py
@@ -192,6 +192,7 @@ def partition_strided_operators(trace: CapturedTrace, constraints: list[Constrai
                     )
                     for j, dim in enumerate(symbolic_shape)
                 }
+                write.vector_shapes = vector_shapes
                 ops_to_combine.append(write)
 
         # Useful to handle write/read dependency

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -11,13 +11,12 @@ from dataclasses import dataclass
 from collections import namedtuple
 import sys
 from ..._support.location import FileLineColInfo
-
+from ..utils.general_utils import get_hardware_constraint
 import torch.fx as fx
 
 from iree.turbine.kernel.lang.global_symbols import *
 from iree.turbine.aot.support.ir_utils import (
     _is_float_type,
-    _is_index_type,
     _is_integer_like_type,
 )
 

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -580,30 +580,36 @@ def gen_sympy_index(dynamics: dict[IndexSymbol, Value], expr: sympy.Expr) -> Val
                     res = arith_d.andi(*_broadcast(res, operand))
                 stack.append(res)
             case sympy.Max():
-                rhs = stack.pop()
-                lhs = stack.pop()
-                _enforce_non_rational(rhs, term)
-                _enforce_non_rational(lhs, term)
-                rhs = _get_ir_value(rhs)
-                lhs = _get_ir_value(lhs)
-                elem_type = get_type_or_element_type(rhs.type)
-                if _is_integer_like_type(elem_type):
-                    res = arith_d.maxsi(*_broadcast(lhs, rhs))
-                else:
-                    res = arith_d.maximumf(*_broadcast(lhs, rhs))
+                count = len(term.args)
+                res = stack.pop()
+                _enforce_non_rational(res, term)
+                res = _get_ir_value(res)
+                elem_type = get_type_or_element_type(res.type)
+                for _ in range(count - 1):
+                    operand = stack.pop()
+                    _enforce_non_rational(operand, term)
+                    operand = _get_ir_value(operand)
+                    if _is_integer_like_type(elem_type):
+                        res = arith_d.maxsi(*_broadcast(res, operand))
+                    else:
+                        res = arith_d.maximumf(*_broadcast(res, operand))
+
                 stack.append(res)
             case sympy.Min():
-                rhs = stack.pop()
-                lhs = stack.pop()
-                _enforce_non_rational(rhs, term)
-                _enforce_non_rational(lhs, term)
-                rhs = _get_ir_value(rhs)
-                lhs = _get_ir_value(lhs)
-                elem_type = get_type_or_element_type(rhs.type)
-                if _is_integer_like_type(elem_type):
-                    res = arith_d.minsi(*_broadcast(lhs, rhs))
-                else:
-                    res = arith_d.minimumf(*_broadcast(lhs, rhs))
+                count = len(term.args)
+                res = stack.pop()
+                _enforce_non_rational(res, term)
+                res = _get_ir_value(res)
+                elem_type = get_type_or_element_type(res.type)
+                for _ in range(count - 1):
+                    operand = stack.pop()
+                    _enforce_non_rational(operand, term)
+                    operand = _get_ir_value(operand)
+                    if _is_integer_like_type(elem_type):
+                        res = arith_d.minsi(*_broadcast(res, operand))
+                    else:
+                        res = arith_d.minimumf(*_broadcast(res, operand))
+
                 stack.append(res)
             case sympy.logic.boolalg.BooleanFalse():
                 res = arith_d.constant(IntegerType.get_signless(1), 0)

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from collections import namedtuple
 import sys
 from ..._support.location import FileLineColInfo
-from ..utils.general_utils import get_hardware_constraint
 import torch.fx as fx
 
 from iree.turbine.kernel.lang.global_symbols import *

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -45,13 +45,14 @@ from ...compiler.ir import (
 )
 
 
+from ..utils.general_utils import get_hardware_constraint
 from ...compiler.builder import IRProxyValue
 from ...compiler.kernel_codegen import BoundKernelSignature
 from ..._support.tracing import CapturedTrace
 from ...compiler.base import CodegenError, NDEBUG
 
 from ...lang.wave_types import IndexSymbol
-from ..constraints import Constraint, TilingConstraint
+from ..constraints import Constraint, TilingConstraint, HardwareConstraint
 from ..._support.indexing import IndexingContext, IndexExpr, xor
 from ..compile_options import WaveCompileOptions
 
@@ -157,6 +158,10 @@ class WaveEmitter:
                         induction_vars.append(self.induction_vars[constraint.dim])
 
         return induction_vars, induction_var_syms
+
+    @property
+    def hardware_constraint(self) -> HardwareConstraint:
+        return get_hardware_constraint(self.constraints)
 
 
 def handle_op(op: Callable[..., Any] | list[Callable[..., Any]]):

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -147,9 +147,13 @@ def _build_mask(
     if is_shared_mem and bounds:
         bounds = remove_global_indexing(bounds, emitter.constraints)
         # Masking against global bounds was already handled when reading from
-        # global mem, but we may still need to handle masking against vector size during shared mem access.
-        # Bound expression for this case will look like `min(global_bound, vector_size)`.
-        # Replace global bound with some known big enough value so it can be simplified to just vector size.
+        # global mem, but we may still need to handle masking against vector
+        # size during shared mem access.
+        # Bound expression for this case will look like
+        # `min(global_bound, vector_size)`.
+        # Replace global bound with `max(tile_size, vector_size)` so the entire
+        # expression `min(max(tile_size, vector_size), vector_size)` can be
+        # simplified to just vector size.
         bounds = {
             k: safe_subs(
                 v, {k: _get_max_tile_size(k, emitter.constraints, vector_shapes)}

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -28,6 +28,7 @@ from ...compiler.ir import (
     vector_d,
 )
 
+from ...compiler.base import ValidationError
 from ...compiler.utils import strides_from_symbolic_shape
 from ...compiler.builder import IRProxyValue
 from ...compiler.vector_codegen import (
@@ -653,7 +654,9 @@ def handle_read(emitter: WaveEmitter, node: fx.Node):
         raise ValidationError("codegen expected read to have index attr.")
 
     index = node.index
-    vector_shapes = get_custom(node).vector_shapes
+    vector_shapes = (
+        get_custom(node).vector_shapes or emitter.hardware_constraint.vector_shapes
+    )
 
     element_type = kb_ir_type.element_type
     vector_type = VectorType.get(vector_shape, element_type)
@@ -750,7 +753,9 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
         raise ValidationError("codegen expected write to have index attr.")
 
     index = node.index
-    vector_shapes = get_custom(node).vector_shapes
+    vector_shapes = (
+        get_custom(node).vector_shapes or emitter.hardware_constraint.vector_shapes
+    )
 
     input_shape = _get_symbolic_shape(register)
     output_shape = _get_symbolic_shape(memory)

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -540,7 +540,7 @@ class WorkgroupConstraint(DistributionConstraint):
         if not self.get_index_bound(vector_shape):
             return None
 
-        return self.dim_bound
+        return self.work_bound
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
@@ -635,7 +635,7 @@ class TilingConstraint(DistributionConstraint):
         if not self.get_index_bound(vector_shape):
             return None
 
-        return self.dim_bound
+        return self.work_bound
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
@@ -715,15 +715,9 @@ class WaveConstraint(DistributionConstraint):
         ), f"Conflicting preset wave_id old: {old_wave_id} new: {self.wave_id}"
         self.wg_constraint = workgroup_constraint
 
-    @property
-    def dim_bound(self) -> IndexExpr:
-        return self.dim
-
     def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        if not self.get_index_bound(vector_shape):
-            return None
-
-        return self.dim_bound
+        # Set by workgroup constraint.
+        return None
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -177,6 +177,12 @@ class DistributionConstraint(Constraint):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
+    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
+        """
+        Returns the preferred bound for the constraint, to minimize masking.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         """
         Returns the index bound for the constraint, which is usually an
@@ -530,6 +536,12 @@ class WorkgroupConstraint(DistributionConstraint):
     def dim_bound(self) -> IndexExpr:
         return self.dim
 
+    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
+        if not self.get_index_bound(vector_shape):
+            return None
+
+        return self.dim_bound
+
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
         if subs_idxc(self.work_bound) != subs_idxc(self.dim_bound):
@@ -618,6 +630,12 @@ class TilingConstraint(DistributionConstraint):
     def dim_bound(self) -> IndexExpr:
         return self.dim
 
+    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
+        if not self.get_index_bound(vector_shape):
+            return None
+
+        return self.dim_bound
+
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
         if subs_idxc(self.work_bound) != subs_idxc(self.dim_bound):
@@ -694,6 +712,16 @@ class WaveConstraint(DistributionConstraint):
             old_wave_id is None or self.wave_id == old_wave_id
         ), f"Conflicting preset wave_id old: {old_wave_id} new: {self.wave_id}"
         self.wg_constraint = workgroup_constraint
+
+    @property
+    def dim_bound(self) -> IndexExpr:
+        return self.dim
+
+    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
+        if not self.get_index_bound(vector_shape):
+            return None
+
+        return self.dim_bound
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -177,14 +177,6 @@ class DistributionConstraint(Constraint):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        """
-        Returns the preferred bound for the constraint, to minimize masking.
-
-        Return None if not needed.
-        """
-        raise NotImplementedError("Subclasses must implement this method")
-
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         """
         Returns the index bound for the constraint, which is usually an
@@ -538,12 +530,6 @@ class WorkgroupConstraint(DistributionConstraint):
     def dim_bound(self) -> IndexExpr:
         return self.dim
 
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        if not self.get_index_bound(vector_shape):
-            return None
-
-        return self.dim_bound
-
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
         if subs_idxc(self.work_bound) != subs_idxc(self.dim_bound):
@@ -628,12 +614,6 @@ class TilingConstraint(DistributionConstraint):
     def work_bound(self) -> IndexExpr:
         return self.start + self.count * self.tile_size
 
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        if not self.get_index_bound(vector_shape):
-            return None
-
-        return self.dim_bound
-
     @property
     def dim_bound(self) -> IndexExpr:
         return self.dim
@@ -712,10 +692,6 @@ class WaveConstraint(DistributionConstraint):
         assert (
             old_wave_id is None or self.wave_id == old_wave_id
         ), f"Conflicting preset wave_id old: {old_wave_id} new: {self.wave_id}"
-
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        # Set by workgroup constraint.
-        return None
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -177,12 +177,6 @@ class DistributionConstraint(Constraint):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        """
-        Returns the preferred bound for the constraint, to minimize masking.
-        """
-        raise NotImplementedError("Subclasses must implement this method")
-
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         """
         Returns the index bound for the constraint, which is usually an
@@ -536,12 +530,6 @@ class WorkgroupConstraint(DistributionConstraint):
     def dim_bound(self) -> IndexExpr:
         return self.dim
 
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        if not self.get_index_bound(vector_shape):
-            return None
-
-        return self.work_bound
-
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
         if subs_idxc(self.work_bound) != subs_idxc(self.dim_bound):
@@ -631,12 +619,6 @@ class TilingConstraint(DistributionConstraint):
     def dim_bound(self) -> IndexExpr:
         return self.dim
 
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        if not self.get_index_bound(vector_shape):
-            return None
-
-        return self.work_bound
-
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
         if subs_idxc(self.work_bound) != subs_idxc(self.dim_bound):
@@ -714,10 +696,6 @@ class WaveConstraint(DistributionConstraint):
             old_wave_id is None or self.wave_id == old_wave_id
         ), f"Conflicting preset wave_id old: {old_wave_id} new: {self.wave_id}"
         self.wg_constraint = workgroup_constraint
-
-    def get_preferred_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
-        # Set by workgroup constraint.
-        return None
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -549,7 +549,8 @@ class WorkgroupConstraint(DistributionConstraint):
 
         if (
             vector_shape is not None
-            and subs_idxc(self.tile_size) % subs_idxc(vector_shape) != 0
+            and vector_shape > 1
+            and subs_idxc(self.tile_size) % vector_shape != 0
         ):
             tile_bound = self.apply().start + self.tile_size
             bound = get_min_expr(bound, tile_bound)
@@ -643,7 +644,8 @@ class TilingConstraint(DistributionConstraint):
 
         if (
             vector_shape is not None
-            and subs_idxc(self.tile_size) % subs_idxc(vector_shape) != 0
+            and vector_shape > 1
+            and subs_idxc(self.tile_size) % vector_shape != 0
         ):
             tile_bound = self.apply().start + self.tile_size
             bound = get_min_expr(bound, tile_bound)
@@ -727,7 +729,8 @@ class WaveConstraint(DistributionConstraint):
         bound = None
         if (
             vector_shape is not None
-            and subs_idxc(self.tile_size) % subs_idxc(vector_shape) != 0
+            and vector_shape > 1
+            and subs_idxc(self.tile_size) % vector_shape != 0
         ):
             bound = (
                 self.wg_constraint.apply().start + self.apply().start + self.tile_size

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -664,6 +664,7 @@ class WaveConstraint(DistributionConstraint):
     dim: IndexExpr
     tile_size: IndexExpr
     wave_id: Optional[IndexExpr | int] = None
+    wg_constraint: Optional[WorkgroupConstraint] = None
 
     def apply(self) -> IndexSequence:
         if self.wave_id is None:
@@ -692,6 +693,7 @@ class WaveConstraint(DistributionConstraint):
         assert (
             old_wave_id is None or self.wave_id == old_wave_id
         ), f"Conflicting preset wave_id old: {old_wave_id} new: {self.wave_id}"
+        self.wg_constraint = workgroup_constraint
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
@@ -699,7 +701,9 @@ class WaveConstraint(DistributionConstraint):
             vector_shape is not None
             and subs_idxc(self.tile_size) % subs_idxc(vector_shape) != 0
         ):
-            bound = self.apply().start + self.tile_size
+            bound = (
+                self.wg_constraint.apply().start + self.apply().start + self.tile_size
+            )
 
         return bound
 

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -532,6 +532,8 @@ class WorkgroupConstraint(DistributionConstraint):
 
     def get_index_bound(self, vector_shape: Optional[int]) -> Optional[IndexExpr]:
         bound = None
+        # Work bound computed as `count * tile_size`, where `count` is
+        # `ceiling(dim / tile_size)`. Check if dim perfectly aligned with tile size.
         if subs_idxc(self.work_bound) != subs_idxc(self.dim_bound):
             bound = self.dim_bound
 

--- a/iree/turbine/kernel/wave/expansion/expansion_utils.py
+++ b/iree/turbine/kernel/wave/expansion/expansion_utils.py
@@ -29,9 +29,13 @@ from ...ops.wave_ops import (
 from ...lang.global_symbols import SHARED_ADDRESS_SPACE
 import itertools
 from iree.turbine.kernel._support.dtype import DataType
+from iree.turbine.kernel.wave.utils.general_utils import ceildiv
 from ..utils.graph_utils import (
     get_inputs,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ExpansionMetadata:
@@ -87,12 +91,12 @@ def get_dim_scaling(
                 tile_size % wave_count != 0
                 or (tile_size / wave_count) % vector_size != 0
             ):
-                raise ValueError(
-                    f"Tile size must be divisible by wave count and vector size, got: "
+                logger.info(
+                    f"Tile size is not divisible by wave count and vector size, got: "
                     f"dim={constraint.dim}, "
                     f"tile_size={tile_size}, wave_count={wave_count}, vector_size={vector_size}"
                 )
-            dim_scaling[constraint.dim] = tile_size // wave_count // vector_size
+            dim_scaling[constraint.dim] = ceildiv(tile_size, wave_count * vector_size)
 
     if isinstance(node.type, DataType):
         return {}

--- a/iree/turbine/kernel/wave/expansion/expansion_utils.py
+++ b/iree/turbine/kernel/wave/expansion/expansion_utils.py
@@ -87,6 +87,7 @@ def get_dim_scaling(
                 raise ValueError(
                     "Tile size, wave count and vector size must be statically known"
                 )
+
             if (
                 tile_size % wave_count != 0
                 or (tile_size / wave_count) % vector_size != 0
@@ -96,6 +97,12 @@ def get_dim_scaling(
                     f"dim={constraint.dim}, "
                     f"tile_size={tile_size}, wave_count={wave_count}, vector_size={vector_size}"
                 )
+
+            if tile_size < vector_size and vector_size % tile_size != 0:
+                raise ValueError(
+                    f"Tile size {tile_size} is smaller than vector size {vector_size} and not divisible by it"
+                )
+
             dim_scaling[constraint.dim] = ceildiv(tile_size, wave_count * vector_size)
 
     if isinstance(node.type, DataType):

--- a/iree/turbine/kernel/wave/shared_memory_indexing.py
+++ b/iree/turbine/kernel/wave/shared_memory_indexing.py
@@ -28,16 +28,3 @@ def apply_shared_memory_indexing_corrections(
         return False
 
     trace.walk(is_shared_memory_ops)
-
-
-def align_index_sizes(trace: CapturedTrace, constraints: list[Constraint]):
-    """
-    Adjust ops index sizes to WG/Tile size, so shared mem ops never need to
-    do partial read/writes.
-    """
-
-    def need_align(node: fx.Node):
-        custom = get_custom(node)
-        custom.align_index(constraints)
-
-    trace.walk(need_align)

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -156,12 +156,9 @@ def align_index_vars(
         if dim not in index:
             continue
 
-        preferred_bound = constraint.get_preferred_bound(vector_shapes.get(dim, None))
+        preferred_bound = constraint.get_index_bound(vector_shapes.get(dim, None))
         if preferred_bound is not None:
-            assert (
-                dim not in key_subs or key_subs[dim] == preferred_bound
-            ), f"Dimension {dim} already in key_subs {key_subs} with value {key_subs[dim]}"
-            key_subs[dim] = preferred_bound
+            key_subs[dim] = get_min_expr(key_subs.get(dim, None), preferred_bound)
 
     return {safe_subs(key, key_subs): index[key] for key in index}
 

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -126,7 +126,7 @@ def remove_global_indexing(
     for key in new_index:
         for constraint in tiling_constraints:
             new_dim = new_index[key]
-            if sympy.sympify(new_dim.start).has(constraint.induction_var):
+            if new_dim.has(constraint.induction_var):
                 new_dim = new_dim.subs({constraint.induction_var: 0})
                 new_dim.start = new_dim.start - constraint.start
                 new_index[key] = new_dim

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -23,7 +23,7 @@ from ..constraints import (
     TilingConstraint,
     WorkgroupConstraint,
 )
-from .symbol_utils import safe_subs, subs_idxc
+from .symbol_utils import get_min_expr, safe_subs, subs_idxc
 
 
 # TODO: Monkey-patching f16 support, need to fix in iree.
@@ -138,25 +138,16 @@ def is_shared_mem_access(custom: "CustomOp") -> bool:
 
 
 def align_index_vars(
-    index: dict[IndexSymbol, IndexSequence], constraints: list[Constraint]
+    index: dict[IndexSymbol, IndexSequence],
+    constraints: list[Constraint],
+    vector_shapes: Optional[dict[IndexSymbol, int]],
 ) -> dict[IndexSymbol, IndexSequence]:
     """
     This function aligns index vars with Workgroup/Tiling constraints so it never
     need partial reads/writes.
     """
-    key_subs = {
-        c.dim: (c.work_bound)
-        for c in constraints
-        if isinstance(c, DistributionConstraint)
-        and subs_idxc(c.dim) != subs_idxc(c.work_bound)
-    }
-    return {safe_subs(key, key_subs): index[key] for key in index}
-
-
-def find_index_bounds(
-    constraints: list[Constraint], index: dict[IndexExpr, IndexExpr]
-) -> Optional[list[IndexExpr]]:
-    bounds = []
+    vector_shapes = vector_shapes or {}
+    key_subs = {}
     for constraint in constraints:
         if not isinstance(constraint, DistributionConstraint):
             continue
@@ -165,13 +156,41 @@ def find_index_bounds(
         if dim not in index:
             continue
 
-        work_size = constraint.work_bound
-        if subs_idxc(work_size) == subs_idxc(dim):
+        preferred_bound = constraint.get_preferred_bound(vector_shapes.get(dim, None))
+        if preferred_bound is not None:
+            assert (
+                dim not in key_subs or key_subs[dim] == preferred_bound
+            ), f"Dimension {dim} already in key_subs {key_subs} with value {key_subs[dim]}"
+            key_subs[dim] = preferred_bound
+
+    return {safe_subs(key, key_subs): index[key] for key in index}
+
+
+def find_index_bounds(
+    constraints: list[Constraint],
+    index: dict[IndexExpr, IndexExpr],
+    vector_shapes: Optional[dict[IndexSymbol, int]],
+) -> Optional[dict[IndexExpr, IndexExpr]]:
+    """
+    Find the bounds for the index variables is partial access/masking is needed.
+
+    Returns None if no partial access is needed.
+    """
+    vector_shapes = vector_shapes or {}
+    bounds = {}
+    for constraint in constraints:
+        if not isinstance(constraint, DistributionConstraint):
             continue
 
-        bounds.append(dim)
+        dim = constraint.dim
+        if dim not in index:
+            continue
 
-    if len(bounds) == 0:
+        bound = constraint.get_index_bound(vector_shapes.get(dim, None))
+        if bound is not None:
+            bounds[dim] = get_min_expr(bounds.get(dim, None), bound)
+
+    if not bounds:
         return None
 
     return bounds

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -128,7 +128,11 @@ def remove_global_indexing(
             new_dim = new_index[key]
             if new_dim.has(constraint.induction_var):
                 new_dim = new_dim.subs({constraint.induction_var: 0})
-                new_dim.start = new_dim.start - constraint.start
+                if isinstance(new_dim.start, IndexSequence):
+                    new_dim.start = new_dim.start - constraint.start
+                else:
+                    new_dim = new_dim - constraint.start
+
                 new_index[key] = new_dim
     return new_index
 

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -128,7 +128,7 @@ def remove_global_indexing(
             new_dim = new_index[key]
             if new_dim.has(constraint.induction_var):
                 new_dim = new_dim.subs({constraint.induction_var: 0})
-                if isinstance(new_dim.start, IndexSequence):
+                if isinstance(new_dim, IndexSequence):
                     new_dim.start = new_dim.start - constraint.start
                 else:
                     new_dim = new_dim - constraint.start

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -156,7 +156,7 @@ def align_index_vars(
         if dim not in index:
             continue
 
-        preferred_bound = constraint.get_index_bound(vector_shapes.get(dim, None))
+        preferred_bound = constraint.get_preferred_bound(vector_shapes.get(dim, None))
         if preferred_bound is not None:
             key_subs[dim] = get_min_expr(key_subs.get(dim, None), preferred_bound)
 

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -141,32 +141,6 @@ def is_shared_mem_access(custom: "CustomOp") -> bool:
     return custom.memory_type.address_space == SHARED_ADDRESS_SPACE
 
 
-def align_index_vars(
-    index: dict[IndexSymbol, IndexSequence],
-    constraints: list[Constraint],
-    vector_shapes: Optional[dict[IndexSymbol, int]],
-) -> dict[IndexSymbol, IndexSequence]:
-    """
-    This function aligns index vars with Workgroup/Tiling constraints so it never
-    need partial reads/writes.
-    """
-    vector_shapes = vector_shapes or {}
-    key_subs = {}
-    for constraint in constraints:
-        if not isinstance(constraint, DistributionConstraint):
-            continue
-
-        dim = constraint.dim
-        if dim not in index:
-            continue
-
-        preferred_bound = constraint.get_preferred_bound(vector_shapes.get(dim, None))
-        if preferred_bound is not None:
-            key_subs[dim] = get_min_expr(key_subs.get(dim, None), preferred_bound)
-
-    return {safe_subs(key, key_subs): index[key] for key in index}
-
-
 def find_index_bounds(
     constraints: list[Constraint],
     index: dict[IndexExpr, IndexExpr],

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -111,8 +111,8 @@ def get_hardware_vector_map(constraints: list[Constraint]) -> dict[IndexSymbol, 
 
 
 def remove_global_indexing(
-    index: dict[IndexSymbol, IndexSequence], constraints: list[Constraint]
-) -> dict[IndexSymbol, IndexSequence]:
+    index: dict[IndexSymbol, IndexSequence | IndexExpr], constraints: list[Constraint]
+) -> dict[IndexSymbol, IndexSequence | IndexExpr]:
     """
     This function takes the index sequence for a global read and removes all
     workgroup and induction level indexing. This is necessary for writes to shared memory
@@ -131,6 +131,9 @@ def remove_global_indexing(
                 if isinstance(new_dim, IndexSequence):
                     new_dim.start = new_dim.start - constraint.start
                 else:
+                    assert isinstance(
+                        new_dim, sympy.Basic
+                    ), f"new_dim is not a sympy expression: {new_dim}"
                     new_dim = new_dim - constraint.start
 
                 new_index[key] = new_dim

--- a/iree/turbine/kernel/wave/utils/symbol_utils.py
+++ b/iree/turbine/kernel/wave/utils/symbol_utils.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ..._support.indexing import IndexExpr, IndexingContext, IndexSymbol, IndexSequence
-from typing import Any
+from typing import Any, Optional
 import sympy
 
 
@@ -28,3 +28,17 @@ def subs_idxc(input: Any) -> IndexSymbol | int:
     """
     idxc = IndexingContext.current()
     return safe_subs(input, idxc.subs)
+
+
+def get_min_expr(
+    expr1: Optional[IndexExpr], expr2: Optional[IndexExpr]
+) -> Optional[IndexExpr]:
+    """
+    Get minimum expression of two expressions.
+    """
+    if expr1 is None:
+        return expr2
+    if expr2 is None:
+        return expr1
+
+    return sympy.Min(expr1, expr2)

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -60,7 +60,6 @@ from .scheduling.schedule import schedule_graph
 from .type_inference import infer_types
 from .shared_memory_indexing import (
     apply_shared_memory_indexing_corrections,
-    align_index_sizes,
 )
 
 # Utils
@@ -587,10 +586,6 @@ class LaunchableWave(Launchable):
                 trace,
                 options.minimize_shared_allocs,
             ),
-            # Align sizes to WG/Tile sizes
-            # This pass changes indexing keys, which can interfere with other passes,
-            # so it should be called close to the end of pipeline.
-            # partial(align_index_sizes, trace, self.constraints),
             partial(add_shared_memory_barriers, trace),
             partial(compute_shared_memory_usage, trace, options.kernel_launch_info),
         ]

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -590,7 +590,7 @@ class LaunchableWave(Launchable):
             # Align sizes to WG/Tile sizes
             # This pass changes indexing keys, which can interfere with other passes,
             # so it should be called close to the end of pipeline.
-            partial(align_index_sizes, trace, self.constraints),
+            # partial(align_index_sizes, trace, self.constraints),
             partial(add_shared_memory_barriers, trace),
             partial(compute_shared_memory_usage, trace, options.kernel_launch_info),
         ]

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -231,7 +231,7 @@ def test_gqa_flash_decoding():
     phase_0 = wave_compile(options, phase_0)
     print(phase_0.asm)
 
-    # CHECK:                func.func @phase_0
+    # CHECK-LABEL:          func.func @phase_0
     # CHECK:                   scf.for
     # CHECK:                      amdgpu.lds_barrier
     # CHECK-COUNT-16:             vector.maskedload

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -219,7 +219,7 @@ def test_causal_extend_attention():
 
     # Expressions to compute loop bound based on causal mask
     # CHECK:                %[[NQ_TILE_UPPER_BOUND:.*]] = affine.apply #[[map32]]()[%[[workgroup_id_0]]]
-    # CHECK:                arith.minsi {{.*}}, %[[NQ_TILE_UPPER_BOUND]]
+    # CHECK:                arith.minsi %[[NQ_TILE_UPPER_BOUND]], {{.*}} : index
 
     # CHECK-COUNT-4:        vector.maskedload
     # CHECK:                amdgpu.lds_barrier

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -186,9 +186,9 @@ def test_gemm_small_tile_size():
     # For tile sizes smaller than vector size, check we are using masked load/stores to shared memory
     # CHECK:              vector.maskedload %[[A]]
     # CHECK:              amdgpu.lds_barrier
-    # CHECK:              vector.maskedstore %[[VIEW0]]
-    # CHECK:              vector.maskedload %[[B]]
     # CHECK:              vector.maskedstore %[[VIEW1]]
+    # CHECK:              vector.maskedload %[[B]]
+    # CHECK:              vector.maskedstore %[[VIEW0]]
     # CHECK:              amdgpu.lds_barrier
     # CHECK:              vector.maskedload %[[VIEW0]]
     # CHECK:              vector.maskedload %[[VIEW1]]

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -125,6 +125,79 @@ def test_gemm():
 
 
 @run_test
+def test_gemm_small_tile_size():
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)
+            b_reg = tkw.read(b)
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        tkw.write(repeat, c)
+
+    options = WaveCompileOptions(
+        subs={
+            M: 64,
+            N: 128,
+            K: 64,
+            BLOCK_M: 8,
+            BLOCK_N: 8,
+            BLOCK_K: 8,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        compile_to_mlir=True,
+    )
+    gemm = wave_compile(options, gemm)
+    print(gemm.asm)
+
+    # CHECK-LABEL:    test_gemm_small_tile_size
+    # CHECK:          func.func @gemm
+    # CHECK-SAME:     (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding)
+    # CHECK:            %[[ALLOC:.*]] = memref.alloc()
+    # CHECK-DAG:        %[[VIEW0:.*]] = memref.view %[[ALLOC]]
+    # CHECK-DAG:        %[[VIEW1:.*]] = memref.view %[[ALLOC]]
+    # CHECK-DAG:        %[[A:.*]] = stream.binding.subspan %[[ARG0]]
+    # CHECK-DAG:        %[[B:.*]] = stream.binding.subspan %[[ARG1]]
+    # CHECK:            scf.for
+    # For tile sizes smaller than vector size, check we are using masked load/stores to shared memory
+    # CHECK:              vector.maskedload %[[A]]
+    # CHECK:              amdgpu.lds_barrier
+    # CHECK:              vector.maskedstore %[[VIEW0]]
+    # CHECK:              vector.maskedload %[[B]]
+    # CHECK:              vector.maskedstore %[[VIEW1]]
+    # CHECK:              amdgpu.lds_barrier
+    # CHECK:              vector.maskedload %[[VIEW0]]
+    # CHECK:              vector.maskedload %[[VIEW1]]
+    # CHECK:              amdgpu.mfma
+    # CHECK:            %[[C:.*]] = stream.binding.subspan %[[ARG2]]
+    # CHECK-COUNT-4:    vector.maskedstore %[[C]]
+
+
+@run_test
 def test_gemm_dot():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -215,7 +215,8 @@ def testPureGemm(
 
 
 @require_e2e
-@pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
+# @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
+@pytest.mark.parametrize("shape", [(32, 32, 32)])
 @pytest.mark.parametrize(
     "enable_scheduling",
     [
@@ -356,6 +357,8 @@ def testGemmSmallTiles(
             )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
+    print(c)
+    print(iree_ref)
     assert_close(c, iree_ref, check_device=False)
 
 

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -215,8 +215,7 @@ def testPureGemm(
 
 
 @require_e2e
-# @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
-@pytest.mark.parametrize("shape", [(32, 32, 32)])
+@pytest.mark.parametrize("shape", [(32, 32, 32)] + get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
     [
@@ -238,6 +237,7 @@ def testGemmSmallTiles(
     mfma_variant: MMAType,
     request,
 ):
+    # Test gemm with tiles smaller than MMA vector sizes.
     run_bench = request.config.getoption("--runperf")
     dump_perf = request.config.getoption("--dump-perf-files-path")
     # Input sizes
@@ -357,9 +357,6 @@ def testGemmSmallTiles(
             )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
-    torch.set_printoptions(profile="full")
-    print(c)
-    print(iree_ref)
     assert_close(c, iree_ref, check_device=False)
 
 

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -357,6 +357,7 @@ def testGemmSmallTiles(
             )
     iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
     generate_iree_ref("mmt", [a, b], [iree_ref])
+    torch.set_printoptions(profile="full")
     print(c)
     print(iree_ref)
     assert_close(c, iree_ref, check_device=False)

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -218,6 +218,151 @@ def testPureGemm(
 @pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",
+    [
+        SchedulingType.NONE,
+    ],
+)
+@param_bool("dynamic_dims", "dyn")
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x16_F16,
+        MMAType.F32_32x32x8_F16,
+    ],
+)
+def testGemmSmallTiles(
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    dynamic_dims: bool,
+    mfma_variant: MMAType,
+    request,
+):
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(1, 1, 1), mma_type=mfma_variant
+        )
+    ]
+
+    # With dynamic dimensions, we need to add an assumption on how big
+    # the iterate dimension is to determine whether we can schedule or not.
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K > BLOCK_K * 4)]
+
+    # Wave-level micro-kernel.
+    # Since warps are not directly addressable, there is no
+    # explicit notion of a warp id (like a workgroup or thread id).
+    # This kernel uses the input sizes M, N, K throughout, as the tiling
+    # and data movement strategy is determined during the compilation process.
+    # These can be influenced by introducing constraints.
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        # This microkernel encodes the fact that if the iterate
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            # a_reg: tkw.Register[M, K, tkl.f16]
+            a_reg = tkw.read(a)
+            # b_reg: tkw.Register[N, K, tkl.f16]
+            b_reg = tkw.read(b)
+            # acc: tkw.Register[M, N, tkl.f32]
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(repeat, c)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_M: 8,
+        BLOCK_N: 8,
+        BLOCK_K: 8,
+        M: shape[0],
+        N: shape[1],
+        K: shape[2],
+    }
+    hyperparams.update(get_default_scheduling_params())
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+    if dynamic_dims:
+        dynamic_symbols_map[M] = hyperparams[M]
+        dynamic_symbols_map[N] = hyperparams[N]
+        dynamic_symbols_map[K] = hyperparams[K]
+        dynamic_symbols.append(M)
+        dynamic_symbols.append(N)
+        dynamic_symbols.append(K)
+        del hyperparams[M]
+        del hyperparams[N]
+        del hyperparams[K]
+
+    perf_filename = request.node.name + ".json"
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=(
+            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
+        ),
+    )
+    options = set_default_run_config(options)
+    gemm = wave_compile(options, gemm)
+
+    a = device_randn(shape[0], shape[2], dtype=torch.float16)
+    b = device_randn(shape[1], shape[2], dtype=torch.float16)
+    c = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    asm = gemm(a, b, c)
+
+    if dump_generated_mlir:
+        filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
+        with open(filename, "w") as f:
+            f.write(asm)
+
+    if run_bench:
+        if dump_perf is not None:
+            options.benchmark_results_file = os.path.join(
+                dump_perf, "iree_" + perf_filename
+            )
+    iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
+    assert_close(c, iree_ref, check_device=False)
+
+
+@require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
+@pytest.mark.parametrize(
+    "enable_scheduling",
     [SchedulingType.NONE, SchedulingType.PREFETCH, SchedulingType.MODULO],
 )
 @param_bool("dynamic_dims", "dyn")


### PR DESCRIPTION
Handle `tile_size < vector_size` case by doing masking on shared mem. For the case when we have `BLOCK_M x BLOCK_N` tile size and `VEC_M x VEC_N` vector shape, it will read `BLOCK_M x BLOCK_N` tile from global to shared mem and then read   `VEC_M x VEC_N` from shared mem, masking values outside of `BLOCK_M x BLOCK_N`  to zeros.

* Refactor `DistributionConstraint` to have `get_index_bound` which will return combined global bound and tile bound and use it to determine bounds.
* Remove old hacky `align_index_sizes` pass, handle shared mem logic directly in `_build_mask` during MLIR lowering.
* Fix `sympy.Min/Max` lowering when the have more then 2 args.