### PR TITLE
[Wave] Change paged decode attention stage 2 distribution.

### DIFF
--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -217,7 +217,11 @@ def get_paged_decode_attention_kernels(
         vector_shapes = {
             S: 0,
             B: BLOCK_B // PHASE_1_BLOCK_B_WAVES,
-            N: BLOCK_N // PHASE_1_BLOCK_N_WAVES,
+            N: (
+                1
+                if phase_1_distribute_query_heads
+                else BLOCK_N // PHASE_1_BLOCK_N_WAVES
+            ),
             U: 1,
         }
         constraints += [

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -96,8 +96,8 @@ def get_paged_decode_attention_kernels(
 
     THREADS_PER_WAVE = 64
     PHASE_1_BLOCK_B_WAVES = 1
-    PHASE_1_BLOCK_B = 64 * PHASE_1_BLOCK_B_WAVES
-    PHASE_1_BLOCK_N = 16
+    PHASE_1_BLOCK_B = 1 * PHASE_1_BLOCK_B_WAVES
+    PHASE_1_BLOCK_N = 64
     head_ratio = shape.num_query_heads // shape.num_kv_heads
     MMA_VEC_SIZE = 16  # TODO: Actual value depends in mma type
     if mha:
@@ -190,16 +190,16 @@ def get_paged_decode_attention_kernels(
         return constraints
 
     def phase_1_constraints() -> list[tkw.Constraint]:
-        constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(B, BLOCK_B, 0)]
+        constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(B, BLOCK_B, 1)]
         constraints += [tkw.WaveConstraint(B, BLOCK_B // PHASE_1_BLOCK_B_WAVES)]
-        constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+        constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
         constraints += [tkw.WaveConstraint(N, BLOCK_N)]
         constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 2)]
         constraints += [tkw.TilingConstraint(U, BLOCK_U, iters=SPLITS_ACTIVE)]
         vector_shapes = {
             S: 0,
             B: BLOCK_B // PHASE_1_BLOCK_B_WAVES,
-            N: 1,
+            N: BLOCK_N,
             U: 1,
         }
         constraints += [

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -101,8 +101,8 @@ def get_paged_decode_attention_kernels(
     THREADS_PER_WAVE = 64
     PHASE_1_BLOCK_B_WAVES = 1
     PHASE_1_BLOCK_B = 1 * PHASE_1_BLOCK_B_WAVES
-    PHASE_1_BLOCK_N = 64
-    PHASE_1_BLOCK_N_WAVES = ceildiv(shape.head_size_kv, PHASE_1_BLOCK_N)
+    PHASE_1_BLOCK_N_WAVES = ceildiv(shape.head_size_kv, 64)
+    PHASE_1_BLOCK_N = 64 * PHASE_1_BLOCK_N_WAVES
     head_ratio = shape.num_query_heads // shape.num_kv_heads
     MMA_VEC_SIZE = 16  # TODO: Actual value depends in mma type
     if mha:

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -99,10 +99,17 @@ def get_paged_decode_attention_kernels(
         PHASE_1 = (1,)
 
     THREADS_PER_WAVE = 64
+
     PHASE_1_BLOCK_B_WAVES = 1
-    PHASE_1_BLOCK_B = 1 * PHASE_1_BLOCK_B_WAVES
-    PHASE_1_BLOCK_N_WAVES = ceildiv(shape.head_size_kv, 64)
-    PHASE_1_BLOCK_N = 64 * PHASE_1_BLOCK_N_WAVES
+    phase_1_distribute_query_heads = shape.num_query_heads > 64
+    if phase_1_distribute_query_heads:
+        PHASE_1_BLOCK_B = 64 * PHASE_1_BLOCK_B_WAVES
+        PHASE_1_BLOCK_N_WAVES = 1
+        PHASE_1_BLOCK_N = 16
+    else:
+        PHASE_1_BLOCK_B = 1 * PHASE_1_BLOCK_B_WAVES
+        PHASE_1_BLOCK_N_WAVES = ceildiv(shape.head_size_kv, 64)
+        PHASE_1_BLOCK_N = 64 * PHASE_1_BLOCK_N_WAVES
     head_ratio = shape.num_query_heads // shape.num_kv_heads
     MMA_VEC_SIZE = 16  # TODO: Actual value depends in mma type
     if mha:
@@ -195,9 +202,15 @@ def get_paged_decode_attention_kernels(
         return constraints
 
     def phase_1_constraints() -> list[tkw.Constraint]:
-        constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(B, BLOCK_B, 1)]
+        constraints: list[tkw.Constraint] = []
+        if phase_1_distribute_query_heads:
+            constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 0)]
+            constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 1)]
+        else:
+            constraints += [tkw.WorkgroupConstraint(B, BLOCK_B, 1)]
+            constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
+
         constraints += [tkw.WaveConstraint(B, BLOCK_B // PHASE_1_BLOCK_B_WAVES)]
-        constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
         constraints += [tkw.WaveConstraint(N, BLOCK_N // PHASE_1_BLOCK_N_WAVES)]
         constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 2)]
         constraints += [tkw.TilingConstraint(U, BLOCK_U, iters=SPLITS_ACTIVE)]
@@ -207,7 +220,6 @@ def get_paged_decode_attention_kernels(
             N: BLOCK_N // PHASE_1_BLOCK_N_WAVES,
             U: 1,
         }
-
         constraints += [
             tkw.HardwareConstraint(
                 threads_per_wave=THREADS_PER_WAVE,

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -198,7 +198,7 @@ def get_paged_decode_attention_kernels(
         constraints: list[tkw.Constraint] = [tkw.WorkgroupConstraint(B, BLOCK_B, 1)]
         constraints += [tkw.WaveConstraint(B, BLOCK_B // PHASE_1_BLOCK_B_WAVES)]
         constraints += [tkw.WorkgroupConstraint(N, BLOCK_N, 0)]
-        constraints += [tkw.WaveConstraint(N, BLOCK_N)]
+        constraints += [tkw.WaveConstraint(N, BLOCK_N // PHASE_1_BLOCK_N_WAVES)]
         constraints += [tkw.WorkgroupConstraint(S, BLOCK_S, 2)]
         constraints += [tkw.TilingConstraint(U, BLOCK_U, iters=SPLITS_ACTIVE)]
         vector_shapes = {

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -93,7 +93,7 @@ def test_paged_flash_decoding():
     print(phase_1.asm)
 
     # CHECK-LABEL:       func.func @phase_1
-    # CHECK:               memref.load
+    # CHECK-COUNT-2:       memref.load
     # CHECK:               scf.for
     # CHECK-COUNT-2:           vector.maskedload
     # CHECK-COUNT-1:           arith.maximumf
@@ -106,7 +106,7 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-2:           arith.mulf
     # CHECK-COUNT-1:           arith.addf
     # CHECK-COUNT-1:      arith.divf
-    # CHECK-COUNT-1:      vector.store
+    # CHECK-COUNT-1:      vector.maskedstore
 
 
 @run_test

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -106,7 +106,7 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-2:           arith.mulf
     # CHECK-COUNT-1:           arith.addf
     # CHECK-COUNT-1:      arith.divf
-    # CHECK-COUNT-1:      vector.maskedstore
+    # CHECK-COUNT-1:      vector.store
 
 
 @run_test

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -106,6 +106,77 @@ def test_paged_flash_decoding():
     # CHECK-COUNT-2:           arith.mulf
     # CHECK-COUNT-1:           arith.addf
     # CHECK-COUNT-1:      arith.divf
+    # Must be non-masked store.
+    # CHECK-COUNT-1:      vector.store
+
+
+@run_test
+def test_paged_flash_decoding_small_query_heads():
+    shape = paged_decode_attention_shape(
+        num_query_heads=6,
+        num_kv_heads=1,
+        head_size=64,
+        head_size_kv=64,
+        block_size=32,
+        num_seqs=8,
+    )
+    num_kv_splits = 8
+    mfma_variant = (tkw.MMAType.F32_16x16x16_F16, tkw.MMAType.F32_16x16x16_F16)
+    (
+        phase_0,
+        phase_1,
+        hyperparams_0,
+        hyperparams_1,
+        dynamic_symbols_0,
+        dynamic_symbols_1,
+    ) = get_paged_decode_attention_kernels(
+        shape,
+        mfma_variant,
+        num_kv_splits,
+    )
+
+    options = WaveCompileOptions(
+        subs=hyperparams_0,
+        canonicalize=True,
+        run_bench=False,
+        schedule=SchedulingType.NONE,
+        use_scheduling_barriers=False,
+        dynamic_symbols=dynamic_symbols_0,
+        compile_to_mlir=True,
+    )
+    phase_0 = wave_compile(options, phase_0)
+    print(phase_0.asm)
+
+    # CHECK-LABEL:          test_paged_flash_decoding_small_query_heads
+    # CHECK:                func.func @phase_0
+
+    options = WaveCompileOptions(
+        subs=hyperparams_1,
+        canonicalize=True,
+        run_bench=False,
+        schedule=SchedulingType.NONE,
+        use_scheduling_barriers=False,
+        dynamic_symbols=dynamic_symbols_1,
+        compile_to_mlir=True,
+    )
+    phase_1 = wave_compile(options, phase_1)
+    print(phase_1.asm)
+
+    # CHECK-LABEL:       func.func @phase_1
+    # CHECK-COUNT-2:       memref.load
+    # CHECK:               scf.for
+    # CHECK-COUNT-2:           vector.maskedload
+    # CHECK-COUNT-1:           arith.maximumf
+    # CHECK-COUNT-1:           arith.subf
+    # CHECK-COUNT-1:           math.exp2
+    # CHECK-COUNT-1:           arith.subf
+    # CHECK-COUNT-1:           math.exp2
+    # CHECK-COUNT-1:           arith.mulf
+    # CHECK-COUNT-1:           arith.addf
+    # CHECK-COUNT-2:           arith.mulf
+    # CHECK-COUNT-1:           arith.addf
+    # CHECK-COUNT-1:      arith.divf
+    # Must be non-masked store.
     # CHECK-COUNT-1:      vector.store
 
 


### PR DESCRIPTION
Distribute across `head_size_kv` instead of `num_query_heads` for low `num_query_heads` to get threads better utilized.

Gave around 85->87 tok/s improvement on e2e bench 
```
NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, NUM_SEQS 
(6, 1, 128, 128, 1)
```