### PR TITLE
[Wave] Use `gpu.block_id`

### DIFF
--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -40,7 +40,6 @@ from ...compiler.ir import (
     arith_d,
     func_d,
     gpu_d,
-    stream_d,
     vector_d,
 )
 

--- a/iree/turbine/kernel/wave/codegen/emitter.py
+++ b/iree/turbine/kernel/wave/codegen/emitter.py
@@ -75,9 +75,9 @@ class WaveEmitter:
 
     def emit_program_invariants(self):
         self.workgroup_ids = [
-            stream_d.dispatch_workgroup_id(IntegerAttr.get(IndexType.get(), 0)),
-            stream_d.dispatch_workgroup_id(IntegerAttr.get(IndexType.get(), 1)),
-            stream_d.dispatch_workgroup_id(IntegerAttr.get(IndexType.get(), 2)),
+            gpu_d.block_id(gpu_d.Dimension.x),
+            gpu_d.block_id(gpu_d.Dimension.y),
+            gpu_d.block_id(gpu_d.Dimension.z),
         ]
         self.thread_ids = [
             gpu_d.thread_id(gpu_d.Dimension.x),

--- a/lit_tests/kernel/wave/attention/extend_attention.py
+++ b/lit_tests/kernel/wave/attention/extend_attention.py
@@ -173,7 +173,7 @@ def test_causal_extend_attention():
     # CHECK-LABEL:       test_causal_extend_attention
     # CHECK-DAG:            #[[map32:.*]] = affine_map<()[s0] -> (s0 * 64 + 64)>
     # CHECK-LABEL:       func.func @extend_attention
-    # CHECK-DAG:            %[[workgroup_id_0:.*]] = stream.dispatch.workgroup.id[0] : index
+    # CHECK-DAG:            %[[workgroup_id_0:.*]] = gpu.block_id x
     # CHECK-DAG:            stream.binding.subspan %{{.*}}[%{{.*}}] : !stream.binding -> memref<?x16x64xf16, strided<[1024, 64, 1], offset: ?>>
     # CHECK-DAG:            %[[C4352:.*]] = arith.constant 4352 : index
     # CHECK-DAG:            %[[C0:.*]] = arith.constant 0 : index

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -79,9 +79,9 @@ def test_read():
     # CHECK-DAG:        #[[MAP0:.*]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (s0 mod s1 + ((s2 * s3) floordiv s4) * s5)>
     # CHECK:          func.func @read
     # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding)
-    # CHECK:            %[[WORKGROUP_ID_0:.+]] = stream.dispatch.workgroup.id[0] : index
-    # CHECK:            %[[WORKGROUP_ID_1:.+]] = stream.dispatch.workgroup.id[1] : index
-    # CHECK:            %[[WORKGROUP_ID_2:.+]] = stream.dispatch.workgroup.id[2] : index
+    # CHECK:            %[[WORKGROUP_ID_0:.+]] = gpu.block_id x
+    # CHECK:            %[[WORKGROUP_ID_1:.+]] = gpu.block_id y
+    # CHECK:            %[[WORKGROUP_ID_2:.+]] = gpu.block_id z
     # CHECK-DAG:        %[[THREAD_ID_X:.+]] = gpu.thread_id  x
     # CHECK-DAG:        %[[THREAD_ID_Y:.+]] = gpu.thread_id  y
     # CHECK-DAG:        %[[THREAD_ID_Z:.+]] = gpu.thread_id  z
@@ -573,7 +573,7 @@ def test_read_write_dynamic_mapping_chain():
     # CHECK:          func.func @read_write_dynamic_mapping_chain
     # CHECK-SAME:     (%[[ARG0:.*]]: !stream.binding, %[[ARG1:.*]]: !stream.binding, %[[ARG2:.*]]: !stream.binding, %[[ARG3:.*]]: !stream.binding)
     # CHECK-DAG:      %[[C0:.*]] = arith.constant 0 : index
-    # CHECK:          %[[WORKGROUP_ID_1:.*]] = stream.dispatch.workgroup.id[1] : index
+    # CHECK:          %[[WORKGROUP_ID_1:.*]] = gpu.block_id y
     # CHECK:          %[[THREAD_ID_X:.*]] = gpu.thread_id  x
     # CHECK:          %[[D0:.*]] = stream.binding.subspan %[[ARG1]][%[[C0]]] : !stream.binding -> memref<16x2xi32, strided<[2, 1], offset: ?>>
     # CHECK:          %[[D1:.*]] = affine.apply #[[map0]]()[%[[THREAD_ID_X]]]
@@ -793,8 +793,8 @@ def test_dynamic_copy():
     # CHECK-DAG:        %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<16xf16>
     # CHECK-DAG:        %[[CST_0:.*]] = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]> : vector<16xindex>
     # CHECK-DAG:        %[[C0:.*]] = arith.constant 0 : index
-    # CHECK:            %[[WORKGROUP_ID_0:.*]] = stream.dispatch.workgroup.id[0] : index
-    # CHECK:            %[[WORKGROUP_ID_1:.*]] = stream.dispatch.workgroup.id[1] : index
+    # CHECK:            %[[WORKGROUP_ID_0:.*]] = gpu.block_id x
+    # CHECK:            %[[WORKGROUP_ID_1:.*]] = gpu.block_id y
     # CHECK:            %[[THREAD_ID_X:.*]] = gpu.thread_id  x
     # CHECK:            %[[D0:.*]] = stream.binding.subspan %[[ARG0]][%[[C0]]] : !stream.binding -> memref<?x?xf16, strided<[?, 1], offset: ?>>{%[[ARG1]], %[[ARG2]]}
     # CHECK:            %[[D1:.*]] = affine.apply #[[map1]]()[%[[THREAD_ID_X]], %[[WORKGROUP_ID_0]]]
@@ -1796,7 +1796,7 @@ def test_explicit_broadcast():
     # CHECK:       func.func @explicit_broadcast
     # CHECK-SAME: (%[[ARG0:.+]]: !stream.binding, %[[ARG1:.+]]: !stream.binding, %{{.+}}: !stream.binding)
     # CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-    # CHECK: %[[workgroup_id_1:.*]] = stream.dispatch.workgroup.id[1] : index
+    # CHECK: %[[workgroup_id_1:.*]] = gpu.block_id y
     # CHECK: %[[thread_id_x:.*]] = gpu.thread_id  x
 
     # Slicing LHS
@@ -1871,7 +1871,7 @@ def test_broadcast_add():
     # CHECK: func.func @broadcast_add
     # CHECK-SAME: (%[[ARG0:.+]]: !stream.binding, %[[ARG1:.+]]: !stream.binding, %{{.+}}: !stream.binding)
     # CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-    # CHECK: %[[workgroup_id_1:.*]] = stream.dispatch.workgroup.id[1] : index
+    # CHECK: %[[workgroup_id_1:.*]] = gpu.block_id y
     # CHECK: %[[thread_id_x:.*]] = gpu.thread_id  x
 
     # Slicing LHS

--- a/lit_tests/kernel/wave/gemm.py
+++ b/lit_tests/kernel/wave/gemm.py
@@ -1776,7 +1776,7 @@ def test_broadcast_batched_gemm_with_vmma():
     # CHECK:          func.func @broadcast_batched_gemm_with_vmma
     # CHECK-SAME:       (%[[ARG0:[a-zA-Z0-9_]+]]: !stream.binding, %[[ARG1:[a-zA-Z0-9_]+]]: !stream.binding,
     # CHECK-SAME:       %[[ARG2:[a-zA-Z0-9_]+]]: !stream.binding) attributes {translation_info = #[[TRANSLATION:.+]]} {
-    # CHECK:            %[[WG_ID2:.+]] = stream.dispatch.workgroup.id[2] : index
+    # CHECK:            %[[WG_ID2:.+]] = gpu.block_id z
     # CHECK:            %[[RHS_GLOBAL:.+]] = stream.binding.subspan %[[ARG1]]
     # CHECK:            %[[LHS_GLOBAL:.+]] = stream.binding.subspan %[[ARG0]]
     # CHECK:            %[[HKV_IDX:.+]] = affine.apply #[[MAP]]()[%[[WG_ID2]]]
@@ -1849,7 +1849,7 @@ def test_batched_gemm_with_permute():
     # Verify that the batch dimension `B = WG` is in it's correct location after
     # the permtue, ie: `[M, B, N]` instead of `[B, M, N]`.
     # CHECK-LABEL:    func.func @batched_gemm_with_permute
-    # CHECK: %[[WG:.*]] = stream.dispatch.workgroup.id[2] : index
+    # CHECK: %[[WG:.*]] = gpu.block_id z
     # CHECK: vector.store %{{.*}}, %{{.*}}[%{{.*}}, %[[WG]], %{{.*}}]
     # CHECK: vector.store %{{.*}}, %{{.*}}[%{{.*}}, %[[WG]], %{{.*}}]
     # CHECK: vector.store %{{.*}}, %{{.*}}[%{{.*}}, %[[WG]], %{{.*}}]

--- a/lit_tests/kernel/wave/mma.py
+++ b/lit_tests/kernel/wave/mma.py
@@ -73,7 +73,7 @@ def test_mma():
     # CHECK-DAG:        #[[MAP3:.*]] = affine_map<()[s0, s1] -> (s0 * 32 + (s1 floordiv 64) * 16 + ((s1 mod 64) floordiv 16) * 4 + 3)>
     # CHECK:          func.func @mma
     # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
-    # CHECK-DAG:        %[[workgroup_id_0:.*]] = stream.dispatch.workgroup.id[0] : index
+    # CHECK-DAG:        %[[workgroup_id_0:.*]] = gpu.block_id x
     # CHECK-DAG:        %[[thread_id_x:.*]] = gpu.thread_id  x
 
     # CHECK-DAG:        %[[BASE_ALLOC:.+]] = memref.alloc() : memref<2560xi8, #gpu.address_space<workgroup>>
@@ -171,7 +171,7 @@ def test_mma_32x32x8():
     # CHECK-DAG:        #[[MAP14:.*]] = affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + ((s1 mod 64) floordiv 32) * 4 + 26)>
     # CHECK-DAG:        #[[MAP15:.*]] = affine_map<()[s0, s1] -> (s0 * 64 + (s1 floordiv 64) * 32 + ((s1 mod 64) floordiv 32) * 4 + 27)>
     # CHECK:          func.func @mma_32x32x8
-    # CHECK-DAG:        %[[workgroup_id_0:.*]] = stream.dispatch.workgroup.id[0] : index
+    # CHECK-DAG:        %[[workgroup_id_0:.*]] = gpu.block_id x
     # CHECK-DAG:        %[[thread_id_x:.*]] = gpu.thread_id  x
 
     # CHECK-DAG:        %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<16xf32>


### PR DESCRIPTION
We want kernel code to use 100% upstream dialects eventually.