### PR TITLE
[Wave] Get dynamic symbols directly from the mlir tensors instead of passing them as args in python

### DIFF
--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -155,7 +155,7 @@ def isolated_test_call(
                 output_tensors,
                 [dynamic_argument_map[dim] for dim in dynamic_symbols] + scalars_args,
                 entrypoints,
-                entry_block.arguments,
+                list(entry_block.arguments) + list(dynamic_argument_map.values()),
                 [dynamic_argument_map[dim] for dim in argument_dims],
                 [dynamic_argument_map[dim] for dim in result_dims],
                 tied_operands=tied_operands,

--- a/iree/turbine/kernel/compiler/ir.py
+++ b/iree/turbine/kernel/compiler/ir.py
@@ -53,6 +53,7 @@ from iree.compiler.dialects import (
     rocdl as rocdl_d,
     scf as scf_d,
     stream as stream_d,
+    tensor as tensor_d,
     transform as transform_d,
     vector as vector_d,
 )

--- a/iree/turbine/kernel/wave/profiling.py
+++ b/iree/turbine/kernel/wave/profiling.py
@@ -128,7 +128,6 @@ def benchmark_module(
     options: WaveCompileOptions,
     kernel_inputs: list[torch.Tensor],
     kernel_outputs: list[torch.Tensor],
-    dynamic_symbols: list[int],
     flatbuffer: bytes,
     entry_function: str,
     timeout=None,
@@ -143,9 +142,7 @@ def benchmark_module(
     for k in kwargs:
         v = kwargs[k]
         args.append(f"--{k}={v}")
-    inputs, tempfiles = construct_inputs(
-        options, kernel_inputs, kernel_outputs, dynamic_symbols
-    )
+    inputs, tempfiles = construct_inputs(options, kernel_inputs, kernel_outputs)
     args += inputs
     args.append("--module=-")
     args.append(f"--device={options.device}")

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -44,12 +44,8 @@ def get_device_uuid(device_list: list[str], device_str: str) -> tuple[int, str]:
     return device_str
 
 
-def _inplace_invoke(
-    vm_context, device, entry_function, inputs, outputs, scalar_args, dynamic_dims
-):
-    linearized_arg_len = (
-        len(inputs) + len(outputs) + len(scalar_args) + len(dynamic_dims)
-    )
+def _inplace_invoke(vm_context, device, entry_function, inputs, outputs, scalar_args):
+    linearized_arg_len = len(inputs) + len(outputs) + len(scalar_args)
     # ret_list is 0 because we modify/write result in place.
     arg_list = rt.VmVariantList(linearized_arg_len)
     ret_list = rt.VmVariantList(0)
@@ -62,8 +58,8 @@ def _inplace_invoke(
         arg_list.push_ref(arg_tensor_bv)
 
     # Linearize arguments, In linearized arg_list, we first push in all inputs,
-    # then all the outputs, and lastly all the dynamic dims.
-    for input in chain(inputs, outputs, scalar_args, dynamic_dims):
+    # then all the outputs, and lastly all the scalar args.
+    for input in chain(inputs, outputs, scalar_args):
         if isinstance(input, torch.Tensor):
             push_tensor_to_arg_list(input)
         elif isinstance(input, int):
@@ -164,7 +160,6 @@ def invoke_vmfb(
         kernel_inputs,
         kernel_outputs,
         scalar_args,
-        dynamic_symbols,
     )
 
     if options.run_bench:


### PR DESCRIPTION
Dynamic args are always bound to the input arrays dims now, so we can extract the from tensors in launch func instead of passing to `vm_context.invoke` explicitly.

Cannot drop existing dynamic args fully, though, as we are still need it for wave runtime.