### PR TITLE
[Wave] Teach compiler to handle "scaled" dimensions/indexing

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -1428,10 +1428,14 @@ class Read(CustomOp):
         return dims
 
     def infer_type(self):
+        from ..wave.utils.general_utils import infer_dim
+
         dtype = self.memory_type.dtype
-        shape = list(self.memory_type.symbolic_shape)
-        if self.mapping is not None:
-            shape = self.indexing_dims
+        memory_shape = list(self.memory_type.symbolic_shape)
+        dim_to_shape = {infer_dim(expr): expr for expr in memory_shape}
+        # Sub in dim's value from memory's type into indexing dim who contains the
+        # correct order/mapping/tensor dims for dst type.
+        shape = [dim_to_shape.get(dim, dim) for dim in self.indexing_dims]
         self.type = Register[(*shape, dtype)]
 
     @property
@@ -1751,9 +1755,11 @@ class Write(CustomOp):
 
         address_space = self.memory_type.address_space
         dtype = self.memory_type.dtype
-        shape = list(self.memory_type.symbolic_shape)
-        if self.mapping is not None:
-            shape = self.indexing_dims
+        memory_shape = list(self.memory_type.symbolic_shape)
+        dim_to_shape = {infer_dim(expr): expr for expr in memory_shape}
+        # Sub in dim's value from memory's type into indexing dim who contains the
+        # correct order/mapping/tensor dims for dst type.
+        shape = [dim_to_shape.get(dim, dim) for dim in self.indexing_dims]
         self.type = Memory[(*shape, address_space, dtype)]
 
     @property

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -40,6 +40,7 @@ from ..utils.general_utils import (
     get_hardware_constraint,
     get_largest_index_and_size,
     get_workgroup_constraints,
+    infer_dim,
     partial,
 )
 from ..utils.mma_utils import (
@@ -53,12 +54,14 @@ from ..utils.print_utils import (
     print_trace,
     try_apply_pass,
 )
-import torch.fx as fx
-import sympy
-from typing import Sequence, Callable, Optional
 from ....support.logging import get_logger
+
 from copy import deepcopy, copy
+from enum import Enum
 from iree.turbine.kernel._support.dtype import DataType
+import sympy
+import torch.fx as fx
+from typing import Sequence, Callable, Optional
 
 logger = get_logger("turbine.wave.index_sequence_analysis")
 
@@ -101,6 +104,107 @@ def set_derived_index(trace):
         for inp in get_inputs(current)[0]:
             new_index = custom.transform_index_backwards(custom.index, inp)
             worklist.append((inp, new_index))
+
+
+def is_scaled_dim(expr: sympy.Expr):
+    """
+    Function that checks if expression is a scaled sympy expression.
+    """
+    # Skip for cases where it is a single symbol or number.
+    if expr.is_Symbol or expr.is_Number:
+        return False
+    # Unhandled case where expression is multiple operations.
+    if sympy.count_ops(expr) != 1:
+        return False
+    # Skip if cannot find a multiply which represents a scale
+    if not isinstance(expr, sympy.Mul):
+        return False
+    return True
+
+
+def has_scaled_indices(node: fx.Node):
+    """
+    Function that checks if node has scaled dims/indexing.
+    """
+    if isinstance(get_custom(node), (Iterate, Output)):
+        return False
+    node_type = node.type
+    if not node_type:
+        return False
+    shape = node_type.symbolic_shape
+    # Skip for cases where it is a single symbol or number.
+    if all(not is_scaled_dim(dim) for dim in shape):
+        return False
+    # Only handle nodes with indices.
+    if not hasattr(node, "index"):
+        return False
+    return True
+
+
+class ScalingType(Enum):
+    MULTIPLY = 0x10
+    DIVIDE = 0x20
+
+
+def get_scale_from_dim(expr: sympy.Expr):
+    """
+    Checks if dim is a scaled dim and return the dim and it's scale
+    if it is indeed scaled dim. Returns the original input and None as scale
+    otherwise.
+    """
+    assert isinstance(expr, sympy.Mul)
+    assert len(expr.free_symbols) == 1
+    dim_symbol = list(expr.free_symbols)[0]
+    # Check that has expression is indeed dim / constant.
+    num, denom = expr.as_numer_denom()
+    # Check that denom is not fractional, one, or negative.
+    # note int(fractional_expr) -> 0.
+    if num != dim_symbol or int(denom) <= 1:
+        return expr, None, None
+    return dim_symbol, ScalingType.DIVIDE, int(denom)
+
+
+def resolve_scaled_indices(trace):
+    """
+    This function walks through operations in the graph and check
+    whether or not it has a "scaled" dim in it's symbolic shape.
+    If it does, then this function will amend it's index, elem_per_thread
+    and vector_shape to use it's "scaled" form.
+    """
+    sources = trace.walk(lambda node: has_scaled_indices(node))
+    for source in sources:
+        for dim in source.type.symbolic_shape:
+            if not is_scaled_dim(dim):
+                continue
+            dim, scale_type, scale_factor = get_scale_from_dim(dim)
+            if scale_type == ScalingType.DIVIDE:
+                source.index[dim].start = source.index[dim].start / scale_factor
+                if source.index[dim].size != 1:
+                    assert (
+                        source.index[dim].size % scale_factor == 0,
+                        "Size needs to be divisible by scale.",
+                    )
+                assert (
+                    source.vector_shapes[dim] % scale_factor == 0,
+                    "Expected vector_shape to be divisble by scale.",
+                )
+                source.index[dim].size = max(source.index[dim].size // scale_factor, 1)
+                source.vector_shapes[dim] = source.vector_shapes[dim] // scale_factor
+                custom = get_custom(source)
+                if isinstance(custom, (Read, Write)):
+                    assert (
+                        custom.elements_per_thread % scale_factor == 0,
+                        "elem per thread needs to be divisble by scale.",
+                    )
+                    scaled_elem_per_thread = int(
+                        custom.elements_per_thread / scale_factor
+                    )
+                    assert scaled_elem_per_thread != 0
+                    custom.update_arg("elements_per_thread", scaled_elem_per_thread)
+            else:
+                raise NotImplementedError(
+                    "Currently only handle case of scaled index where scaling is division."
+                )
 
 
 def verify_nodes(trace: CapturedTrace, constraints: list[Constraint]):
@@ -182,6 +286,7 @@ def set_node_indices(
     graph_passes += [
         partial(set_derived_index, trace),
         partial(resolve_thread_shapes, trace, constraints),
+        partial(resolve_scaled_indices, trace),
         partial(verify_nodes, trace, constraints),
     ]
     for p in graph_passes:
@@ -423,8 +528,9 @@ def should_update_index(
     # Get symbolic shape without any aliased variables.
     aliased_dims = [x.source for x in symbolic_constraints]
 
+    source_dims = [infer_dim(dim) for dim in source.type.symbolic_shape]
     if source.type:
-        symbolic_shape = set(source.type.symbolic_shape).difference(aliased_dims)
+        symbolic_shape = set(source_dims).difference(aliased_dims)
     else:
         symbolic_shape = []
 
@@ -486,7 +592,7 @@ def propagate_indices(
                 continue
             # GetResults inherit their index from the Iterate node
             # and hence we don't need to update their index.
-            source.vector_shapes = source_vector_shapes
+            source.vector_shapes = deepcopy(source_vector_shapes)
             if not isinstance(source, GetResult):
                 source_index = source.transform_index(source_index)
                 source.index = combine_indices(source.index, source_index)

--- a/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
+++ b/iree/turbine/kernel/wave/analysis/index_sequence_analysis.py
@@ -182,7 +182,7 @@ def resolve_scaled_indices(trace):
                 if source.index[dim].size != 1:
                     assert (
                         source.index[dim].size % scale_factor == 0,
-                        "Size needs to be divisible by scale.",
+                        f"Size({source.index[dim].size}) needs to be divisible by scale ({scale_factor}).",
                     )
                 assert (
                     source.vector_shapes[dim] % scale_factor == 0,

--- a/iree/turbine/kernel/wave/codegen/handlers.py
+++ b/iree/turbine/kernel/wave/codegen/handlers.py
@@ -1521,8 +1521,7 @@ def handle_bitcast(emitter: WaveEmitter, node: fx.Node):
     # Determine shape and type of target bitcast
     src_width = src_vector_type.element_type.width
     dst_width = dst_elem_type.width
-    if src_width != dst_width:
-        raise NotImplementedError("Currently only support same bitwidth casting.")
+    assert src_width % dst_width == 0 or dst_width % src_width == 0
     scale_factor = src_width / dst_width
     dst_vector_shape = int(src_vector_type.shape[0] * scale_factor)
     dst_vector_type = VectorType.get([dst_vector_shape], dst_elem_type)

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -39,7 +39,7 @@ from ...compiler.vector_codegen import (
 
 from ...ops.wave_ops import get_custom, read, write, CustomOp
 
-from ..utils.general_utils import get_fastest_index
+from ..utils.general_utils import get_fastest_index, infer_dim
 from ..utils.symbol_utils import safe_subs, subs_idxc
 
 from ..._support.indexing import IndexingContext, IndexExpr, IndexSequence, IndexSymbol
@@ -177,7 +177,8 @@ def _construct_gather_scatter_indices(
         assert (
             mapping.is_output_identity()
         ), "non-identity output mapping is not supported yet"
-        index_mapping = mapping.map_input_indices(symbolic_shape)
+        symbolic_dims = [infer_dim(dim_size) for dim_size in symbolic_shape]
+        index_mapping = mapping.map_input_indices(symbolic_dims)
     else:
         assert (
             mapping.is_input_identity()

--- a/iree/turbine/kernel/wave/constraints.py
+++ b/iree/turbine/kernel/wave/constraints.py
@@ -748,16 +748,20 @@ def get_constrained_shape(
             constraint
             for constraint in constraints
             if isinstance(constraint, (WorkgroupConstraint, TilingConstraint))
-            and dim == constraint.dim
+            and dim.has(constraint.dim)
         ]
         if not dim_constraints:
             continue
         if all_same_type(dim_constraints, WorkgroupConstraint) or all_same_type(
             dim_constraints, TilingConstraint
         ):
-            constrained_shape[i] = dim_constraints[0].tile_size
+            constrained_shape[i] = constrained_shape[i].subs(
+                dim_constraints[0].dim, dim_constraints[0].tile_size
+            )
             continue
         constrained_shape[i] = [
-            x.tile_size for x in dim_constraints if isinstance(x, TilingConstraint)
+            constrained_shape[i].subs(x.dim, x.tile_size)
+            for x in dim_constraints
+            if isinstance(x, TilingConstraint)
         ][0]
     return tuple(constrained_shape)

--- a/iree/turbine/kernel/wave/minimize_global_loads.py
+++ b/iree/turbine/kernel/wave/minimize_global_loads.py
@@ -17,6 +17,7 @@ from ..lang.global_symbols import *
 from .utils.general_utils import (
     delinearize_index,
     ceildiv,
+    infer_dim,
     is_shared_read,
     get_fastest_index,
 )
@@ -98,9 +99,12 @@ def materialize_shape(
     constraint_tile_size: dict[IndexSymbol, int], symbolic_shape: list[IndexSymbol]
 ) -> list[int]:
     materialized_shape = []
-    for dim in symbolic_shape:
+    for dim_expr in symbolic_shape:
+        dim = infer_dim(dim_expr)
         if dim in constraint_tile_size:
-            materialized_shape.append(subs_idxc(constraint_tile_size[dim]))
+            materialized_shape.append(
+                subs_idxc(dim_expr.subs(dim, constraint_tile_size[dim]))
+            )
         else:
             materialized_shape.append(subs_idxc(dim))
     return materialized_shape

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -456,3 +456,11 @@ def remove_files_with_extension(directory, extension):
             print(f"File not found: {file_path}")
         except Exception as e:
             print(f"Error removing {file_path}: {e}")
+
+
+def infer_dim(expr):
+    # Skip cases where infer_dim cannot or does not handle.
+    if expr.is_Symbol or expr.is_Number or len(expr.free_symbols) != 1:
+        return expr
+    dim_symbol = list(expr.free_symbols)[0]
+    return dim_symbol

--- a/iree/turbine/kernel/wave/utils/mapping_utils.py
+++ b/iree/turbine/kernel/wave/utils/mapping_utils.py
@@ -3,6 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from .general_utils import infer_dim
 from .symbol_utils import IndexExpr, IndexSymbol, subs_idxc
 from ...lang.wave_types import IndexMapping
 from ..._support.indexing import IndexingContext
@@ -205,7 +206,8 @@ def check_is_mapping_contiguous(
         assert (
             mapping.is_output_identity()
         ), "non-identity output mapping is not supported yet"
-        index_mapping = mapping.map_input_indices(symbolic_shape)
+        symbolic_dims = [infer_dim(dim_size) for dim_size in symbolic_shape]
+        index_mapping = mapping.map_input_indices(symbolic_dims)
     else:
         assert (
             mapping.is_input_identity()

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -482,11 +482,12 @@ def test_packed_gemm():
     # Lastly, we need to check that indeed we have half the shapes (<2xi32>) before bitcasting to f16 (<4xf16>).
     # %[[IV_K:.+]] = affine.apply #[[MAP_IV_K]]()[%[[IV]], %[[TID_X]]]
 
+    # CHECK-LABEL:    test_packed_gemm
     # CHECK-DAG:      #[[MAP_IV_K:.+]] = affine_map<()[s0, s1] -> (s0 * 8 + ((s1 mod 64) floordiv 16) * 2)>
-    # CHECK-LABEL:    func.func @packed_gemm
-    # CHECK:            %[[C1:.+]] = arith.constant 1 : index
-    # CHECK:            %[[C4:.+]] = arith.constant 4 : index
-    # CHECK:            %[[C0:.+]] = arith.constant 0 : index
+    # CHECK:          func.func @packed_gemm
+    # CHECK-DAG:        %[[C1:.+]] = arith.constant 1 : index
+    # CHECK-DAG:        %[[C4:.+]] = arith.constant 4 : index
+    # CHECK-DAG:        %[[C0:.+]] = arith.constant 0 : index
     # CHECK:            %[[TID_X:.+]] = gpu.thread_id  x
     # CHECK-COUNT-1:    %[[ALLOC:.+]] = memref.alloc()
     # CHECK:            %[[RHS_SHARED:.+]] = memref.view %[[ALLOC]][%c0][] : memref<2560xi8, #gpu.address_space<workgroup>> to memref<32x10xi32, #gpu.address_space<workgroup>>

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -412,6 +412,100 @@ def test_cdna3_int_gemm():
 
 
 @run_test
+def test_packed_gemm():
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(2, 2, 1),
+            mma_type=tkw.MMAType.F32_16x16x16_F16,
+        )
+    ]
+
+    @tkw.wave(constraints)
+    def packed_gemm(
+        a: tkl.Memory[M, K / 2, ADDRESS_SPACE, tkl.i32],
+        b: tkl.Memory[N, K / 2, ADDRESS_SPACE, tkl.i32],
+        c: tkl.Memory[M, N, ADDRESS_SPACE_0, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)  # [M, K/2, tkl.i32]
+            a_reg = tkw.bitcast(a_reg, tkl.f16)  # [M, K, tkl.f16]
+            b_reg = tkw.read(b)  # [M, K/2, tkl.i32]
+            b_reg = tkw.bitcast(b_reg, tkl.f16)  # [N, K, tkl.f16]
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        tkw.write(repeat, c)
+
+    options = WaveCompileOptions(
+        subs={
+            M: 64,
+            N: 128,
+            K: 64,
+            BLOCK_M: 32,
+            BLOCK_N: 32,
+            BLOCK_K: 16,
+            ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+            ADDRESS_SPACE_0: GLOBAL_ADDRESS_SPACE,
+        },
+        canonicalize=True,
+        compile_to_mlir=True,
+    )
+    packed_gemm = wave_compile(options, packed_gemm)
+    print(packed_gemm.asm)
+
+    # This test is important to test "scaled" dimension in the field of index propagation, expansion and shapes.
+    # In this test we have halved the K dim to K/2 as we packed f16 to i32. This means before bitcasting,
+    # we will have 1/2 the number of elements.
+    #
+    # Hence we need to check that we are indexing correctly specifically of lhs and rhs in the Iterate.
+    # This means mapping/indexing of K-dim needs to be halved then original F16 variant:
+    # Original: (s0 * 16 + ((s1 mod 64) floordiv 16) * 4)
+    # Packed:   (s0 * 8 + ((s1 mod 64) floordiv 16) * 2)
+    #
+    # Moreover, we need to that the allocated shared memory in i32 indeed has half the
+    # size if it was f16, modulo padding.
+    #
+    # Then, we'd need to ensure that loop bound and step stays as 0->4 (K/BLOCK_K = 64 / 16) with step 1,
+    # as if we are iterating on the original K dim. This is because we are handling the "scaled" K dim
+    # in the index (by scaling/halving it's index), hence no need to modify loop bound or steps.
+    #
+    # Lastly, we need to check that indeed we have half the shapes (<2xi32>) before bitcasting to f16 (<4xf16>).
+    # %[[IV_K:.+]] = affine.apply #[[MAP_IV_K]]()[%[[IV]], %[[TID_X]]]
+
+    # CHECK-DAG:      #[[MAP_IV_K:.+]] = affine_map<()[s0, s1] -> (s0 * 8 + ((s1 mod 64) floordiv 16) * 2)>
+    # CHECK-LABEL:    func.func @packed_gemm
+    # CHECK:            %[[C1:.+]] = arith.constant 1 : index
+    # CHECK:            %[[C4:.+]] = arith.constant 4 : index
+    # CHECK:            %[[C0:.+]] = arith.constant 0 : index
+    # CHECK:            %[[TID_X:.+]] = gpu.thread_id  x
+    # CHECK-COUNT-1:    %[[ALLOC:.+]] = memref.alloc()
+    # CHECK:            %[[RHS_SHARED:.+]] = memref.view %[[ALLOC]][%c0][] : memref<2560xi8, #gpu.address_space<workgroup>> to memref<32x10xi32, #gpu.address_space<workgroup>>
+    # CHECK:            %[[LHS_SHARED:.+]] = memref.view %[[ALLOC]][%c1280][] : memref<2560xi8, #gpu.address_space<workgroup>> to memref<32x10xi32, #gpu.address_space<workgroup>>
+    # CHECK:            scf.for %[[IV:.+]] = %[[C0]] to %[[C4]] step %[[C1]]
+    # CHECK:              %[[IV_K:.+]] = affine.apply #[[MAP_IV_K]]()[%[[IV]], %[[TID_X]]]
+    # CHECK:              %[[LHS_REG:.+]] = vector.load %{{.*}}[%{{.*}}, %[[IV_K]]] : memref<64x32xi32, strided<[32, 1], offset: ?>>, vector<2xi32>
+    # CHECK:              amdgpu.lds_barrier
+    # CHECK:              vector.store %[[LHS_REG]], %[[LHS_SHARED]]
+    # CHECK:              %[[RHS_REG:.+]] = vector.load  %{{.*}}[%{{.*}}, %[[IV_K]]] : memref<128x32xi32, strided<[32, 1], offset: ?>>, vector<2xi32>
+    # CHECK:              vector.store %[[RHS_REG]], %[[RHS_SHARED]]
+    # CHECK:              amdgpu.lds_barrier
+    # CHECK-COUNT-2:      vector.load {{.*}} : {{.*}}, vector<2xi32>
+    # CHECK-COUNT-2:      vector.bitcast %{{.*}} : vector<2xi32> to vector<4xf16>
+    # CHECK:              amdgpu.mfma
+    # CHECK-COUNT-4:    vector.store
+
+
+@run_test
 def test_batched_gemm():
     constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
     constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -1364,6 +1364,147 @@ def testF8Gemm(
 
 
 @require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
+@pytest.mark.parametrize(
+    "enable_scheduling",
+    [
+        SchedulingType.NONE,
+    ],
+)
+@param_bool("dynamic_dims", "dyn", [False])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x16_F16,
+        MMAType.F32_32x32x8_F16,
+    ],
+)
+def testPackedGemm(
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    dynamic_dims: bool,
+    mfma_variant: MMAType,
+    request,
+):
+    # TODO: Convert this to i8 -> bitcast f16 gemm
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(2, 2, 1), mma_type=mfma_variant
+        )
+    ]
+
+    # With dynamic dimensions, we need to add an assumption on how big
+    # the iterate dimension is to determine whether we can schedule or not.
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K > BLOCK_K * 4)]
+
+    # Wave-level micro-kernel.
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K / 2, ADDRESS_SPACE, tkl.i32],
+        b: tkl.Memory[N, K / 2, ADDRESS_SPACE, tkl.i32],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        # This microkernel encodes the fact that if the iterate
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)  # tkw.Register[M, K/2, tkl.i32]
+            a_reg = tkw.bitcast(a_reg, tkl.f16)  # tkw.Register[M, K, tkl.f16]
+            b_reg = tkw.read(b)  # tkw.Register[N, K/2, tkl.i32]
+            b_reg = tkw.bitcast(b_reg, tkl.f16)  # tkw.Register[M, K, tkl.f16]
+            # acc: tkw.Register[M, N, tkl.f32]
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(repeat, c)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K: 32,
+        M: shape[0],
+        N: shape[1],
+        K: shape[2],
+    }
+    hyperparams.update(get_default_scheduling_params())
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+    if dynamic_dims:
+        dynamic_symbols_map[M] = hyperparams[M]
+        dynamic_symbols_map[N] = hyperparams[N]
+        dynamic_symbols_map[K] = hyperparams[K]
+        dynamic_symbols.append(M)
+        dynamic_symbols.append(N)
+        dynamic_symbols.append(K)
+        del hyperparams[M]
+        del hyperparams[N]
+        del hyperparams[K]
+
+    perf_filename = request.node.name + ".json"
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=(
+            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
+        ),
+    )
+    options = set_default_run_config(options)
+    gemm = wave_compile(options, gemm)
+
+    a = device_randn(shape[0], shape[2], dtype=torch.float16)
+    b = device_randn(shape[1], shape[2], dtype=torch.float16)
+    c = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    asm = gemm(a.view(torch.int32), b.view(torch.int32), c)
+
+    if dump_generated_mlir:
+        filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
+        with open(filename, "w") as f:
+            f.write(asm)
+
+    if run_bench:
+        if dump_perf is not None:
+            options.benchmark_results_file = os.path.join(
+                dump_perf, "iree_" + perf_filename
+            )
+    iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
+    assert_close(c, iree_ref, check_device=False)
+
+
+@require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_batched_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",

--- a/tests/kernel/wave/wave_gemm_test.py
+++ b/tests/kernel/wave/wave_gemm_test.py
@@ -1505,6 +1505,154 @@ def testPackedGemm(
 
 
 @require_e2e
+@pytest.mark.parametrize("shape", get_test_shapes("test_gemm"))
+@pytest.mark.parametrize(
+    "enable_scheduling",
+    [
+        SchedulingType.NONE,
+    ],
+)
+@param_bool("dynamic_dims", "dyn", [False])
+@pytest.mark.parametrize(
+    "mfma_variant",
+    [
+        MMAType.F32_16x16x16_F16,
+        MMAType.F32_32x32x8_F16,
+    ],
+)
+def testPackedNonTransposeGemm(
+    shape: tuple[int],
+    enable_scheduling: SchedulingType,
+    dynamic_dims: bool,
+    mfma_variant: MMAType,
+    request,
+):
+    # TODO: Convert this to i8 -> bitcast f16 gemm
+    run_bench = request.config.getoption("--runperf")
+    dump_perf = request.config.getoption("--dump-perf-files-path")
+    # Input sizes
+    M = tkl.sym.M
+    N = tkl.sym.N
+    K = tkl.sym.K
+    # Workgroup tile sizes
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    BLOCK_K = tkl.sym.BLOCK_K
+    # Address space (for GPU, shared(1) or global(0))
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    # Expose user-constraints
+    constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(M, BLOCK_M, 0)]
+    constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+    constraints += [tkw.TilingConstraint(K, BLOCK_K)]
+    constraints += [tkw.WaveConstraint(M, BLOCK_M / 2)]
+    constraints += [tkw.WaveConstraint(N, BLOCK_N / 2)]
+
+    constraints += [
+        tkw.HardwareConstraint(
+            threads_per_wave=64, waves_per_block=(2, 2, 1), mma_type=mfma_variant
+        )
+    ]
+
+    # With dynamic dimensions, we need to add an assumption on how big
+    # the iterate dimension is to determine whether we can schedule or not.
+    if dynamic_dims:
+        constraints += [tkw.Assumption(K > BLOCK_K * 4)]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    # Transpose during read for expected shape: (M, K) @ (N, K) -> (M, N)
+    b_mapping = tkw.IndexMapping(
+        num_iterators=2, inputs={N: i, K: j}, outputs={N: i, K: j}
+    )
+
+    # Wave-level micro-kernel.
+    @tkw.wave(constraints)
+    def gemm(
+        a: tkl.Memory[M, K / 2, ADDRESS_SPACE, tkl.i32],
+        b: tkl.Memory[K / 2, N, ADDRESS_SPACE, tkl.i32],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        c_reg = tkl.Register[M, N, tkl.f32](0.0)
+
+        # This microkernel encodes the fact that if the iterate
+        # dimension were tiled, then we would need to materialize a loop.
+        @tkw.iterate(K, init_args=[c_reg])
+        def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
+            a_reg = tkw.read(a)  # tkw.Register[M, K/2, tkl.i32]
+            a_reg = tkw.bitcast(a_reg, tkl.f16)  # tkw.Register[M, K, tkl.f16]
+            b_reg = tkw.read(b, mapping=b_mapping)  # tkw.Register[N, K/2, tkl.i32]
+            b_reg = tkw.bitcast(b_reg, tkl.f16)  # tkw.Register[M, K, tkl.f16]
+            # acc: tkw.Register[M, N, tkl.f32]
+            acc = tkw.mma(a_reg, b_reg, acc)
+            return acc
+
+        # repeat represents the results of the loop
+        tkw.write(repeat, c)
+
+    hyperparams = {
+        ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
+        BLOCK_M: 64,
+        BLOCK_N: 64,
+        BLOCK_K: 32,
+        M: shape[0],
+        N: shape[1],
+        K: shape[2],
+    }
+    hyperparams.update(get_default_scheduling_params())
+
+    dynamic_symbols = []
+    dynamic_symbols_map = {}
+    if dynamic_dims:
+        dynamic_symbols_map[M] = hyperparams[M]
+        dynamic_symbols_map[N] = hyperparams[N]
+        dynamic_symbols_map[K] = hyperparams[K]
+        dynamic_symbols.append(M)
+        dynamic_symbols.append(N)
+        dynamic_symbols.append(K)
+        del hyperparams[M]
+        del hyperparams[N]
+        del hyperparams[K]
+
+    perf_filename = request.node.name + ".json"
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        canonicalize=True,
+        run_bench=run_bench,
+        schedule=enable_scheduling,
+        use_scheduling_barriers=enable_scheduling_barriers,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+        benchmark_batch_size=10,
+        benchmark_repetitions=3,
+        benchmark_results_file=(
+            os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
+        ),
+    )
+    options = set_default_run_config(options)
+    gemm = wave_compile(options, gemm)
+
+    a = device_randn(shape[0], shape[2], dtype=torch.float16)
+    b = device_randn(shape[1], shape[2], dtype=torch.float16)
+    c = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    asm = gemm(a.view(torch.int32), b.view(torch.int32).T.contiguous(), c)
+
+    if dump_generated_mlir:
+        filename = f"wave_gemm_{'x'.join(map(str, shape))}.mlir"
+        with open(filename, "w") as f:
+            f.write(asm)
+
+    if run_bench:
+        if dump_perf is not None:
+            options.benchmark_results_file = os.path.join(
+                dump_perf, "iree_" + perf_filename
+            )
+    iree_ref = device_zeros(shape[0], shape[1], dtype=torch.float32)
+    generate_iree_ref("mmt", [a, b], [iree_ref])
+    assert_close(c, iree_ref, check_device=False)
+
+
+@require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("test_batched_gemm"))
 @pytest.mark.parametrize(
     "enable_scheduling",


### PR DESCRIPTION
This a first PR in a series of PR that will ultimately add sub-byte matmul support on Wave. This PR specifically gives our compiler the capability to handle "scaled" dimensions which will be useful for representing for example MxKxF4 -> Mx(K/2)xI8 or on our current tests packed MxKxF16 -> Mx(K/2)xI32. 

To accomplish the above, we added these following changes:

1. Teach read/write to handle type with scales (M, K/2). Letting indexing_dims of read/write use infer_dim to get `K` from scaled expr `K/2`. Moreover, then we teach infer_type of read/write to map these dimensions into it's scaled type (e.g K -> K/2), this is important for read/write with mapping/transpose.

2. Enable BitcastOp handle scale_factor != 1. We already have this implemented in a previous PR but artificially blocked it since there are no tests, but now since we have tests for bitcast with scale_factor != 1 we enable it.

3. Teach index analysis to look for ops with "scaled" dims/indexing and then handle it by scaling it's elements_per_thread, start index expression, and vector_shapes accordingly.

4. Teach constraints, expansion_utils and minimiz_global_loads to use "scaled" tile size (e.g block_k/2 instead of block_k). 

5. Teach mapping_utils, and read_write to handle scaled dims mapping by inferring back it's original dims (e.g instead of trying to map `K/2` we infer back to `K` which is easy/correct expr to map).