### PR TITLE
[Wave] Add scatter_add operation

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -256,6 +256,16 @@ def select(
 ) -> "Register": ...
 
 
+def scatter_add(
+    register_src: "Register",
+    register_idx: "Register",
+    dim: IndexExpr,
+    memory: "Memory",
+    mapping: IndexMapping,
+    elements_per_thread: Optional[IndexExpr | int] = None,
+) -> "Register": ...
+
+
 def define_op(op_name: str) -> Callable[[T], T]:
     def decorator(cls: T) -> T:
         cls.tkw_op_name = op_name
@@ -2321,3 +2331,49 @@ class Reshape(CustomOp, ABC):
 
     def infer_type(self):
         self.type = get_custom(_to_sequence(self.args)[0]).type
+
+
+@define_op("scatter_add")
+@dataclass
+class ScatterAdd(CustomOp):
+    """
+    Scatter_add performs element-wise accumulation from a source register into shared memory (LDS)
+    at a location determined by the index register along a specified dimension.
+    """
+
+    register_src: fx.Node
+    register_idx: fx.Node
+    dim: IndexExpr
+    memory: fx.Node
+    mapping: IndexMapping
+    elements_per_thread: Optional[Any] = None
+    bounds: Optional[dict[IndexSymbol, IndexExpr]] = None
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        if self.mapping is not None:
+            return list(self.mapping.input_shape)
+        # TODO: This could contain ints.
+        return list(self.memory_type.symbolic_shape)
+
+    def infer_type(self):
+        address_space = self.memory_type.address_space
+        dtype = self.memory_type.dtype
+        self.type = Memory[(*self.indexing_dims, address_space, dtype)]
+
+    @property
+    def memory_type(self) -> "Memory":
+        return get_custom(self.memory).type
+
+    @property
+    def register_type(self) -> "Register":
+        return get_custom(self.register_src).type
+
+    @property
+    def register_index(self) -> dict[IndexSymbol, IndexSequence]:
+        custom = get_custom(self.register_src)
+        return custom.index
+
+    @property
+    def has_side_effects(self) -> bool:
+        return True

--- a/iree/turbine/kernel/wave/codegen/read_write.py
+++ b/iree/turbine/kernel/wave/codegen/read_write.py
@@ -29,15 +29,20 @@ from ...compiler.ir import (
 )
 
 from ...compiler.base import ValidationError
+from iree.turbine.aot.support.ir_utils import (
+    _is_float_type,
+    _is_integer_like_type,
+)
 from ...compiler.utils import strides_from_symbolic_shape
 from ...compiler.builder import IRProxyValue
 from ...compiler.vector_codegen import (
     cast_kernel_buffer,
     cast_py_literal,
     cast_vector,
+    cast_py_value,
 )
 
-from ...ops.wave_ops import get_custom, read, write, CustomOp
+from ...ops.wave_ops import get_custom, read, write, scatter_add, CustomOp
 
 from ..utils.general_utils import get_fastest_index, infer_dim
 from ..utils.symbol_utils import safe_subs, subs_idxc
@@ -46,12 +51,17 @@ from ..._support.indexing import IndexingContext, IndexExpr, IndexSequence, Inde
 from ...lang.global_symbols import *
 from ...lang.wave_types import IndexMapping
 
+from ..constraints import (
+    Constraint,
+    HardwareConstraint,
+)
 from .emitter import (
     WaveEmitter,
     handle_op,
     add_emitter_subs,
     gen_sympy_index,
     get_constant_attr,
+    get_type_or_element_type,
 )
 
 
@@ -786,3 +796,102 @@ def handle_write(emitter: WaveEmitter, node: fx.Node):
             mask,
             offsets_vec,
         )
+
+
+def _handle_scatter_op(
+    emitter: WaveEmitter,
+    node: fx.Node,
+    rmw_kind: arith_d.AtomicRMWKind,
+):
+    try:
+        (
+            register_src,
+            register_idx,
+            dim,
+            memory,
+            mapping,
+            elements_per_thread,
+            bounds,
+        ) = node.args
+    except ValueError as e:
+        raise ValidationError("Malformed arguments") from e
+
+    for constraint in emitter.constraints:
+        if isinstance(constraint, (HardwareConstraint)):
+            node.vector_shapes = constraint.vector_shapes
+
+    output_shape = _get_symbolic_shape(memory)
+    elements_per_thread = int(cast_py_literal(emitter, elements_per_thread))
+    cast_vector(emitter, register_idx, element_type=IndexType.get())
+
+    index_mapping = mapping.map_output_indices(output_shape)
+
+    idxc = IndexingContext.current()
+    index_mapping = tuple(i.subs(idxc.subs) for i in index_mapping)
+    iters = mapping.iters
+    index = node.index
+    subs = [
+        (sym, expr.start) for sym, expr in zip(iters.keys(), index.values())
+    ] + list(idxc.subs.items())
+
+    result_index = {key: m.subs(subs) for key, m in zip(output_shape, index_mapping)}
+
+    mask = _build_mask(emitter, index, elements_per_thread, bounds)
+    if mask is None:
+        mask_vec_type = VectorType.get(
+            [elements_per_thread], IntegerType.get_signless(1)
+        )
+        mask = _constant_mask(mask_vec_type)
+
+    start_indices, start_indices_wg, start_indices_th = _build_start_indices(
+        emitter, result_index
+    )
+
+    register_idx = cast_py_value(emitter, register_idx).ir_value
+    register_src = cast_py_value(emitter, register_src).ir_value
+    memory = cast_py_value(emitter, memory).ir_value
+
+    results = []
+    for i in range(elements_per_thread):
+        index_elem = vector_d.extract(
+            register_idx, static_position=[i], dynamic_position=[]
+        )
+        index_elem = arith_d.index_cast(IndexType.get(), index_elem)
+        reg_elem = vector_d.extract(
+            register_src, static_position=[i], dynamic_position=[]
+        )
+        indices = list(start_indices)
+        if dim >= len(indices):
+            raise ValueError(
+                f"Invalid scatter dim {dim} for rank-{len(indices)} memory"
+            )
+
+        indices[dim] = index_elem
+
+        # In case 4 elements per thread are used, makes sure values are stored at the right non-scatter dimension
+        if elements_per_thread > 1:
+            other_dims = [d for d in range(len(indices)) if d != dim]
+            if other_dims:
+                # Heuristic: offset the innermost (fastest varying) dimension
+                fast_dim = other_dims[-1]
+                indices[fast_dim] = arith_d.addi(
+                    indices[fast_dim], arith_d.constant(IndexType.get(), i)
+                )
+            else:
+                pass
+        result = memref_d.atomic_rmw(rmw_kind, reg_elem, memory, indices)
+        results.append(result)
+
+    result_type = VectorType.get([elements_per_thread], register_src.type.element_type)
+    result_vector = vector_d.from_elements(result_type, results)
+
+
+@handle_op(scatter_add)
+def handle_scatter_add(emitter: WaveEmitter, node: fx.Node):
+    register_src = cast_py_value(emitter, node.args[0])
+    src_data_type = get_type_or_element_type(register_src.ir_value.type)
+    if _is_float_type(src_data_type):
+        rmw_kind = arith_d.AtomicRMWKind.addf
+    else:
+        rmw_kind = arith_d.AtomicRMWKind.addi
+    _handle_scatter_op(emitter, node, rmw_kind)

--- a/iree/turbine/kernel/wave/expansion/expansion.py
+++ b/iree/turbine/kernel/wave/expansion/expansion.py
@@ -24,6 +24,7 @@ from ...ops.wave_ops import (
     GetResult,
     MMA,
     SetSymbol,
+    ScatterAdd,
     ApplyExpr,
     Broadcast,
 )
@@ -750,6 +751,7 @@ def is_leaf_node(node):
         isinstance(custom, Write)
         or (isinstance(custom, GetResult) and not custom.users)
         or isinstance(custom, SetSymbol)
+        or isinstance(custom, ScatterAdd)
     )
 
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -29,6 +29,7 @@ from iree.turbine.kernel.wave.utils.run_utils import (
 from iree.turbine.kernel.wave.utils.torch_utils import (
     device_full,
     device_randint,
+    device_arange,
     device_randn,
     device_randperm,
     device_zeros,
@@ -2052,3 +2053,110 @@ def test_atomic_min(shape, use_buffer_ops, request):
     test(a, c)
     assert_close(c[0, :], b)
     assert_close(c[1, :], b)
+
+
+@require_e2e
+@pytest.mark.parametrize(
+    "shape, elems_per_thread",
+    [
+        ((3840, 1), 1),
+        ((64, 64), 1),
+        ((64, 64), 2),
+        ((64, 64), 4),
+    ],
+)
+def test_scatter_add(shape, elems_per_thread, request):
+    run_bench = request.config.getoption("--runperf")
+
+    M = tkl.sym.M
+    N = tkl.sym.N
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    m_size, n_size = shape
+
+    constraints = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 64, N: elems_per_thread},
+        ),
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.WaveConstraint(M, BLOCK_M),
+        tkw.WaveConstraint(N, BLOCK_N),
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    mapping = tkw.IndexMapping(
+        num_iterators=2,
+        inputs={M: i, N: j},
+        outputs={M: i, N: j},
+    )
+
+    @tkw.wave(constraints)
+    def test(
+        a: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        index: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        lds: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f32],
+        b: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        index_reg = tkw.read(index, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        tkw.scatter_add(
+            a_reg,
+            index_reg,
+            dim=0,
+            memory=lds,
+            mapping=mapping,
+            elements_per_thread=STORE_ELEMS_PER_THREAD,
+        )
+        lds_reg = tkw.read(
+            lds, elements_per_thread=LOAD_ELEMS_PER_THREAD, mapping=mapping
+        )
+        tkw.write(
+            lds_reg, b, elements_per_thread=STORE_ELEMS_PER_THREAD, mapping=mapping
+        )
+
+    options = WaveCompileOptions(
+        subs={
+            M: m_size,
+            N: n_size,
+            BLOCK_M: m_size,
+            BLOCK_N: n_size,
+            LOAD_ELEMS_PER_THREAD: elems_per_thread,
+            STORE_ELEMS_PER_THREAD: elems_per_thread,
+            ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
+        },
+        canonicalize=True,
+        run_bench=run_bench,
+    )
+    options = set_default_run_config(options)
+    test_fn = wave_compile(options, test)
+
+    input = (
+        device_arange(m_size * n_size, dtype=torch.float32)
+        .reshape(m_size, n_size)
+        .contiguous()
+    )
+    index = device_randint(0, m_size, (m_size, n_size), dtype=torch.int32).contiguous()
+    lds = device_zeros((m_size, n_size), dtype=torch.float32).contiguous()
+    output = device_zeros((m_size, n_size), dtype=torch.float32).contiguous()
+
+    test_fn(input, index, lds, output)
+
+    def scatter_add_baseline(input, index):
+        index = index.to(dtype=torch.int64)
+        if index.shape != input.shape:
+            while index.dim() < input.dim():
+                index = index.unsqueeze(-1)
+            index = index.expand_as(input)
+        baseline_output = device_zeros(input.shape, dtype=torch.float32)
+        return baseline_output.scatter_add(dim=0, index=index, src=input)
+
+    torch_output = scatter_add_baseline(input, index)
+    assert_close(output, torch_output)


### PR DESCRIPTION
This PR introduces a new Wave operation: “scatter_add” . The scatter_add  operation performs element-wise accumulation from a source register into shared memory (LDS) using dynamic indices along a specified dimension. It supports both integer and floating-point data types and is lowered to memref.atomic_rmw using either addi or addf, depending on the type.

Input arguments:
-	src: a register containing the values to scatter
-	index a register containing the indices along dim where values should be added
-	dim the dimension along which scattering is performed
-	memory: the target tensor in LDS where results are accumulated
-	mapping: the index mapping representing mapping between sets of indices
-	elements_per_thread: number of elements each thread loads in it's VGPR

Currently scatter_add accepts only static one-to-one index mappings. The lowering logic internally performs dynamic indexing , combining index and dim with the provided mapping to compute final memory access indices. _Potential Future Work:_ rewrite the operation handler and API to align with the write() implementation where in case of a scatter operation, index mapping expressions passed through are fully dynamic.

**Limitations:**
Only intra-workgroup scattering is supported (i.e. within LDS/ shared memory) with up to 4 waves. The operation handles multiple elements per thread, provided that the non-scatter dimension is large enough (> elements_per_thread)