### PR TITLE
[BOO] Reduce some additional cpu overhead

### DIFF
--- a/iree/turbine/kernel/boo/modeling/replace.py
+++ b/iree/turbine/kernel/boo/modeling/replace.py
@@ -48,9 +48,6 @@ class BooConv1d(torch.nn.Module):
             self.register_parameter("bias", None)
 
     def forward(self, x):
-        input_layout = "NCH"
-        kernel_layout = "NCH"
-        output_layout = "NCH"
         no_batch = len(x.shape) == 2
         if no_batch:
             x = x.unsqueeze(0)
@@ -71,9 +68,6 @@ class BooConv1d(torch.nn.Module):
             padding=self.padding,
             dilation=self.dilation,
             groups=self.groups,
-            input_layout=input_layout,
-            kernel_layout=kernel_layout,
-            output_layout=output_layout,
         )
         return result.squeeze(0) if no_batch else result
 
@@ -108,20 +102,10 @@ class BooConv2d(torch.nn.Module):
             self.register_parameter("bias", None)
 
     def forward(self, x):
-        input_layout = "NCHW"
-        kernel_layout = "NCHW"
-        output_layout = "NCHW"
         no_batch = len(x.shape) == 3
         if no_batch:
             x = x.unsqueeze(0)
-        if x.is_contiguous(memory_format=torch.channels_last):
-            x = x.permute([0, 2, 3, 1])
-            input_layout = "NHWC"
         w = self.weight
-        if w.is_contiguous(memory_format=torch.channels_last):
-            w = w.permute([0, 2, 3, 1])
-            kernel_layout = "NHWC"
-            output_layout = "NHWC"
         bias = self.bias
         device_type = x.device.type
         if torch.is_autocast_enabled(device_type):
@@ -137,12 +121,7 @@ class BooConv2d(torch.nn.Module):
             padding=self.padding,
             dilation=self.dilation,
             groups=self.groups,
-            input_layout=input_layout,
-            kernel_layout=kernel_layout,
-            output_layout=output_layout,
         )
-        if output_layout == "NHWC":
-            result = result.permute([0, 3, 1, 2])
         return result.squeeze(0) if no_batch else result
 
 
@@ -176,20 +155,10 @@ class BooConv3d(torch.nn.Module):
             self.register_parameter("bias", None)
 
     def forward(self, x):
-        input_layout = "NCDHW"
-        kernel_layout = "NCDHW"
-        output_layout = "NCDHW"
         no_batch = len(x.shape) == 4
         if no_batch:
             x = x.unsqueeze(0)
-        if x.is_contiguous(memory_format=torch.channels_last_3d):
-            x = x.permute([0, 2, 3, 4, 1])
-            input_layout = "NDHWC"
         w = self.weight
-        if w.is_contiguous(memory_format=torch.channels_last_3d):
-            w = w.permute([0, 2, 3, 4, 1])
-            kernel_layout = "NDHWC"
-            output_layout = "NDHWC"
         bias = self.bias
         device_type = x.device.type
         if torch.is_autocast_enabled(device_type):
@@ -205,12 +174,7 @@ class BooConv3d(torch.nn.Module):
             padding=self.padding,
             dilation=self.dilation,
             groups=self.groups,
-            input_layout=input_layout,
-            kernel_layout=kernel_layout,
-            output_layout=output_layout,
         )
-        if output_layout == "NDHWC":
-            result = result.permute([0, 4, 1, 2, 3])
         return result.squeeze(0) if no_batch else result
 
 

--- a/iree/turbine/kernel/boo/ops/__init__.py
+++ b/iree/turbine/kernel/boo/ops/__init__.py
@@ -5,4 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .conv import *
+from .layout_customizable_conv import *
 from .library import *
+from .utils import *

--- a/iree/turbine/kernel/boo/ops/conv.py
+++ b/iree/turbine/kernel/boo/ops/conv.py
@@ -60,6 +60,12 @@ def make_tuple(a: Iterable | int, size: int) -> Tuple:
     raise TypeError(f"Input {a} is expected to be an iterable or int. Got {type(a)}.")
 
 
+CL_LAYOUT = {1: "NHC", 2: "NHWC", 3: "NDHWC"}
+CL_MEM = {2: torch.channels_last, 3: torch.channels_last_3d}
+CL_CONTIGUOUS_PERM = {1: [0, 2, 1], 2: [0, 2, 3, 1], 3: [0, 2, 3, 4, 1]}
+CONTIGUOUS_CL_PERM = {1: [0, 2, 1], 2: [0, 3, 1, 2], 3: [0, 4, 1, 2, 3]}
+
+
 @functools.lru_cache(maxsize=None)
 def get_func_name(
     input_shape: tuple,
@@ -105,7 +111,7 @@ def get_func_name(
 
 define_schema(
     "convolution",
-    "(Tensor x, Tensor w, Tensor? b, int[] stride, int[] padding, int[] dilation, int groups, str input_layout, str kernel_layout, str output_layout) -> Tensor",
+    "(Tensor x, Tensor w, Tensor? b, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor",
 )
 
 
@@ -118,10 +124,25 @@ def _boo_convolution_impl(
     padding: Sequence[int],
     dilation: Sequence[int],
     groups: int,
-    input_layout: str,
-    kernel_layout: str,
-    output_layout: str,
 ) -> torch.Tensor:
+
+    num_spatial_dims = len(x.shape) - 2
+
+    mem_format = CL_MEM[num_spatial_dims]
+    default_layout = DEFAULT_LAYOUTS[num_spatial_dims]
+    cl_layout = CL_LAYOUT[num_spatial_dims]
+    cl_contig_perm = CL_CONTIGUOUS_PERM[num_spatial_dims]
+    contig_cl_perm = CONTIGUOUS_CL_PERM[num_spatial_dims]
+
+    x_cl = x.is_contiguous(memory_format=mem_format)
+    w_cl = w.is_contiguous(memory_format=mem_format)
+
+    input_layout = cl_layout if x_cl else default_layout
+    kernel_layout = cl_layout if w_cl else default_layout
+    output_layout = cl_layout if w_cl else default_layout
+
+    x = x if not x_cl else x.permute(cl_contig_perm)
+    w = w if not w_cl else w.permute(cl_contig_perm)
 
     # Unfortunately, pytorch converts the tuple inputs to lists for some reason.
     # We need to convert them back to tuples.
@@ -142,7 +163,8 @@ def _boo_convolution_impl(
     args = (x.data, w.data) if b is None else (x.data, w.data, b.data)
     cache_hit = ConvLaunchableRuntimeCache.get(func_name)
     if cache_hit:
-        return cache_hit(*args)
+        result = cache_hit(*args)
+        return result if not w_cl else result.permute(contig_cl_perm)
 
     sig = ConvSignature(
         input_shape=x.shape,
@@ -163,7 +185,8 @@ def _boo_convolution_impl(
 
     # Get a launchable and apply.
     conv = get_launchable(sig)
-    return conv(*args)
+    result = conv(*args)
+    return result if not w_cl else result.permute(contig_cl_perm)
 
 
 @register_meta("convolution")
@@ -175,17 +198,10 @@ def _boo_convolution_meta(
     padding: Sequence[int],
     dilation: Sequence[int],
     groups: int,
-    input_layout: str,
-    kernel_layout: str,
-    output_layout: str,
 ) -> torch.Tensor:
     sig = ConvSignature(
         input_shape=x.shape,
         kernel_shape=w.shape,
-        input_layout=input_layout,
-        kernel_layout=kernel_layout,
-        output_layout=output_layout,
-        bias=(b is not None),
         dtype=x.dtype,
         stride=stride,
         padding=padding,
@@ -195,14 +211,22 @@ def _boo_convolution_meta(
         groups=groups,
         mode="fwd",
     )
-    return torch.empty(sig.output_shape, dtype=sig.dtype, device=x.device)
+    num_spatial_dims = len(x.shape) - 2
+    memory_format = (
+        CL_MEM[num_spatial_dims]
+        if w.is_contiguous(memory_format=CL_MEM[num_spatial_dims])
+        else torch.contiguous
+    )
+    return torch.empty(
+        sig.output_shape, dtype=sig.dtype, device=x.device, memory_format=memory_format
+    )
 
 
 # Backward Convolution Implementations #
 
 define_schema(
     "convolution_backward",
-    "(Tensor x, Tensor w, Tensor grad_output, int[] stride, int[] padding, int[] dilation, int groups, str input_layout, str kernel_layout, str output_layout, bool[] mask) -> (Tensor?, Tensor?, Tensor?)",
+    "(Tensor x, Tensor w, Tensor grad_output, int[] stride, int[] padding, int[] dilation, int groups, bool[] mask) -> (Tensor?, Tensor?, Tensor?)",
 )
 
 
@@ -215,11 +239,27 @@ def _boo_convolution_backward_impl(
     padding: Sequence[int],
     dilation: Sequence[int],
     groups: int,
-    input_layout: str,
-    kernel_layout: str,
-    output_layout: str,
     mask: Tuple[bool, bool, bool],
 ) -> Tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+
+    num_spatial_dims = len(x.shape) - 2
+    mem_format = CL_MEM[num_spatial_dims]
+    default_layout = DEFAULT_LAYOUTS[num_spatial_dims]
+    cl_layout = CL_LAYOUT[num_spatial_dims]
+    cl_contig_perm = CL_CONTIGUOUS_PERM[num_spatial_dims]
+    contig_cl_perm = CONTIGUOUS_CL_PERM[num_spatial_dims]
+
+    x_cl = x.is_contiguous(memory_format=mem_format)
+    w_cl = w.is_contiguous(memory_format=mem_format)
+    o_cl = grad_output.is_contiguous(memory_format=mem_format)
+
+    input_layout = cl_layout if x_cl else default_layout
+    kernel_layout = cl_layout if w_cl else default_layout
+    output_layout = cl_layout if o_cl else default_layout
+
+    x = x if not x_cl else x.permute(cl_contig_perm)
+    w = w if not w_cl else w.permute(cl_contig_perm)
+    grad_output = grad_output if not o_cl else grad_output.permute(cl_contig_perm)
 
     kwargs = {
         "stride": stride,
@@ -237,10 +277,12 @@ def _boo_convolution_backward_impl(
         bwd_sig = ConvSignature.get(x, w, mode="bwd", **kwargs)
         bwd_conv = get_launchable(bwd_sig)
         input_grad = bwd_conv(grad_output, w.data)
+        input_grad = input_grad if not x_cl else input_grad.permute(contig_cl_perm)
 
     if mask[1]:
         wrw_conv = get_launchable(ConvSignature.get(x, w, mode="wrw", **kwargs))
         weight_grad = wrw_conv(grad_output, x.data)
+        weight_grad = weight_grad if not w_cl else weight_grad.permute(contig_cl_perm)
 
     if mask[2]:
         # TODO: use iree to perform the reduce sum?
@@ -263,9 +305,6 @@ def _boo_convolution_backward_meta(
     padding: Sequence[int],
     dilation: Sequence[int],
     groups: int,
-    input_layout: str,
-    kernel_layout: str,
-    output_layout: str,
     mask: Tuple[bool, bool, bool],
 ) -> Tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
     input_grad = weight_grad = bias_grad = None
@@ -274,7 +313,7 @@ def _boo_convolution_backward_meta(
     if mask[1]:
         weight_grad = torch.empty_like(w)
     if mask[2]:
-        output_channels = w.shape[kernel_layout.find("N")]
+        output_channels = w.shape[0]
         bias_grad = torch.empty([output_channels], dtype=x.dtype, device=x.device)
     return input_grad, weight_grad, bias_grad
 
@@ -286,16 +325,6 @@ def pytorch_convolution_backward(ctx, grad_output):
     mask = tuple((ctx.needs_input_grad[i] for i in range(3)))
 
     # return to NCHW if necessary
-    rank = len(x.shape)
-    perm = [0] + [rank - 1] + list(range(1, rank - 1))
-    inv_perm = [0] + list(range(2, rank)) + [1]
-    if ctx.input_layout.endswith("C"):
-        x = x.permute(perm)
-    if ctx.kernel_layout.endswith("C"):
-        w = w.permute(perm)
-    if ctx.output_layout.endswith("C"):
-        grad_output = grad_output.permute(perm)
-
     input_grad, weight_grad, bias_grad = torch.ops.aten.convolution_backward(
         grad_output,
         x,
@@ -310,12 +339,8 @@ def pytorch_convolution_backward(ctx, grad_output):
         mask,
     )
 
-    if ctx.input_layout.endswith("C") and mask[0]:
-        input_grad = input_grad.permute(inv_perm)
-    if ctx.kernel_layout.endswith("C") and mask[1]:
-        weight_grad = weight_grad.permute(inv_perm)
     # return `None` for attribute args
-    return input_grad, weight_grad, bias_grad, None, None, None, None, None, None, None
+    return input_grad, weight_grad, bias_grad, None, None, None, None
 
 
 # Autograd Implementation #
@@ -332,9 +357,6 @@ class _BooConvolution(torch.autograd.Function):
             padding,
             dilation,
             groups,
-            input_layout,
-            kernel_layout,
-            output_layout,
         ) = args
 
         ctx.save_for_backward(x, w)
@@ -342,11 +364,6 @@ class _BooConvolution(torch.autograd.Function):
         ctx.padding = padding
         ctx.dilation = dilation
         ctx.groups = groups
-        ctx.input_layout = input_layout
-        ctx.kernel_layout = kernel_layout
-        ctx.output_layout = output_layout
-
-        ctx.use_bias = b is not None
 
         return torch.ops.boo.convolution(
             x,
@@ -356,9 +373,6 @@ class _BooConvolution(torch.autograd.Function):
             padding,
             dilation,
             groups,
-            input_layout,
-            kernel_layout,
-            output_layout,
         )
 
     @staticmethod
@@ -378,9 +392,6 @@ class _BooConvolution(torch.autograd.Function):
             ctx.padding,
             ctx.dilation,
             ctx.groups,
-            ctx.input_layout,
-            ctx.kernel_layout,
-            ctx.output_layout,
             mask,
         )
 
@@ -389,9 +400,6 @@ class _BooConvolution(torch.autograd.Function):
             input_grad,
             weight_grad,
             bias_grad,
-            None,
-            None,
-            None,
             None,
             None,
             None,
@@ -407,9 +415,6 @@ def boo_convolution(
     padding: Sequence[int],
     dilation: Sequence[int],
     groups: int,
-    input_layout: str,
-    kernel_layout: str,
-    output_layout: str,
 ) -> torch.Tensor:
     """Similar to boo_conv, but does not pre-process, nor provide defaults for, arguments like stride, dilation, etc."""
     use_autograd = torch._C.is_grad_enabled() and (
@@ -424,9 +429,6 @@ def boo_convolution(
             padding,
             dilation,
             groups,
-            input_layout,
-            kernel_layout,
-            output_layout,
         )
         if use_autograd
         else torch.ops.boo.convolution(
@@ -437,9 +439,6 @@ def boo_convolution(
             padding,
             dilation,
             groups,
-            input_layout,
-            kernel_layout,
-            output_layout,
         )
     )
 
@@ -456,10 +455,6 @@ def boo_conv(
     padding: int | Sequence[int] = 0,
     dilation: int | Sequence[int] = 1,
     groups: int = 1,
-    shared_layout: str | None = None,
-    input_layout: str | None = None,
-    kernel_layout: str | None = None,
-    output_layout: str | None = None,
 ):
     """
     Applies a differentiable forward convolution kernel.
@@ -470,20 +465,9 @@ def boo_conv(
         padding        : int or int[]
         dilation       : int or int[]
         groups         : int
-
-    Users can also specify alternative layouts for each convolution:
-
-        shared_layout  : str
-        input_layout   : str
-        kernel_layout  : str
-        output_layout  : str
-
-    These layouts should be permutations of "NCH", "NCHW", or "NCDHW".
     """
 
     num_spatial_dims = len(weight.shape) - 2
-
-    _infer = lambda layout: shared_layout or layout or DEFAULT_LAYOUTS[num_spatial_dims]
 
     # The decorators torch.amp.custom_fwd/custom_bwd don't seem to work with torch.library.custom_op
     # For now, this is a quick hack to manually do the casting outside our custom op.
@@ -502,7 +486,4 @@ def boo_conv(
         make_tuple(padding, num_spatial_dims),
         make_tuple(dilation, num_spatial_dims),
         groups,
-        _infer(input_layout),
-        _infer(kernel_layout),
-        _infer(output_layout),
     )

--- a/iree/turbine/kernel/boo/ops/layout_customizable_conv.py
+++ b/iree/turbine/kernel/boo/ops/layout_customizable_conv.py
@@ -1,0 +1,369 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Sequence, Tuple
+
+import torch
+
+from ..conv_exports import (
+    ConvSignature,
+    get_launchable,
+    DEFAULT_LAYOUTS,
+    ConvLaunchableRuntimeCache,
+)
+
+from .library import define_schema, register_impl, register_meta
+from .utils import *
+
+__all__ = [
+    "boo_layout_customizable_convolution",
+]
+
+# Forward Convolution Implementations #
+
+define_schema(
+    "layout_customizable_convolution",
+    "(Tensor x, Tensor w, Tensor? b, int[] stride, int[] padding, int[] dilation, int groups, str input_layout, str kernel_layout, str output_layout) -> Tensor",
+)
+
+
+@register_impl("layout_customizable_convolution")
+def _boo_layout_customizable_convolution_impl(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    b: None | torch.Tensor,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    input_layout: str,
+    kernel_layout: str,
+    output_layout: str,
+) -> torch.Tensor:
+
+    # Unfortunately, pytorch converts the tuple inputs to lists for some reason.
+    # We need to convert them back to tuples.
+    func_name = get_func_name(
+        tuple(x.shape),
+        tuple(w.shape),
+        str(x.dtype),
+        "FORWARD",
+        (b is not None),
+        tuple(stride),
+        tuple(padding),
+        tuple(dilation),
+        groups,
+        input_layout,
+        kernel_layout,
+        output_layout,
+    )
+    args = (x.data, w.data) if b is None else (x.data, w.data, b.data)
+    cache_hit = ConvLaunchableRuntimeCache.get(func_name)
+    if cache_hit:
+        return cache_hit(*args)
+
+    sig = ConvSignature(
+        input_shape=x.shape,
+        kernel_shape=w.shape,
+        input_layout=input_layout,
+        kernel_layout=kernel_layout,
+        output_layout=output_layout,
+        bias=(b is not None),
+        dtype=x.dtype,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        transposed=False,
+        output_padding=0,
+        groups=groups,
+        mode="fwd",
+    )
+
+    # Get a launchable and apply.
+    conv = get_launchable(sig)
+    return conv(*args)
+
+
+@register_meta("layout_customizable_convolution")
+def _boo_layout_customizable_convolution_meta(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    b: None | torch.Tensor,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    input_layout: str,
+    kernel_layout: str,
+    output_layout: str,
+) -> torch.Tensor:
+    sig = ConvSignature(
+        input_shape=x.shape,
+        kernel_shape=w.shape,
+        input_layout=input_layout,
+        kernel_layout=kernel_layout,
+        output_layout=output_layout,
+        bias=(b is not None),
+        dtype=x.dtype,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        transposed=False,
+        output_padding=0,
+        groups=groups,
+        mode="fwd",
+    )
+    return torch.empty(sig.output_shape, dtype=sig.dtype, device=x.device)
+
+
+# Backward Convolution Implementations #
+
+define_schema(
+    "layout_customizable_convolution_backward",
+    "(Tensor x, Tensor w, Tensor grad_output, int[] stride, int[] padding, int[] dilation, int groups, str input_layout, str kernel_layout, str output_layout, bool[] mask) -> (Tensor?, Tensor?, Tensor?)",
+)
+
+
+@register_impl("layout_customizable_convolution_backward")
+def _boo_layout_customizable_convolution_backward_impl(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    grad_output: torch.Tensor,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    input_layout: str,
+    kernel_layout: str,
+    output_layout: str,
+    mask: Tuple[bool, bool, bool],
+) -> Tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+
+    kwargs = {
+        "stride": stride,
+        "padding": padding,
+        "dilation": dilation,
+        "groups": groups,
+        "input_layout": input_layout,
+        "kernel_layout": kernel_layout,
+        "output_layout": output_layout,
+    }
+
+    input_grad = weight_grad = bias_grad = None
+
+    if mask[0]:
+        bwd_sig = ConvSignature.get(x, w, mode="bwd", **kwargs)
+        bwd_conv = get_launchable(bwd_sig)
+        input_grad = bwd_conv(grad_output, w.data)
+
+    if mask[1]:
+        wrw_conv = get_launchable(ConvSignature.get(x, w, mode="wrw", **kwargs))
+        weight_grad = wrw_conv(grad_output, x.data)
+
+    if mask[2]:
+        # TODO: use iree to perform the reduce sum?
+        output_layout = output_layout
+        reduce_dims = []
+        for i, char in enumerate(output_layout):
+            if char != "C":
+                reduce_dims.append(i)
+        bias_grad = torch.sum(grad_output, reduce_dims)
+
+    return input_grad, weight_grad, bias_grad
+
+
+@register_meta("layout_customizable_convolution_backward")
+def _boo_layout_customizable_convolution_backward_meta(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    grad_output: torch.Tensor,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    input_layout: str,
+    kernel_layout: str,
+    output_layout: str,
+    mask: Tuple[bool, bool, bool],
+) -> Tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    input_grad = weight_grad = bias_grad = None
+    if mask[0]:
+        input_grad = torch.empty_like(x)
+    if mask[1]:
+        weight_grad = torch.empty_like(w)
+    if mask[2]:
+        output_channels = w.shape[kernel_layout.find("N")]
+        bias_grad = torch.empty([output_channels], dtype=x.dtype, device=x.device)
+    return input_grad, weight_grad, bias_grad
+
+
+def pytorch_layout_customizable_convolution_backward(ctx, grad_output):
+    """Fallback implementation for backward."""
+    x, w = ctx.saved_tensors
+
+    mask = tuple((ctx.needs_input_grad[i] for i in range(3)))
+
+    # return to NCHW if necessary
+    rank = len(x.shape)
+    perm = [0] + [rank - 1] + list(range(1, rank - 1))
+    inv_perm = [0] + list(range(2, rank)) + [1]
+    if ctx.input_layout.endswith("C"):
+        x = x.permute(perm)
+    if ctx.kernel_layout.endswith("C"):
+        w = w.permute(perm)
+    if ctx.output_layout.endswith("C"):
+        grad_output = grad_output.permute(perm)
+
+    input_grad, weight_grad, bias_grad = torch.ops.aten.convolution_backward(
+        grad_output,
+        x,
+        w,
+        None,
+        ctx.stride,
+        ctx.padding,
+        ctx.dilation,
+        False,
+        [0] * len(ctx.stride),
+        ctx.groups,
+        mask,
+    )
+
+    if ctx.input_layout.endswith("C") and mask[0]:
+        input_grad = input_grad.permute(inv_perm)
+    if ctx.kernel_layout.endswith("C") and mask[1]:
+        weight_grad = weight_grad.permute(inv_perm)
+    # return `None` for attribute args
+    return input_grad, weight_grad, bias_grad, None, None, None, None, None, None, None
+
+
+# Autograd Implementation #
+
+
+class _Boolayout_customizable_Convolution(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, *args):
+        (
+            x,
+            w,
+            b,
+            stride,
+            padding,
+            dilation,
+            groups,
+            input_layout,
+            kernel_layout,
+            output_layout,
+        ) = args
+
+        ctx.save_for_backward(x, w)
+        ctx.stride = stride
+        ctx.padding = padding
+        ctx.dilation = dilation
+        ctx.groups = groups
+        ctx.input_layout = input_layout
+        ctx.kernel_layout = kernel_layout
+        ctx.output_layout = output_layout
+
+        ctx.use_bias = b is not None
+
+        return torch.ops.boo.layout_customizable_convolution(
+            x,
+            w,
+            b,
+            stride,
+            padding,
+            dilation,
+            groups,
+            input_layout,
+            kernel_layout,
+            output_layout,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        if not is_boo_backward_enabled():
+            return pytorch_layout_customizable_convolution_backward(ctx, grad_output)
+
+        x, w = ctx.saved_tensors
+
+        mask = tuple((ctx.needs_input_grad[i] for i in range(3)))
+
+        (
+            input_grad,
+            weight_grad,
+            bias_grad,
+        ) = torch.ops.boo.layout_customizable_convolution_backward(
+            x,
+            w,
+            grad_output,
+            ctx.stride,
+            ctx.padding,
+            ctx.dilation,
+            ctx.groups,
+            ctx.input_layout,
+            ctx.kernel_layout,
+            ctx.output_layout,
+            mask,
+        )
+
+        # return `None` for attribute args
+        return (
+            input_grad,
+            weight_grad,
+            bias_grad,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def boo_layout_customizable_convolution(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    b: torch.Tensor,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    groups: int,
+    input_layout: str,
+    kernel_layout: str,
+    output_layout: str,
+) -> torch.Tensor:
+    """A fully layout-customizable convolution. Inputs x, and w are expected to have appropriate shapes for the provided layouts."""
+    use_autograd = torch._C.is_grad_enabled() and (
+        w.requires_grad or x.requires_grad or (b is not None and b.requires_grad)
+    )
+    return (
+        _Boolayout_customizable_Convolution.apply(
+            x,
+            w,
+            b,
+            stride,
+            padding,
+            dilation,
+            groups,
+            input_layout,
+            kernel_layout,
+            output_layout,
+        )
+        if use_autograd
+        else torch.ops.boo.layout_customizable_convolution(
+            x,
+            w,
+            b,
+            stride,
+            padding,
+            dilation,
+            groups,
+            input_layout,
+            kernel_layout,
+            output_layout,
+        )
+    )

--- a/iree/turbine/kernel/boo/ops/utils.py
+++ b/iree/turbine/kernel/boo/ops/utils.py
@@ -1,0 +1,106 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import functools
+
+from typing import Tuple, Iterable
+
+import torch
+
+__all__ = [
+    "is_boo_backward_enabled",
+    "enable_backward",
+    "disable_backward",
+    "make_tuple",
+    "CL_LAYOUT",
+    "CL_MEM",
+    "CL_CONTIGUOUS_PERM",
+    "CONTIGUOUS_CL_PERM",
+    "get_func_name",
+]
+
+# Toggle Using Boo Backward Kernels #
+
+BOO_USE_BACKWARD_KERNELS = int(os.getenv("BOO_USE_BACKWARD_KERNELS", "0"))
+
+
+def is_boo_backward_enabled():
+    return bool(BOO_USE_BACKWARD_KERNELS)
+
+
+def enable_backward():
+    """Allows toggling on Boo backward convolution kernels from python."""
+    global BOO_USE_BACKWARD_KERNELS
+    BOO_USE_BACKWARD_KERNELS = 1
+
+
+def disable_backward():
+    """Allows toggling off Boo backward convolution kernels from python."""
+    global BOO_USE_BACKWARD_KERNELS
+    BOO_USE_BACKWARD_KERNELS = 0
+
+
+# Utilities #
+
+
+def make_tuple(a: Iterable | int, size: int) -> Tuple:
+    """Tries to convert `a` into a Tuple of ints."""
+    if isinstance(a, Iterable):
+        result = tuple(a)
+        assert len(result) == size
+        assert isinstance(result[0], int)
+        return result
+    if isinstance(a, int):
+        return (a,) * size
+    raise TypeError(f"Input {a} is expected to be an iterable or int. Got {type(a)}.")
+
+
+CL_LAYOUT = {1: "NHC", 2: "NHWC", 3: "NDHWC"}
+CL_MEM = {2: torch.channels_last, 3: torch.channels_last_3d}
+CL_CONTIGUOUS_PERM = {1: [0, 2, 1], 2: [0, 2, 3, 1], 3: [0, 2, 3, 4, 1]}
+CONTIGUOUS_CL_PERM = {1: [0, 2, 1], 2: [0, 3, 1, 2], 3: [0, 4, 1, 2, 3]}
+
+
+@functools.lru_cache(maxsize=None)
+def get_func_name(
+    input_shape: tuple,
+    kernel_shape: tuple,
+    dtype: str,
+    mode: str,
+    bias: bool,
+    stride: tuple,
+    padding: tuple,
+    dilation: tuple,
+    groups: int,
+    input_layout: str,
+    kernel_layout: str,
+    output_layout: str,
+) -> str:
+    num_spatial_dims = len(input_shape) - 2
+    name_items = [
+        "conv",
+        f"{num_spatial_dims}d",
+        str(dtype).removeprefix("torch."),
+        str(mode).lower(),
+    ]
+    if bias and mode == "FORWARD":
+        name_items.append("b")
+    l2s = lambda l: "x".join([str(i) for i in l])
+    name_items.extend(
+        [
+            l2s(input_shape),
+            input_layout.lower(),
+            l2s(kernel_shape),
+            kernel_layout.lower().replace("n", "f"),
+            output_layout.lower().replace("c", "f"),
+            l2s(stride) + "s",
+            l2s(padding) + "p",
+            l2s(dilation) + "d",
+            f"{groups}g",
+        ]
+    )
+    return "_".join(name_items)

--- a/iree/turbine/kernel/boo/ops/utils.py
+++ b/iree/turbine/kernel/boo/ops/utils.py
@@ -16,10 +16,10 @@ __all__ = [
     "enable_backward",
     "disable_backward",
     "make_tuple",
-    "CL_LAYOUT",
-    "CL_MEM",
-    "CL_CONTIGUOUS_PERM",
-    "CONTIGUOUS_CL_PERM",
+    "CHANNELS_LAST_LAYOUTS",
+    "CHANNELS_LAST_MEMORY_FORMAT",
+    "CHANNELS_LAST_TO_CONTIGUOUS_PERMUTATION",
+    "CONTIGUOUS_TO_CHANNELS_LAST_PERMUTATION",
     "get_func_name",
 ]
 
@@ -59,10 +59,18 @@ def make_tuple(a: Iterable | int, size: int) -> Tuple:
     raise TypeError(f"Input {a} is expected to be an iterable or int. Got {type(a)}.")
 
 
-CL_LAYOUT = {1: "NHC", 2: "NHWC", 3: "NDHWC"}
-CL_MEM = {2: torch.channels_last, 3: torch.channels_last_3d}
-CL_CONTIGUOUS_PERM = {1: [0, 2, 1], 2: [0, 2, 3, 1], 3: [0, 2, 3, 4, 1]}
-CONTIGUOUS_CL_PERM = {1: [0, 2, 1], 2: [0, 3, 1, 2], 3: [0, 4, 1, 2, 3]}
+CHANNELS_LAST_LAYOUTS = {1: "NHC", 2: "NHWC", 3: "NDHWC"}
+CHANNELS_LAST_MEMORY_FORMAT = {2: torch.channels_last, 3: torch.channels_last_3d}
+CHANNELS_LAST_TO_CONTIGUOUS_PERMUTATION = {
+    1: [0, 2, 1],
+    2: [0, 2, 3, 1],
+    3: [0, 2, 3, 4, 1],
+}
+CONTIGUOUS_TO_CHANNELS_LAST_PERMUTATION = {
+    1: [0, 2, 1],
+    2: [0, 3, 1, 2],
+    3: [0, 4, 1, 2, 3],
+}
 
 
 @functools.lru_cache(maxsize=None)
@@ -89,17 +97,17 @@ def get_func_name(
     ]
     if bias and mode == "FORWARD":
         name_items.append("b")
-    l2s = lambda l: "x".join([str(i) for i in l])
+    to_shape_string = lambda l: "x".join([str(i) for i in l])
     name_items.extend(
         [
-            l2s(input_shape),
+            to_shape_string(input_shape),
             input_layout.lower(),
-            l2s(kernel_shape),
+            to_shape_string(kernel_shape),
             kernel_layout.lower().replace("n", "f"),
             output_layout.lower().replace("c", "f"),
-            l2s(stride) + "s",
-            l2s(padding) + "p",
-            l2s(dilation) + "d",
+            to_shape_string(stride) + "s",
+            to_shape_string(padding) + "p",
+            to_shape_string(dilation) + "d",
             f"{groups}g",
         ]
     )

--- a/tests/kernel/boo/ops/boo_conv_test.py
+++ b/tests/kernel/boo/ops/boo_conv_test.py
@@ -41,7 +41,7 @@ def testBackwardCachePytorch(x_grad, w_grad):
         w = torch.ones(
             [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=w_grad
         )
-        y = boo_conv(x, w)
+        y = boo_conv(x, w, shared_layout="NCHW")
 
         context = (
             contextlib.nullcontext()
@@ -82,7 +82,7 @@ def testBackwardCacheBoo(x_grad, w_grad):
         w = torch.ones(
             [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=w_grad
         )
-        y = boo_conv(x, w)
+        y = boo_conv(x, w, shared_layout="NCHW")
 
         context = (
             contextlib.nullcontext()
@@ -171,7 +171,7 @@ class BooConvTest(unittest.TestCase):
             set_boo_cache(Path(td))
 
             with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
-                y = boo_conv(x, w)
+                y = boo_conv(x, w, shared_layout="NCHW")
                 loss = y.sum()
 
             loss.backward()
@@ -205,7 +205,7 @@ class BooConvTest(unittest.TestCase):
             set_boo_cache(Path(td_0))
 
             with torch.amp.autocast(device_type="cpu", dtype=torch.bfloat16):
-                y = boo_conv(x, w)
+                y = boo_conv(x, w, shared_layout="NCHW")
                 loss = y.sum()
 
             loss.backward()
@@ -247,7 +247,7 @@ class BooConvTest(unittest.TestCase):
                 [1, 1, 4, 4], dtype=torch.float32, device=device, requires_grad=True
             )
             with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
-                y = boo_conv(x, w)
+                y = boo_conv(x, w, shared_layout="NCHW")
                 loss = y.sum()
 
             loss.backward()


### PR DESCRIPTION
Although mostly a feature of using pytorch backward convs, it is advantageous to move `torch.permute` calls inside the custom op body, since the backward call for pytorch needed to permute all of  `x, w, grad_output, grad_input, grad_weight`.

E.g., running the resent 18 example, the second boo conv forward takes approximately the same time with/without these changes (~330us); however the backward call takes 533us instead of 710us, which saves a significant chunk of CPU time.

It may eventually be a good idea to figure out how to manage this better during the dlpack handoff instead of needing to explicitly permute the tensor from `torch.channels_last` "NCHW" to contiguous "NHWC".

### changes:
1. The op `boo_convolution` and `boo.convolution_backward` are modified to no-longer accept explicit layout specifications. They instead now internally check the layout of input tensors and apply appropriate permutations and kernels. 
2. The old explicit layout functionality is preserved by introducing the separate custom op `boo_layout_customizable_convolution`, which will expect contiguous tensors whose shape matches the specified layout. 
3. The lazy autograd function `boo_conv` now will choose whether to apply `boo_layout_customizable_convolution` or `boo_convolution` depending on whether any of the layout kwargs are not `None`. 
4. Helper functions common between the two boo convolution implementations are factored out into a `utils.py` file. 
5. Some tests needed to be reworked. E.g. a tensor with shape `[1, 1, 16, 16]` is both contiguous and channels_last, so an explicit `shared_layout="NCHW" is passed to the `boo_conv` call to ensure the same kernels are being launched. 
