### PR TITLE
[boo] don't wait for Tracy indefinitely

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -209,9 +209,9 @@ def trace_gpu(func: Callable[[], str]) -> tuple[dict[str, list[int]], str]:
             try:
                 # Tracy will never exit if it fails to connect, so kill the process after some time.
                 out, err = tracy.communicate(timeout=5)
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as e:
                 tracy.kill()
-                out, err = tracy.communicate()
+                raise ValueError("Tracy failed to connect.") from e
         if tracy.returncode:
             raise ValueError(f"Tracy failed:\n{out}\n{err}")
 


### PR DESCRIPTION
The logic that was supposed to abort if Tracy pipe failed to communicate was in fact re-launching it with no timeout, making the program never exit. Raise an error instead.