### PR TITLE
Add stack tracing capability to Wave

### DIFF
--- a/iree/turbine/kernel/_support/location_config.py
+++ b/iree/turbine/kernel/_support/location_config.py
@@ -1,0 +1,20 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class LocationCaptureLevel(Enum):
+    NONE = 0
+    FILE_LINE_COL = 1
+    STACK_TRACE = 2
+    STACK_TRACE_WITH_SYSTEM = 3
+
+
+@dataclass
+class LocationCaptureConfig:
+    level: LocationCaptureLevel = LocationCaptureLevel.NONE

--- a/iree/turbine/kernel/_support/regions.py
+++ b/iree/turbine/kernel/_support/regions.py
@@ -14,12 +14,21 @@ import contextlib
 import torch.fx as fx
 import torch.utils._pytree as pytree
 
+from .location_config import LocationCaptureConfig
+
 
 class RegionGraph:
-    def __init__(self):
+    def __init__(
+        self, *, location_capture_config: Optional[LocationCaptureConfig] = None
+    ):
         self.tracers: List["SubgraphTracer"] = []
         self.subgraphs: Dict[str, fx.Graph] = dict()
         self.inner_freevars: Dict[fx.Graph, List[fx.Proxy]] = dict()
+        self.location_capture_config: LocationCaptureConfig = (
+            location_capture_config
+            if location_capture_config is not None
+            else LocationCaptureConfig()
+        )
 
     @property
     def root_tracer(self) -> "SubgraphTracer":

--- a/iree/turbine/kernel/_support/tracing.py
+++ b/iree/turbine/kernel/_support/tracing.py
@@ -35,6 +35,7 @@ from ..lang.wave_types import IndexMapping
 from ..ops.wave_ops import CustomOp
 
 from .regions import RegionGraph, SubgraphTracer
+from .location_config import LocationCaptureConfig
 
 from .. import ops
 from ..ops.base import (
@@ -60,6 +61,13 @@ TCallable = TypeVar("TCallable", bound=Callable)
 
 
 class KernelRegionGraph(RegionGraph):
+    def __init__(
+        self, *, location_capture_config: Optional[LocationCaptureConfig] = None
+    ):
+        super(KernelRegionGraph, self).__init__(
+            location_capture_config=location_capture_config
+        )
+
     def new_subtracer(
         self,
         region_graph: "RegionGraph",

--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -23,7 +23,7 @@ from ..lang.global_symbols import *
 from .._support.indexing import IndexExpr, IndexSymbol, IndexSequence
 from .._support.dtype import DataType, i1
 from .._support.regions import RegionGraph
-from .._support.location import FileLineColInfo
+from .._support.location import FileLineColInfo, StackTraceInfo, capture_location
 from .base import OpDispatcher
 import numpy as np
 
@@ -449,7 +449,7 @@ class CustomOp(ABC):
     _tracing_function: Optional[Callable[..., Any]] = field(default=None, init=False)
 
     @property
-    def location(self) -> Optional[FileLineColInfo]:
+    def location(self) -> Optional[Union[FileLineColInfo, StackTraceInfo]]:
         return getattr(self.fx_node, "location", None)
 
     @classmethod
@@ -626,7 +626,7 @@ class CustomOp(ABC):
         node._add_proxy_to_graph(graph)
         node.fx_node.node.tkw_op = cls
         node.fx_node.node.tkw_op_name = cls.tkw_op_name
-        node.fx_node.node.location = FileLineColInfo.capture_current_location()
+        node.fx_node.node.location = capture_location(graph.location_capture_config)
         return node.fx_node
 
     @property

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -117,7 +117,9 @@ class WaveEmitter:
         except KeyError:
             raise CodegenError(f"No handler registered for op {target_op}")
 
-        location = getattr(node, "location", None)  # type: FileLineColInfo
+        location = getattr(
+            node, "location", None
+        )  # type: Optional[Union[FileLineColInfo, StackTraceInfo]]
         ir_location = location.to_mlir() if location else Location.unknown()
         with ir_location:
             try:

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -4,6 +4,7 @@ import torch
 import glob
 from copy import copy
 from .._support.indexing import IndexingContext
+from .._support.location_config import LocationCaptureLevel
 from ..compiler import kernel_codegen, host_codegen
 from .compile_options import WaveCompileOptions
 
@@ -140,10 +141,18 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
     options.kernel_sig = kernel_sig
 
     host_codegen.isolated_test_call(
-        mb, exe, kernel_sig, entrypoint_name, options.func_name, options.dynamic_symbols
+        mb,
+        exe,
+        kernel_sig,
+        entrypoint_name,
+        options.func_name,
+        options.dynamic_symbols,
+        location_capture_config=options.location_capture_config,
     )
     asm = mb.module_op.get_asm(
-        enable_debug_info=options.debug_info, use_local_scope=options.use_local_scope
+        enable_debug_info=options.location_capture_config.level
+        != LocationCaptureLevel.NONE,
+        use_local_scope=options.use_local_scope,
     )
     if options.print_mlir:
         print(asm)

--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from .scheduling.schedule_enums import SchedulingType
 from .._support.indexing import IndexExpr, IndexSymbol
+from .._support.location_config import LocationCaptureConfig
 from .utils.classes import KernelLaunchInfo
 from ..compiler.kernel_codegen import KernelBufferUsage
 
@@ -53,7 +54,9 @@ class WaveCompileOptions:
     dump_binaries: str = None
     dump_intermediates: str = False
     compile_to_mlir: bool = False
-    debug_info: bool = False
+    location_capture_config: LocationCaptureConfig = field(
+        default_factory=LocationCaptureConfig
+    )
     use_local_scope: bool = False
 
     # === Performance options ===

--- a/lit_tests/kernel/wave/location.py
+++ b/lit_tests/kernel/wave/location.py
@@ -8,6 +8,10 @@ from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
 from iree.turbine.kernel.wave.utils.general_utils import (
     run_test,
 )
+from iree.turbine.kernel._support.location_config import (
+    LocationCaptureConfig,
+    LocationCaptureLevel,
+)
 
 M = tkl.sym.M
 N = tkl.sym.N
@@ -30,7 +34,7 @@ def _make_constraints() -> list[tkw.Constraint]:
 
 
 def _make_options(
-    *, debug_info: bool, use_local_scope: bool = False
+    *, loc_level: LocationCaptureLevel, use_local_scope: bool = False
 ) -> WaveCompileOptions:
     subs = {
         M: 16,
@@ -42,7 +46,7 @@ def _make_options(
     options = WaveCompileOptions(
         subs=subs,
         compile_to_mlir=True,
-        debug_info=debug_info,
+        location_capture_config=LocationCaptureConfig(loc_level),
         use_local_scope=use_local_scope,
     )
     return options
@@ -51,7 +55,9 @@ def _make_options(
 @run_test
 def test_location_local_scope():
     constraints = _make_constraints()
-    options = _make_options(debug_info=True, use_local_scope=True)
+    options = _make_options(
+        loc_level=LocationCaptureLevel.FILE_LINE_COL, use_local_scope=True
+    )
 
     @tkw.wave(constraints)
     def add_loc_local_scope(
@@ -74,7 +80,9 @@ def test_location_local_scope():
 @run_test
 def test_location_global_scope():
     constraints = _make_constraints()
-    options = _make_options(debug_info=True, use_local_scope=False)
+    options = _make_options(
+        loc_level=LocationCaptureLevel.FILE_LINE_COL, use_local_scope=False
+    )
 
     @tkw.wave(constraints)
     def add_loc_global_scope(
@@ -101,7 +109,7 @@ def test_location_global_scope():
 @run_test
 def test_no_location():
     constraints = _make_constraints()
-    options = _make_options(debug_info=False)
+    options = _make_options(loc_level=LocationCaptureLevel.NONE)
 
     @tkw.wave(constraints)
     def add_no_loc_info(
@@ -116,3 +124,100 @@ def test_no_location():
 
     # CHECK-LABEL: @add_no_loc
     # CHECK-NOT: loc(
+
+
+@run_test
+def test_stack_trace():
+    constraints = _make_constraints()
+    options = _make_options(
+        loc_level=LocationCaptureLevel.STACK_TRACE, use_local_scope=True
+    )
+
+    @tkw.wave(constraints)
+    def add_stack_trace(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        a_reg = tkw.read(a, elements_per_thread=16)
+        res = a_reg + a_reg
+
+    add_stack_trace = wave_compile(options, add_stack_trace)
+    print(add_stack_trace.asm)
+
+    # A relatively high-level check for stack trace. Verify that it is represented
+    # as callsite locations and that we see not only this file, but also torch fx.
+    # But not the "system frames" from iree/turbine/kernel.
+    #
+    # CHECK-LABEL: @add_stack_trace
+    # CHECK:       arith.addf
+    # CHECK-SAME:  loc(
+    # CHECK-SAME:    callsite(
+    # CHECK-SAME:      location.py
+    # CHECK-SAME:      at callsite(
+    # CHECK-SAME:        torch/fx
+    # CHECK-NOT:     iree/turbine/kernel
+    # CHECK:       return
+
+
+@run_test
+def test_stack_trace_with_system():
+    constraints = _make_constraints()
+    options = _make_options(
+        loc_level=LocationCaptureLevel.STACK_TRACE_WITH_SYSTEM, use_local_scope=True
+    )
+
+    @tkw.wave(constraints)
+    def add_stack_trace_with_system(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        a_reg = tkw.read(a, elements_per_thread=16)
+        res = a_reg + a_reg
+
+    add_stack_trace_with_system = wave_compile(options, add_stack_trace_with_system)
+    print(add_stack_trace_with_system.asm)
+
+    # A relatively high-level check for stack trace. Verify that it is represented
+    # as callsite locations and that we see not only this file, but also torch fx
+    # and "system frames" from iree/turbine/kernel.
+    #
+    # CHECK-LABEL: @add_stack_trace_with_system
+    # CHECK:       arith.addf
+    # CHECK-SAME:  loc(
+    # CHECK-SAME:    callsite(
+    # CHECK-SAME:      location.py
+    # CHECK-SAME:      at callsite(
+    # CHECK-SAME:        torch/fx
+    # CHECK-SAME:     iree/turbine/kernel
+    # CHECK:       return
+
+
+@run_test
+def test_stack_trace_dedup():
+    constraints = _make_constraints()
+    options = _make_options(
+        loc_level=LocationCaptureLevel.STACK_TRACE, use_local_scope=False
+    )
+
+    @tkw.wave(constraints)
+    def test_stack_trace_dedup(
+        a: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+        b: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f16],
+    ):
+        a_reg = tkw.read(a, elements_per_thread=16)
+        res = a_reg + a_reg
+
+    test_stack_trace_dedup = wave_compile(options, test_stack_trace_dedup)
+    print(test_stack_trace_dedup.asm)
+
+    # Ensure that stack trace location is deduplicated to avoid IR size growth.
+    # In particular, check that both the read and athe addition share a common
+    # parent location, that of the tracer.
+    #
+    # CHECK-LABEL: @test_stack_trace_dedup
+    # CHECK:       vector.load
+    # CHECK-SAME:  loc(#[[loc_load:.+]])
+    # CHECK:       arith.addf
+    # CHECK-SAME:  loc(#[[loc_addf:.+]])
+    # CHECK:       #[[loc_load]] = loc(callsite(#{{.*}} at #[[loc_parent:.+]])
+    # CHECK:       #[[loc_addf]] = loc(callsite(#{{.*}} at #[[loc_parent]])


### PR DESCRIPTION
Extend the previously added location information capability to capture complete stack traces when constructing Wave operations. This is particularly useful for debugging kernels integrated into Pytorch or more complex setups with nested function calls or decorators.

Thread the configuration options through the RegionGraph object because it's the only one accessible everywhere during op construction. For non-Wave kernels, the configuration may remain empty.

The location capture configuration options are added in a separate file to avoid transitive import of MLIR components when only configuration is necessary.