### PR TITLE
[Wave] Implement BitcastOp

### DIFF
--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -889,7 +889,10 @@ def test_unary_lowerings():
         res = tkw.roundeven(res)
         res = tkw.sin(res)
         res = tkw.cos(res)
+        res = tkw.bitcast(res, tkl.bf16)
         res = tkw.exp(res)
+        res = tkw.bitcast(res, tkl.f16)
+
         tkw.write(res, a, elements_per_thread=4)
         tkw.write(res_b, b, elements_per_thread=4)
 
@@ -944,8 +947,14 @@ def test_unary_lowerings():
     # Tests cos
     # CHECK: %[[COS:.+]] = math.cos %[[SIN]]
 
+    # Test bitcast to bf16
+    # CHECK: %[[COS_BF16:.+]] = vector.bitcast %[[COS]] : vector<4xf16> to vector<4xbf16>
+
     # Tests exp
-    # CHECK: %[[EXP:.+]] = math.exp %[[COS]]
+    # CHECK: %[[EXP_BF16:.+]] = math.exp %[[COS_BF16]]
+
+    # Test bitcast back to f16
+    # CHECK: %[[EXP:.+]] = vector.bitcast %[[EXP_BF16]] : vector<4xbf16> to vector<4xf16>
 
 
 # Important to check lowering of scheduling/barrier ops.


### PR DESCRIPTION
This is a simple PR that introduces bitcastOp into wave. Bitcating is very useful to represent or pack data from different bitwidths. Currently bitcastOp only support bitcast for same bitwidth. In follow on PRs, we will add support for scaled dimension and bitcasting to different widths.