### PR TITLE
[Wave] fix gemm_tutorial

### DIFF
--- a/docs/wave/gemm_tutorial.rst
+++ b/docs/wave/gemm_tutorial.rst
@@ -43,7 +43,6 @@ First, we need to import the necessary modules and define our symbolic dimension
 
     # Define the address space for our memory
     ADDRESS_SPACE = sym.ADDRESS_SPACE
-    GLOBAL_ADDRESS_SPACE = sym.GLOBAL_ADDRESS_SPACE
 
 Now, let's define our GEMM kernel with appropriate constraints:
 


### PR DESCRIPTION
The GLOBAL_ADDRESS_SPACE definition shadows the one from iree.turbine.kernel.lang.global_symbols.