### PR TITLE
[boo] swap the import dependency condition for tracy

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/README.md
+++ b/iree/turbine/kernel/boo/conv_exports/README.md
@@ -167,7 +167,6 @@ The `-t 1` option to collect timing is implemented by launching the kernel in a 
 
 #### pip installed `iree-base-runtime`:
 
-- set `IREE_PY_RUNTIME=tracy` in your environment.
 - build `tracy-csvexport` and add it to your `PATH`:
 
 ```

--- a/iree/turbine/kernel/boo/conv_exports/README.md
+++ b/iree/turbine/kernel/boo/conv_exports/README.md
@@ -167,7 +167,10 @@ The `-t 1` option to collect timing is implemented by launching the kernel in a 
 
 #### pip installed `iree-base-runtime`:
 
+- set `BOO_FORCE_TRACY_RUNTIME` in your environment to ensure `tracy` is used for GPU kernels; **NOTE** that setting this flag will cause _module import failures_ for IREE runtimes not built for distribution with PIP.
 - build `tracy-csvexport` and add it to your `PATH`:
+
+You can also set `IREE_PY_RUNTIME=tracy` directly, which will enable tracing of both the kernels and the surrounding machinery.
 
 ```
 git clone https://github.com/wolfpld/tracy.git

--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -69,6 +69,10 @@ command-line arguments are appended to the arguments from the file.
 
             runner.run(runner_args, args.gpu_id)
             continue
+
+        # Print proof of life.
+        print(" ".join(runner_args))
+
         try:
             zones, func_name = trace_gpu(runner_args, args.gpu_id)
         except Exception as exc:

--- a/iree/turbine/kernel/boo/conv_exports/boo_driver.py
+++ b/iree/turbine/kernel/boo/conv_exports/boo_driver.py
@@ -125,7 +125,8 @@ def trace_gpu(runner_args: str, gpu_id: int) -> tuple[dict[str, list[int]], str]
             text=True,
         ) as tracy:
             environ = copy.deepcopy(os.environ)
-            environ["IREE_PY_RUNTIME"] = "tracy"
+            if "BOO_FORCE_TRACY_RUNTIME" in os.environ:
+                environ["IREE_PY_RUNTIME"] = "tracy"
             environ["TRACY_PORT"] = TRACY_PORT
             process = subprocess.run(
                 ["python", "runner.py", str(gpu_id)] + runner_args,

--- a/iree/turbine/kernel/boo/conv_exports/runner.py
+++ b/iree/turbine/kernel/boo/conv_exports/runner.py
@@ -16,10 +16,6 @@ from iree.turbine.kernel.boo.conv_exports import (
 
 
 def run(cli_args: Sequence[str], gpu_id: int):
-    # In order to be properly traced only the subprocesses should import
-    # 'iree.runtime', so all turbine imports need to be kept local.
-
-    # print(shlex.join(cli_args))
     parser = mio.get_miopen_parser()
     parser.add_argument(
         "--iter", type=int, help="Number of iterations to run", default=100

--- a/iree/turbine/kernel/boo/conv_exports/runner.py
+++ b/iree/turbine/kernel/boo/conv_exports/runner.py
@@ -1,0 +1,90 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+from typing import Sequence
+import math
+import gc
+import sys
+from iree.turbine.kernel.boo.conv_exports import (
+    miopen_parser as mio,
+    get_launchable,
+)
+
+
+def run(cli_args: Sequence[str], gpu_id: int):
+    # In order to be properly traced only the subprocesses should import
+    # 'iree.runtime', so all turbine imports need to be kept local.
+
+    # print(shlex.join(cli_args))
+    parser = mio.get_miopen_parser()
+    parser.add_argument(
+        "--iter", type=int, help="Number of iterations to run", default=100
+    )
+    parser.add_argument(
+        "--splat-input-value",
+        default=None,
+        type=int,
+        help="use a splat value for inputs (defaults to random values)",
+    )
+    args = parser.parse_args(cli_args)
+    sig = mio.get_signature(args)
+    conv = get_launchable(sig)
+
+    # get the number of available GPU's
+    num_devices = 1 if gpu_id != -1 else torch.cuda.device_count()
+    devices = (
+        [f"cuda:{gpu_id}"]
+        if gpu_id != -1
+        else [f"cuda:{i}" for i in range(num_devices)]
+    )
+    iter_per_device = args.iter // num_devices
+    rem_iter = args.iter % num_devices
+
+    # generate sample conv args on each GPU
+    per_device_data = [
+        sig.get_sample_conv_args(
+            seed=10,
+            device=device,
+            splat_value=args.splat_input_value,
+        )
+        for device in devices
+    ]
+
+    # determine an iter threshold to pause and collect garbage
+    numel = 0
+    if int(sig.mode) == 0:
+        numel = math.prod(sig.output_shape)
+    elif int(sig.mode) == 1:
+        numel = math.prod(sig.input_shape)
+    elif int(sig.mode) == 2:
+        numel = math.prod(sig.kernel_shape)
+    dtype_bytes = int(sig.dtype.itemsize)
+    res_mem_bytes = numel * dtype_bytes
+    # This is a rough threshold: Mi300x 192 GB memory divided by 2.
+    mem_bytes_threshold = 96 * (10**9)
+    iter_thresh = int(mem_bytes_threshold // res_mem_bytes)
+
+    result = None
+    for iter in range(iter_per_device + 1):
+        for device_idx, conv_args in enumerate(per_device_data):
+            if iter == iter_per_device and device_idx >= rem_iter:
+                break
+            result = conv(*conv_args)
+        if (iter + 1) % iter_thresh == 0:
+            print(f"Synchronizing all devices on iter {iter} and collecting garbage.")
+            for i in range(num_devices):
+                torch.cuda.synchronize(torch.device(f"cuda:{i}"))
+            gc.collect()
+
+    torch.cuda.synchronize()
+
+    # Print the function name so it can be picked up by the pipe.
+    print(sig.get_func_name())
+
+
+if __name__ == "__main__":
+    run(sys.argv[2:], int(sys.argv[1]))


### PR DESCRIPTION
The original implementation for conv was importing the conv op definition only when timing/tracing is enabled to avoid option clash for IREE runtime that is unconditionally loaded when traversing the python package tree for iree.turbine.kernel. This made it virtually impossible to refactor out the tracing-related code.

Swap the dependency condition. This requires the traced function to be placed in a fully separated process, not a fork of the current process. This has a positive side effet of being runnable on all operating systems and not only those supporting process forks. It also removes the need for the user to explicitly mess the environment when they want tracing as we can set up environment variables programmatically for spawed processes.