### PR TITLE
Make B, H, M, K2 dynamic dims in bhsd_attention kernel

### DIFF
--- a/iree/turbine/kernel/wave/templates/vanilla_attention.py
+++ b/iree/turbine/kernel/wave/templates/vanilla_attention.py
@@ -677,17 +677,17 @@ def get_bhsd_attention_kernel(
     dynamic_symbols = []
     dynamic_symbols_map = {}
     if dynamic_dims:
-        dynamic_symbols_map[M] = hyperparams[M]
-        dynamic_symbols_map[N] = hyperparams[N]
         dynamic_symbols_map[B] = hyperparams[B]
+        dynamic_symbols_map[H] = hyperparams[H]
+        dynamic_symbols_map[M] = hyperparams[M]
         dynamic_symbols_map[K2] = hyperparams[K2]
-        dynamic_symbols.append(M)
-        dynamic_symbols.append(N)
         dynamic_symbols.append(B)
+        dynamic_symbols.append(H)
+        dynamic_symbols.append(M)
         dynamic_symbols.append(K2)
-        del hyperparams[M]
-        del hyperparams[N]
         del hyperparams[B]
+        del hyperparams[H]
+        del hyperparams[M]
         del hyperparams[K2]
 
     if is_custom_mask:

--- a/tests/kernel/wave/attention/vanilla_attention_test.py
+++ b/tests/kernel/wave/attention/vanilla_attention_test.py
@@ -427,7 +427,7 @@ def testAttentionBSHD(
 @require_e2e
 @pytest.mark.parametrize("shape", get_test_shapes("bhsd_attention"))
 @pytest.mark.parametrize("enable_scheduling", [SchedulingType.NONE])
-@param_bool("dynamic_dims", "dyn", [False])
+@param_bool("dynamic_dims", "dyn", [False, True])
 @pytest.mark.parametrize(
     "mfma_variant",
     [


### PR DESCRIPTION
This PR is to make the N (head size kv) dimension static and H (num_heads) dimension dynamic and changes the order of the dynamic dims to B, H, M, K2, so the index arguments for the dynamic dimensions are based on the order of the inputs.