### PR TITLE
[Wave] add optimization_level compile option

### DIFF
--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -60,6 +60,7 @@ class WaveCompileOptions:
     use_water_leak_check: bool = False
 
     # === Performance options ===
+    optimization_level: bool = True
     denorm_fp_math_f32: str = None
     waves_per_eu: int = None
     wave_runtime: str = None

--- a/iree/turbine/kernel/wave/wave.py
+++ b/iree/turbine/kernel/wave/wave.py
@@ -569,13 +569,19 @@ class LaunchableWave(Launchable):
             trace, options, print_ir_before, print_ir_after
         )
 
-        # Optimizations.
         graph_passes += [
             partial(decompose_vmma_ops, trace, self.constraints),
             partial(decompose_dot_mma, trace, self.constraints),
-            partial(hoist_loop_invariant_ops, trace, self.constraints),
-            partial(global_to_shared_gathers, trace, self.constraints),
-            partial(minimize_global_loads, trace, self.constraints),
+        ]
+
+        # Optimizations.
+        if options.optimization_level:
+            graph_passes += [
+                partial(hoist_loop_invariant_ops, trace, self.constraints),
+                partial(global_to_shared_gathers, trace, self.constraints),
+                partial(minimize_global_loads, trace, self.constraints),
+            ]
+        graph_passes += [
             partial(apply_shared_memory_indexing_corrections, trace, self.constraints),
         ]
 
@@ -605,21 +611,22 @@ class LaunchableWave(Launchable):
                 options.dump_schedule,
             )
         )
-        graph_passes.append(
-            partial(
-                schedule_reordering,
-                trace,
-                self.constraints,
-                scheduling_type,
-            )
-        )
 
+        if options.optimization_level:
+            graph_passes += [
+                partial(
+                    schedule_reordering,
+                    trace,
+                    self.constraints,
+                    scheduling_type,
+                ),
+                partial(
+                    minimize_shared_allocs,
+                    trace,
+                    options.minimize_shared_allocs,
+                ),
+            ]
         graph_passes += [
-            partial(
-                minimize_shared_allocs,
-                trace,
-                options.minimize_shared_allocs,
-            ),
             partial(add_shared_memory_barriers, trace),
             partial(compute_shared_memory_usage, trace, options.kernel_launch_info),
             partial(generate_bounds_exprs, trace, self.constraints),

--- a/tests/kernel/wave/wave_e2e_test.py
+++ b/tests/kernel/wave/wave_e2e_test.py
@@ -1478,9 +1478,22 @@ _layouts = [
 @pytest.mark.parametrize("n, h, w, c, hf, wf, nf, stride", _igemm_cases)
 @pytest.mark.parametrize("mem_space", _mem_spaces)
 @pytest.mark.parametrize("layout", _layouts)
+@pytest.mark.parametrize("optimization_level", [False, True])
 @param_bool("use_buffer_ops", "buf_ops")
 def test_igemm_conv(
-    n, h, w, c, hf, wf, nf, stride, mem_space, layout, use_buffer_ops, request
+    n,
+    h,
+    w,
+    c,
+    hf,
+    wf,
+    nf,
+    stride,
+    mem_space,
+    layout,
+    optimization_level,
+    use_buffer_ops,
+    request,
 ):
     cf = c
     padding = 0  # TODO: only pad=0 is supported for now
@@ -1534,6 +1547,7 @@ def test_igemm_conv(
             os.path.join(dump_perf, "tk_" + perf_filename) if dump_perf else None
         ),
         dump_intermediates="./inter",
+        optimization_level=optimization_level,
     )
     options = set_default_run_config(options)
     conv = wave_compile(options, conv)


### PR DESCRIPTION
This gives the option a default level of 2, and disables optimization passes for optimization level 0.