### PR TITLE
[Wave] NFC: Remove superfluous reduction subgraph after pipelining

### DIFF
--- a/iree/turbine/kernel/wave/scheduling/loop_reconstruction.py
+++ b/iree/turbine/kernel/wave/scheduling/loop_reconstruction.py
@@ -667,8 +667,9 @@ def construct_pipelined_loop(
         visualize,
     )
 
-    # Remove the unpipelined reduction.
+    # Remove the unpipelined reduction and the corresponding subgraph
     reduction.graph.erase_node(reduction.fx_node)
+    del trace.region_graph.subgraphs[reduction.subgraph_name]
 
     if visualize:
         visualize_graph(pipelined_reduction.graph, "pipelined.png")


### PR DESCRIPTION
The pipelining of a reduction graph creates a new reduction node and a corresponding subgraph. 
The old reduction node is erased, but its subgraph stays in the trace and also shows up during printing of the trace.
This removes the old unused subgraph