### PR TITLE
[Wave] Adding scatter_max operation for single wave exec

### DIFF
--- a/iree/turbine/kernel/ops/wave_ops.py
+++ b/iree/turbine/kernel/ops/wave_ops.py
@@ -256,6 +256,16 @@ def select(
 ) -> "Register": ...
 
 
+def scatter_max(
+    register_src: "Register",
+    register_idx: "Register",
+    dim: IndexExpr,
+    memory: "Memory",
+    mapping: IndexMapping,
+    elements_per_thread: Optional[IndexExpr | int] = None,
+) -> "Register": ...
+
+
 def define_op(op_name: str) -> Callable[[T], T]:
     def decorator(cls: T) -> T:
         cls.tkw_op_name = op_name
@@ -2321,3 +2331,48 @@ class Reshape(CustomOp, ABC):
 
     def infer_type(self):
         self.type = get_custom(_to_sequence(self.args)[0]).type
+
+
+@define_op("scatter_max")
+@dataclass
+class ScatterMax(CustomOp):
+    """
+    Scatter_max operation performs element-wise maximum reduction from a source register into shared memory (LDS)
+    at a location determined by the index register along a specified dimension.
+    """
+
+    register_src: fx.Node
+    register_idx: fx.Node
+    dim: IndexExpr
+    memory: fx.Node
+    mapping: IndexMapping
+    elements_per_thread: Optional[Any] = None
+    bounds: Optional[dict[IndexSymbol, IndexExpr]] = None
+
+    @property
+    def indexing_dims(self) -> list[IndexSymbol]:
+        if self.mapping is not None:
+            return list(self.mapping.input_shape)
+        return list(self.memory_type.symbolic_shape)
+
+    def infer_type(self):
+        address_space = self.memory_type.address_space
+        dtype = self.memory_type.dtype
+        self.type = Memory[(*self.indexing_dims, address_space, dtype)]
+
+    @property
+    def memory_type(self) -> "Memory":
+        return get_custom(self.memory).type
+
+    @property
+    def register_type(self) -> "Register":
+        return get_custom(self.register_src).type
+
+    @property
+    def register_index(self) -> dict[IndexSymbol, IndexSequence]:
+        custom = get_custom(self.register_src)
+        return custom.index
+
+    @property
+    def has_side_effects(self) -> bool:
+        return True

--- a/iree/turbine/kernel/wave/expansion/expansion.py
+++ b/iree/turbine/kernel/wave/expansion/expansion.py
@@ -24,6 +24,7 @@ from ...ops.wave_ops import (
     GetResult,
     MMA,
     SetSymbol,
+    ScatterMax,
     ApplyExpr,
     Broadcast,
 )
@@ -750,6 +751,7 @@ def is_leaf_node(node):
         isinstance(custom, Write)
         or (isinstance(custom, GetResult) and not custom.users)
         or isinstance(custom, SetSymbol)
+        or isinstance(custom, ScatterMax)
     )
 
 

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -30,6 +30,7 @@ from iree.turbine.kernel.wave.utils.torch_utils import (
     device_full,
     device_randint,
     device_randn,
+    device_arange,
     device_randperm,
     device_zeros,
     to_default_device,
@@ -2052,3 +2053,107 @@ def test_atomic_min(shape, use_buffer_ops, request):
     test(a, c)
     assert_close(c[0, :], b)
     assert_close(c[1, :], b)
+
+
+@require_e2e
+@pytest.mark.parametrize(
+    "shape, elems_per_thread",
+    [
+        ((3840, 1), 1),
+        ((64, 64), 1),
+        ((64, 64), 2),
+        ((64, 64), 4),
+    ],
+)
+def test_scatter_max(shape, elems_per_thread, request):
+    run_bench = request.config.getoption("--runperf")
+    M = tkl.sym.M
+    N = tkl.sym.N
+    BLOCK_M = tkl.sym.BLOCK_M
+    BLOCK_N = tkl.sym.BLOCK_N
+    LOAD_ELEMS_PER_THREAD = tkl.sym.LOAD_ELEMS_PER_THREAD
+    STORE_ELEMS_PER_THREAD = tkl.sym.STORE_ELEMS_PER_THREAD
+    ADDRESS_SPACE = tkl.sym.ADDRESS_SPACE
+
+    m_size, n_size = shape
+
+    constraints = [
+        tkw.HardwareConstraint(
+            threads_per_wave=64,
+            waves_per_block=(1, 1, 1),
+            vector_shapes={M: 64, N: elems_per_thread},
+        ),
+        tkw.WorkgroupConstraint(M, BLOCK_M, 0),
+        tkw.WorkgroupConstraint(N, BLOCK_N, 1),
+        tkw.WaveConstraint(M, BLOCK_M / 1),
+        tkw.WaveConstraint(N, BLOCK_N),
+    ]
+
+    i = tkw.IndexMapping.iterator(0)
+    j = tkw.IndexMapping.iterator(1)
+    mapping1 = tkw.IndexMapping(
+        num_iterators=2,
+        inputs={M: i, N: j},
+        outputs={M: i, N: j},
+    )
+
+    @tkw.wave(constraints)
+    def read_kernel(
+        a: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        index: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.i32],
+        lds: tkl.Memory[M, N, ADDRESS_SPACE, tkl.f32],
+        b: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+    ):
+        index_reg = tkw.read(index, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)
+        tkw.scatter_max(
+            a_reg,
+            index_reg,
+            dim=0,
+            memory=lds,
+            mapping=mapping1,
+            elements_per_thread=LOAD_ELEMS_PER_THREAD,
+        )
+        lds_reg = tkw.read(
+            lds, elements_per_thread=LOAD_ELEMS_PER_THREAD, mapping=mapping1
+        )
+        tkw.write(lds_reg, b, elements_per_thread=STORE_ELEMS_PER_THREAD)
+
+    options = WaveCompileOptions(
+        subs={
+            M: m_size,
+            N: n_size,
+            BLOCK_M: m_size,
+            BLOCK_N: n_size,
+            LOAD_ELEMS_PER_THREAD: elems_per_thread,
+            STORE_ELEMS_PER_THREAD: elems_per_thread,
+            ADDRESS_SPACE: tkl.AddressSpace.SHARED_MEMORY.value,
+        },
+        canonicalize=True,
+        run_bench=run_bench,
+    )
+    options = set_default_run_config(options)
+    read_fn = wave_compile(options, read_kernel)
+
+    input = (
+        device_arange(m_size * n_size, dtype=torch.float32)
+        .reshape(m_size, n_size)
+        .contiguous()
+    )
+    index = device_randint(0, m_size, (m_size, n_size), dtype=torch.int32).contiguous()
+    lds = device_zeros((m_size, n_size), dtype=torch.float32).contiguous()
+    output = device_zeros((m_size, n_size), dtype=torch.float32).contiguous()
+
+    read_fn(input, index, lds, output)
+
+    def scatter_max_baseline(input, index):
+        input = input.to(dtype=torch.float32).contiguous()
+        index = index.to(dtype=torch.int64).contiguous()
+        baseline_output = device_zeros(input.shape, dtype=torch.float32)
+        baseline_output.scatter_reduce_(
+            dim=0, index=index, src=input, reduce="amax", include_self=False
+        )
+        return baseline_output
+
+    torch_output = scatter_max_baseline(input, index)
+    assert_close(output, torch_output)


### PR DESCRIPTION
This PR introduces a new Wave operation: “scatter_max” . The scatter_max operation performs an element-wise maximum reduction from a source register into shared memory (LDS) using dynamic indices along a specified dimension. It supports both integer and floating-point data types and is lowered to memref.atomic_rmw using either maxs or maximumf, depending on the type.

**Input arguments:**
-	src: a register containing the values to scatter
-	index a register containing the indices along dim where values should be written
-	dim the dimension along which scattering is performed
-	memory: the target tensor in LDS where results are accumulated
-	mapping: the index mapping representing mapping between sets of indices
-	elements_per_thread: number of elements each thread loads -
Tests are included in wave_e2e_test.py to validate the correctness of scatter_max

**Implementation notes:**
Currently scatter_max accepts only static one-to-one index mappings. The lowering logic internally performs dynamic indexing , combining **index** and **dim** with the provided **mapping** to compute final memory access indices. _Potential Future Work_: rewrite the operation handler and API to align with wave's  write() operation  implementation where in case of a scatter operation, index mapping expressions passed through are fully dynamic.

**Limitations:**
Currently, scatter_max only works with a single wave. Using 2 or 4 waves results in incorrect behavior, especially when thread index to the same location. The emitted code is identical to scatter_add when simply swapping the op, suggesting the bug may lie in the iree lowering to LLVM dialect. This needs further investigation. The operation supports multiple elements per thread provided that the non-scatter dimension is large enough (> elements_per_thread)