### PR TITLE
[Wave] Add outer loop to search for schedules

### DIFF
--- a/docs/wave/optimize_schedule.rst
+++ b/docs/wave/optimize_schedule.rst
@@ -1,0 +1,249 @@
+Schedule Optimization with tune_attention
+=========================================
+
+This document explains how the `tune_attention` function works to optimize attention kernel schedules using hill climbing optimization.
+
+Overview
+--------
+
+The `tune_attention` function implements an automated schedule optimization process for vanilla attention kernels. It uses a hill climbing algorithm to iteratively improve the schedule by moving operations to different cycles while maintaining resource and dependency constraints.
+
+Key Components
+--------------
+
+1. **ScheduleValidator**: Validates and modifies schedules while maintaining constraints
+2. **ScheduleOptimizer**: Implements the hill climbing optimization algorithm
+3. **Resource Reservation Table (RRT)**: Tracks resource usage across scheduling cycles
+4. **TuningLogger**: Logs optimization progress and saves intermediate schedules
+
+How It Works
+------------
+
+The optimization process follows these steps:
+
+1. **Initial Schedule Generation**: Compile the kernel and extract the initial schedule
+2. **Schedule Loading**: Load the schedule with resource requirements and dependencies
+3. **Optimization Loop**: Iteratively improve the schedule using hill climbing
+4. **Schedule Validation**: Ensure each move maintains resource and dependency constraints
+5. **Performance Measurement**: Measure latency for each candidate schedule
+6. **Progress Logging**: Save schedules and track improvements
+
+Example Usage
+------------
+
+Here's a complete example of how to use `tune_attention`:
+
+.. code-block:: python
+
+    from iree.turbine.kernel.wave.tuner.tune_attention import (
+        tune_attention, AttentionConfig
+    )
+    from iree.turbine.kernel.wave.constraints import MMAType
+    from iree.turbine.kernel.wave.scheduling import SchedulingType
+
+    # Configure the attention kernel
+    config = AttentionConfig(
+        batch_size=1,
+        num_heads=32,
+        seq_len_q=512,
+        seq_len_k=512,
+        head_dim=64,
+        head_dim_kv=64,
+        mfma_variant=(MMAType.F32_32x32x8_F16, MMAType.F32_32x32x8_F16),
+        enable_scheduling=SchedulingType.MODULO,
+        dynamic_dims=False,
+        num_warmup=10,
+        num_iterations=100,
+    )
+
+    # Run optimization
+    best_schedule, best_latency = tune_attention(config)
+    print(f"Best latency: {best_latency:.6f} seconds")
+
+Configuration Parameters
+------------------------
+
+The `AttentionConfig` class controls the optimization process:
+
+- **batch_size**: Number of batches to process
+- **num_heads**: Number of attention heads
+- **seq_len_q**: Query sequence length
+- **seq_len_k**: Key sequence length
+- **head_dim**: Dimension of each attention head
+- **head_dim_kv**: Dimension of key/value heads
+- **mfma_variant**: Matrix multiply-accumulate variant to use
+- **enable_scheduling**: Type of scheduling to enable
+- **dynamic_dims**: Whether dimensions are dynamic
+- **num_warmup**: Number of warmup iterations for timing
+- **num_iterations**: Number of benchmark iterations
+
+Optimization Algorithm
+---------------------
+
+The hill climbing algorithm works as follows:
+
+1. **Random Move Selection**: Randomly select a node and a new target cycle
+2. **Move Validation**: Check if the move maintains all constraints
+3. **Schedule Repair**: If needed, repair the schedule to satisfy dependencies
+4. **Performance Measurement**: Measure the latency of the new schedule
+5. **Improvement Check**: Accept the move if it improves performance
+6. **Iteration**: Repeat until no improvement is found or max iterations reached
+
+Schedule Validation
+------------------
+
+Each schedule modification is validated using the `ScheduleValidator`:
+
+.. code-block:: python
+
+    # Example of schedule validation
+    validator = ScheduleValidator(
+        initial_schedule=schedule,
+        T=initiation_interval,
+        nodes=nodes,
+        resource_limits=resource_limits,
+        node_rrt_getter=node_rrt_getter,
+        raw_edges_list=edges,
+        num_resource_types=num_resource_types,
+    )
+
+    # Attempt to move a node
+    success, new_schedule, error_msg = validator.attempt_move(node, new_cycle)
+    if success:
+        validator.commit_move(new_schedule, new_rrt)
+
+Resource Reservation Table (RRT)
+-------------------------------
+
+The RRT tracks resource usage across scheduling cycles:
+
+.. code-block:: python
+
+    # RRT structure: (num_cycles, num_resource_types)
+    rrt = np.zeros((initiation_interval, num_resource_types), dtype=int)
+
+    # Example RRT for a 4-cycle schedule with 3 resource types
+    # Cycle | Resource1 | Resource2 | Resource3
+    #   0   |     1     |     0     |     2
+    #   1   |     0     |     2     |     1
+    #   2   |     2     |     1     |     0
+    #   3   |     1     |     1     |     1
+
+The RRT is updated whenever nodes are moved to ensure resource constraints are maintained.
+
+Output and Logging
+-----------------
+
+The optimization process generates several output files:
+
+1. **Schedule Files**: Each iteration's schedule saved as both JSON and text
+2. **Progress Log**: CSV file tracking latency improvements
+3. **Tuning History**: JSON file with complete optimization history
+4. **Final Results**: Summary of the best schedule found
+
+Example output structure:
+
+.. code-block:: text
+
+    attention_tuning/
+    └── tune_20250703_123456/
+        ├── schedules/
+        │   ├── schedule_0000.txt    # Initial schedule
+        │   ├── schedule_0001.txt    # First improvement
+        │   ├── schedule_0002.txt    # Second improvement
+        │   └── ...
+        ├── traces/
+        │   ├── trace_0000.rpd       # RPD traces for timing
+        │   └── ...
+        ├── tuning.log               # Detailed log
+        ├── tuning_progress.csv      # Progress tracking
+        ├── tuning_history.json      # Complete history
+        └── final_results.json       # Final summary
+
+Performance Measurement
+----------------------
+
+Performance is measured using RPD (https://github.com/ROCm/rocmProfileData) when available:
+
+.. code-block:: python
+
+    def measure_with_rpd(kernel_fn, *args, num_warmup, num_iterations,
+                        output_filename, config):
+        # Warmup runs
+        for _ in range(num_warmup):
+            _ = kernel_fn(*args)
+
+        # Benchmark runs with profiling
+        tracer = rpdTracerControl()
+        tracer.start()
+        for _ in range(num_iterations):
+            _ = kernel_fn(*args)
+        tracer.stop()
+
+        # Calculate average latency
+        avg_time = calculate_average_latency(output_filename)
+        return avg_time
+
+
+Constraints and Validation
+-------------------------
+
+The optimization process maintains several constraints:
+
+1. **Resource Constraints**: No cycle can exceed resource limits
+2. **Dependency Constraints**: Predecessors must execute before successors
+3. **Schedule Validity**: All nodes must be scheduled within valid cycles
+
+Troubleshooting
+--------------
+
+Common issues and solutions:
+
+1. **Compilation Failures**: Invalid schedules may cause compilation to fail
+
+   - The system returns infinity latency for failed compilations
+   - These schedules are automatically rejected
+
+2. **No Improvements**: If no improvements are found
+
+   - Check if the initial schedule is already optimal
+   - Increase max_iterations or max_no_improvement parameters
+   - Verify resource constraints are not too restrictive
+
+3. **Resource Violations**: If resource constraints are violated
+
+   - Check the RRT in schedule files
+   - Verify resource limits are appropriate for the kernel
+
+4. **Dependency Violations**: If dependency constraints are violated
+
+   - Check the schedule file for cycles where predecessors > successors
+   - Verify the dependency graph is correctly constructed
+
+Advanced Usage
+-------------
+
+For advanced users, you can customize the optimization process:
+
+.. code-block:: python
+
+    # Custom optimization parameters
+    result = optimizer.optimize(
+        max_iterations=50,           # More iterations
+        max_no_improvement=30,       # Longer patience
+        verbose=True                 # Detailed logging
+    )
+
+    # Access optimization history
+    print(f"Improvement history: {result.improvement_history}")
+    print(f"Total iterations: {result.iterations}")
+
+    # Save custom schedule files
+    dump_schedule(
+        schedule=result.schedule,
+        initiation_interval=initiation_interval,
+        num_stages=num_stages,
+        dump_file="custom_schedule.txt",
+        resource_reservations=resource_reservations,
+        resource_names=resource_names
+    )

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -34,10 +34,12 @@ class WaveKernel:
         gpu_binary_path: Optional[str],
         bound_scalar_symbols: dict[IndexSymbol, int],
         symbols_args_map: dict[IndexSymbol, tuple[int, int]],
+        trace: Optional["CapturedTrace"] = None,
     ):
         self.options = options
         self.executable = executable
         self.asm = asm
+        self.trace = trace
         if gpu_binary_path:
             import wave_runtime
 
@@ -48,6 +50,12 @@ class WaveKernel:
             self.gpu_func = None
         self.bound_scalar_symbols = bound_scalar_symbols
         self.symbols_args_map = symbols_args_map
+
+    def get_trace(self) -> Optional["CapturedTrace"]:
+        """Returns the trace used to generate this kernel.
+        If this is a cached kernel, the trace is not available.
+        """
+        return self.trace
 
     def __call__(self, *args, **kwargs):
         return self.invoke(*args, **kwargs)
@@ -128,6 +136,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
             options.kernel_launch_info = cached_kernel.kernel_launch_info
             if options.wave_runtime:
                 binary_path = get_binary_path()
+
             return WaveKernel(
                 options,
                 cached_kernel.vmfb,
@@ -161,6 +170,13 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
         options,
     ) = kernel._trace_and_get_kernel_signature(options)
     options.kernel_sig = kernel_sig
+
+    # Get the trace from the kernel. Since the trace contains complex objects
+    # that are not easily serializable, we don't cache the trace. So this trace
+    # is not available for cached kernels. The primary use case for the trace is
+    # is for tuning where each kernel is different from the others and so we
+    # don't want to cache the kernel in that case.
+    trace = kernel._trace()
 
     host_codegen.isolated_test_call(
         mb,
@@ -219,4 +235,5 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
         binary_path,
         bound_scalar_symbols,
         symbols_args_map,
+        trace,
     )

--- a/iree/turbine/kernel/wave/scheduling/optimize_schedule.py
+++ b/iree/turbine/kernel/wave/scheduling/optimize_schedule.py
@@ -1,0 +1,434 @@
+from .verifier import ScheduleValidator as ScheduleModifier
+import random
+from typing import Callable, Dict, Tuple, Optional, List
+from dataclasses import dataclass
+from enum import Enum, auto
+from iree.turbine.kernel.wave.scheduling.resources import (
+    get_custom_operation_type,
+    Operation,
+)
+from iree.turbine.kernel.ops.wave_ops import get_custom
+from iree.turbine.kernel.wave.tuner.utils import latency_to_us, format_latency_us
+import logging
+import numpy as np
+
+
+class OptimizationAlgorithm(Enum):
+    HILL_CLIMBING = auto()
+    # Add more algorithms here as needed
+
+
+@dataclass
+class OptimizationResult:
+    schedule: Dict
+    latency: float
+    iterations: int
+    algorithm: OptimizationAlgorithm
+    improvement_history: List[float]
+
+
+class ScheduleOptimizer:
+    def __init__(
+        self,
+        validator: ScheduleModifier,
+        measure_fn: Callable[[Dict], float],
+        algorithm: OptimizationAlgorithm = OptimizationAlgorithm.HILL_CLIMBING,
+        logger: Optional[logging.Logger] = None,
+        progress_file: Optional[str] = None,
+        tuning_logger=None,
+        random_seed: Optional[int] = None,
+    ):
+        """Initialize the schedule optimizer.
+
+        Args:
+            validator: A ScheduleModifier instance that validates and modifies schedules
+            measure_fn: A function that takes a schedule and returns its latency
+            algorithm: The optimization algorithm to use
+            logger: Optional logger for tracking optimization progress
+            progress_file: Optional path to progress file
+            tuning_logger: Optional tuning logger for saving schedules
+            random_seed: Optional seed for reproducible random number generation
+        """
+        self.validator = validator
+        self.measure_fn = measure_fn
+        self.algorithm = algorithm
+        self.logger = logger
+        self.progress_file = progress_file
+        self.tuning_logger = tuning_logger
+        self.current_best_schedule = None
+        self.current_best_latency = float("inf")
+        self.improvement_history = []
+        self.current_iteration = 0
+
+        # Initialize random number generator with seed for reproducibility
+        self.rng = random.Random(random_seed) if random_seed is not None else random
+
+        # Initialize progress file if provided
+        if self.progress_file is not None:
+            with open(self.progress_file, "w") as f:
+                f.write("iteration,latency_us,is_improvement,is_best\n")
+
+    def _write_progress(
+        self, iteration: int, latency: float, is_improvement: bool, is_best: bool
+    ) -> None:
+        """Write progress to file if progress_file is set.
+
+        Args:
+            iteration: Current iteration number
+            latency: Achieved latency
+            is_improvement: Whether this is an improvement
+            is_best: Whether this is the best latency so far
+        """
+        if self.progress_file is not None:
+            latency_us = latency_to_us(latency)
+            with open(self.progress_file, "a") as f:
+                f.write(f"{iteration},{latency_us},{is_improvement},{is_best}\n")
+
+    def _log_iteration(
+        self, schedule: Dict, latency: float, is_improvement: bool
+    ) -> None:
+        """Log an optimization iteration.
+
+        Args:
+            schedule: Current schedule
+            latency: Achieved latency
+            is_improvement: Whether this is an improvement
+        """
+        if self.logger is None:
+            return
+
+        latency_str = format_latency_us(latency)
+
+        if is_improvement:
+            self.logger.info(
+                f"Iteration {self.current_iteration}: Found improvement! "
+                f"Latency: {latency_str}"
+            )
+        else:
+            self.logger.debug(
+                f"Iteration {self.current_iteration}: No improvement. "
+                f"Latency: {latency_str}"
+            )
+
+    def _log_summary(self) -> None:
+        """Log a summary of the optimization process."""
+        if self.logger is None:
+            return
+
+        self.logger.info("\nOptimization Summary:")
+        best_latency_str = format_latency_us(self.current_best_latency)
+        improvement_history = [latency_to_us(h) for h in self.improvement_history]
+
+        self.logger.info(f"Best latency: {best_latency_str}")
+        self.logger.info(f"Total iterations: {self.current_iteration}")
+        self.logger.info(f"Improvement history: {improvement_history}")
+
+    def _measure_with_logging(self, schedule: Dict) -> float:
+        """Measure schedule latency with logging.
+
+        Args:
+            schedule: Schedule to measure
+
+        Returns:
+            Measured latency
+        """
+        latency = self.measure_fn(schedule)
+        self.current_iteration += 1
+        return latency
+
+    def _initialize_optimization(self, verbose: bool) -> Tuple[Dict, float]:
+        """Initialize the optimization process with the current best schedule.
+
+        Args:
+            verbose: Whether to print progress information
+
+        Returns:
+            Tuple of (current_best_schedule, current_best_latency)
+        """
+        if verbose and self.logger:
+            self.logger.info("Starting Hill Climbing Optimization...")
+
+        current_best_schedule, _ = self.validator.get_current_schedule_state()
+        current_best_latency = self._measure_with_logging(current_best_schedule)
+        self.improvement_history = [current_best_latency]
+
+        # Write initial progress
+        self._write_progress(0, current_best_latency, True, True)
+
+        if verbose and self.logger:
+            self.logger.info(
+                f"Initial Best Latency: {format_latency_us(current_best_latency)} for schedule: {{ { {n.name: s for n,s in current_best_schedule.items()} } }}"
+            )
+
+        return current_best_schedule, current_best_latency
+
+    def _get_schedulable_nodes(self) -> List:
+        """Get list of nodes that can be scheduled (non-NOOP operations).
+
+        Returns:
+            List of schedulable nodes
+        """
+        return [
+            n
+            for n in self.validator.nodes
+            if get_custom_operation_type_val(get_custom(n)) != Operation.NOOP
+        ]
+
+    def _select_random_move(
+        self, schedulable_nodes: List, current_best_schedule: Dict
+    ) -> Tuple:
+        """Select a random node and generate a new target cycle for it.
+
+        Args:
+            schedulable_nodes: List of nodes that can be moved
+            current_best_schedule: Current best schedule
+
+        Returns:
+            Tuple of (node_to_move, new_target_cycle)
+        """
+        node_to_move = self.rng.choice(schedulable_nodes)
+        original_cycle = current_best_schedule[node_to_move]
+        delta_cycle = self.rng.randrange(-self.validator.T, self.validator.T + 1)
+        if delta_cycle == 0:
+            delta_cycle = self.rng.choice([-1, 1])
+        new_target_cycle = max(0, original_cycle + delta_cycle)
+
+        return node_to_move, new_target_cycle
+
+    def _evaluate_move(
+        self,
+        node_to_move,
+        new_target_cycle: int,
+        current_best_latency: float,
+        verbose: bool,
+    ) -> Tuple[bool, float, Optional[Dict], Optional[np.ndarray]]:
+        """Evaluate a potential move and determine if it's an improvement.
+
+        Args:
+            node_to_move: Node to move
+            new_target_cycle: New target cycle for the node
+            current_best_latency: Current best latency
+            verbose: Whether to print progress information
+
+        Returns:
+            Tuple of (is_improvement, new_latency, new_schedule, resource_table) or (False, current_latency, None, None) if invalid
+        """
+        if verbose and self.logger:
+            self.logger.info(
+                f"  Attempting to move node {node_to_move.name} to cycle {new_target_cycle}"
+            )
+
+        (
+            is_valid_move,
+            candidate_schedule,
+            error_message,
+        ) = self.validator.attempt_move(node_to_move, new_target_cycle)
+
+        if not is_valid_move or candidate_schedule is None:
+            return False, current_best_latency, None, None
+
+        candidate_latency = self._measure_with_logging(candidate_schedule)
+
+        # Skip invalid results (infinity indicates compilation failure)
+        if candidate_latency == float("inf"):
+            return False, current_best_latency, None, None
+
+        is_improvement = candidate_latency < current_best_latency
+
+        # Use tuning logger to save the schedule if available
+        if self.tuning_logger is not None:
+            self.tuning_logger.log_iteration(
+                self.current_iteration,
+                candidate_schedule,
+                candidate_latency,
+                is_improvement,
+            )
+        else:
+            self._log_iteration(candidate_schedule, candidate_latency, is_improvement)
+
+        self._write_progress(
+            self.current_iteration, candidate_latency, is_improvement, is_improvement
+        )
+
+        if is_improvement and verbose and self.logger:
+            self.logger.info(
+                f"  *** Improvement found! New latency: {format_latency_us(candidate_latency)} (old: {format_latency_us(current_best_latency)}) ***"
+            )
+
+        # Get the resource table from the validator's current state
+        _, resource_table = self.validator.get_current_schedule_state()
+        return is_improvement, candidate_latency, candidate_schedule, resource_table
+
+    def _update_best_solution(
+        self,
+        is_improvement: bool,
+        candidate_latency: float,
+        candidate_schedule: Dict,
+        candidate_rt: Optional[np.ndarray],
+        current_best_schedule: Dict,
+        current_best_latency: float,
+    ) -> Tuple[Dict, float, int]:
+        """Update the best solution if an improvement is found.
+
+        Args:
+            is_improvement: Whether the candidate is an improvement
+            candidate_latency: Latency of the candidate schedule
+            candidate_schedule: Candidate schedule
+            candidate_rt: Candidate resource table
+            current_best_schedule: Current best schedule
+            current_best_latency: Current best latency
+
+        Returns:
+            Tuple of (new_best_schedule, new_best_latency, no_improvement_streak)
+        """
+        if is_improvement:
+            if candidate_rt is not None:
+                self.validator.commit_move(candidate_schedule, candidate_rt)
+            self.improvement_history.append(candidate_latency)
+            return candidate_schedule, candidate_latency, 0
+        else:
+            return current_best_schedule, current_best_latency, 1
+
+    def _log_final_results(
+        self, current_best_latency: float, current_best_schedule: Dict, verbose: bool
+    ) -> None:
+        """Log the final optimization results.
+
+        Args:
+            current_best_latency: Final best latency
+            current_best_schedule: Final best schedule
+            verbose: Whether to print progress information
+        """
+        if verbose and self.logger:
+            self.logger.info("\nOptimization Finished.")
+            self.logger.info(
+                f"Final Best Latency: {format_latency_us(current_best_latency)}"
+            )
+            self.logger.info(
+                f"Final Best Schedule: {{ { {n.name: s for n,s in current_best_schedule.items()} } }}"
+            )
+
+    def _run_hill_climbing(
+        self,
+        max_iterations: int = 100,
+        max_no_improvement: int = 20,
+        verbose: bool = True,
+    ) -> OptimizationResult:
+        """Run hill climbing optimization algorithm.
+
+        Args:
+            max_iterations: Maximum number of iterations to run
+            max_no_improvement: Maximum number of iterations without improvement before stopping
+            verbose: Whether to print progress information
+
+        Returns:
+            OptimizationResult containing the best schedule and optimization metrics
+        """
+        # Initialize optimization
+        current_best_schedule, current_best_latency = self._initialize_optimization(
+            verbose
+        )
+
+        no_improvement_streak = 0
+        iteration = 0
+
+        while iteration < max_iterations:
+            if verbose and self.logger:
+                self.logger.info(f"\nIteration {iteration + 1}/{max_iterations}")
+
+            # Get schedulable nodes
+            schedulable_nodes = self._get_schedulable_nodes()
+            if not schedulable_nodes:
+                if verbose and self.logger:
+                    self.logger.info(
+                        "  No schedulable (non-NOOP) nodes to move. Stopping."
+                    )
+                break
+
+            # Select and evaluate a random move
+            node_to_move, new_target_cycle = self._select_random_move(
+                schedulable_nodes, current_best_schedule
+            )
+            is_improvement, candidate_latency, candidate_schedule, candidate_rt = (
+                self._evaluate_move(
+                    node_to_move, new_target_cycle, current_best_latency, verbose
+                )
+            )
+
+            # Update best solution if improvement found
+            current_best_schedule, current_best_latency, streak_increment = (
+                self._update_best_solution(
+                    is_improvement,
+                    candidate_latency,
+                    candidate_schedule,
+                    candidate_rt,
+                    current_best_schedule,
+                    current_best_latency,
+                )
+            )
+            no_improvement_streak += streak_increment
+
+            # Check early stopping condition
+            if no_improvement_streak >= max_no_improvement:
+                if verbose and self.logger:
+                    self.logger.info(
+                        f"\nStopping early: No improvement in {max_no_improvement} iterations."
+                    )
+                break
+
+            iteration += 1
+
+        # Log final results
+        self._log_final_results(current_best_latency, current_best_schedule, verbose)
+
+        # Update the instance variables for logging
+        self.current_best_latency = current_best_latency
+        self.current_iteration = iteration
+
+        self._log_summary()
+
+        return OptimizationResult(
+            schedule=current_best_schedule,
+            latency=current_best_latency,
+            iterations=iteration,
+            algorithm=OptimizationAlgorithm.HILL_CLIMBING,
+            improvement_history=self.improvement_history,
+        )
+
+    def optimize(
+        self,
+        max_iterations: int = 100,
+        max_no_improvement: int = 20,
+        verbose: bool = True,
+    ) -> OptimizationResult:
+        """Run the selected optimization algorithm.
+
+        Args:
+            max_iterations: Maximum number of iterations to run
+            max_no_improvement: Maximum number of iterations without improvement before stopping
+            verbose: Whether to print progress information
+
+        Returns:
+            OptimizationResult containing the best schedule and optimization metrics
+        """
+        if self.algorithm == OptimizationAlgorithm.HILL_CLIMBING:
+            return self._run_hill_climbing(
+                max_iterations=max_iterations,
+                max_no_improvement=max_no_improvement,
+                verbose=verbose,
+            )
+        else:
+            raise ValueError(f"Unsupported optimization algorithm: {self.algorithm}")
+
+
+def get_custom_operation_type_val(custom: "CustomOp") -> str:
+    """Get the string value of the operation type for a custom operation.
+
+    Args:
+        custom: The custom operation to get the type value for
+
+    Returns:
+        The string value of the operation type (e.g. "read_shared", "write_global", etc.)
+    """
+    op_type = get_custom_operation_type(custom)
+    return op_type.value if op_type is not None else Operation.NOOP.value

--- a/iree/turbine/kernel/wave/scheduling/schedule.py
+++ b/iree/turbine/kernel/wave/scheduling/schedule.py
@@ -119,7 +119,6 @@ def schedule_reduction(
 
         if dump_schedule_file:
             dump_schedule(
-                graph,
                 schedule,
                 initiation_interval,
                 num_stages,

--- a/iree/turbine/kernel/wave/tuner/tune_attention.py
+++ b/iree/turbine/kernel/wave/tuner/tune_attention.py
@@ -1,0 +1,844 @@
+import torch
+import json
+import math
+import os
+import logging
+import datetime
+import random
+import sqlite3
+import pandas as pd
+from pathlib import Path
+from typing import Dict, Tuple, Optional, Any, List
+from dataclasses import dataclass, asdict
+import iree.turbine.kernel as tk
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.wave.utils.general_utils import get_default_scheduling_params
+from iree.turbine.kernel.wave.utils.run_utils import set_default_run_config
+from iree.turbine.kernel.wave.utils.torch_utils import device_randn, device_zeros
+from iree.turbine.kernel.wave.compile import WaveCompileOptions, wave_compile
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.templates.vanilla_attention import (
+    get_vanilla_attention_kernel,
+)
+from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
+from iree.turbine.kernel.wave.scheduling.optimize_schedule import (
+    ScheduleOptimizer,
+    OptimizationAlgorithm,
+    OptimizationResult,
+)
+from iree.turbine.kernel.wave.scheduling.verifier import (
+    ScheduleValidator as ScheduleModifier,
+)
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
+from enum import Enum
+import torch.fx as fx
+import numpy as np
+from iree.turbine.kernel.wave.utils.print_utils import load_schedule, dump_schedule
+from iree.turbine.kernel.wave.scheduling.resources import (
+    resource_reservation_table,
+    get_custom_operation_type,
+    Operation,
+)
+from iree.turbine.kernel.ops.wave_ops import get_custom
+from iree.turbine.kernel.wave.tuner.utils import (
+    latency_to_us,
+    format_latency_us,
+    enum_to_str,
+)
+
+try:
+    from rpdTracerControl import rpdTracerControl
+except ImportError:
+    logging.warning("rpdTracerControl not found")
+    RPD_AVAILABLE = False
+else:
+    RPD_AVAILABLE = True
+
+
+@dataclass
+class AttentionConfig:
+    """Configuration for attention kernel tuning."""
+
+    batch_size: int
+    num_heads: int
+    seq_len_q: int
+    seq_len_k: int
+    head_dim: int
+    head_dim_kv: int
+    mfma_variant: Tuple[MMAType, MMAType]
+    enable_scheduling: SchedulingType = SchedulingType.MODULO
+    dynamic_dims: bool = False
+    num_warmup: int = 10
+    num_iterations: int = 100
+    random_seed: Optional[int] = None
+
+
+def get_attention_shape(config: AttentionConfig) -> AttentionShape:
+    """Convert config to AttentionShape."""
+    return AttentionShape(
+        num_query_heads=config.num_heads,
+        num_kv_heads=config.num_heads,
+        query_seq_len=config.seq_len_q,
+        head_size_kv=config.head_dim_kv,
+        head_size=config.head_dim,
+        kv_seq_len=config.seq_len_k,
+    )
+
+
+@dataclass
+class TimingResult:
+    """Results from timing a kernel execution."""
+
+    latency_ms: float
+    throughput_tflops: float
+    trace_file: Optional[str] = None
+
+
+def calculate_throughput(
+    batch_size: int,
+    num_heads: int,
+    seq_len_q: int,
+    seq_len_k: int,
+    head_dim: int,
+    latency_seconds: float,
+) -> float:
+    """Calculate theoretical throughput in TFLOPs.
+
+    Args:
+        batch_size: Batch dimension
+        num_heads: Number of attention heads
+        seq_len_q: Query sequence length
+        seq_len_k: Key sequence length
+        head_dim: Head dimension
+        latency_seconds: Execution time in seconds
+
+    Returns:
+        Throughput in TFLOPs
+    """
+    # For attention, we have:
+    # 1. QK matmul: 2 * B * H * M * N * K operations
+    # 2. Softmax: 2 * B * H * M * N operations
+    # 3. V matmul: 2 * B * H * M * N * K operations
+    # Total: 4 * B * H * M * N * K + 2 * B * H * M * N operations
+    total_ops = (
+        4 * batch_size * num_heads * seq_len_q * seq_len_k * head_dim
+        + 2 * batch_size * num_heads * seq_len_q * seq_len_k
+    )
+    return total_ops / (latency_seconds * 1e12)  # Convert to TFLOPs
+
+
+def measure_with_rpd(
+    kernel_fn,
+    *args,
+    num_warmup: int,
+    num_iterations: int,
+    output_filename: str,
+    config: AttentionConfig,
+) -> TimingResult:
+    """Measure kernel performance using RPD tracer.
+
+    Args:
+        kernel_fn: The kernel function to measure
+        *args: Arguments to pass to the kernel
+        num_warmup: Number of warmup iterations
+        num_iterations: Number of benchmark iterations
+        output_filename: Path to save RPD trace
+        config: Attention configuration for throughput calculation
+
+    Returns:
+        TimingResult with latency and throughput
+    """
+    if not RPD_AVAILABLE:
+        raise RuntimeError("RPD tracer not available")
+
+    # Warmup
+    for _ in range(num_warmup):
+        _ = kernel_fn(*args)
+
+    # Synchronize GPU
+    torch.cuda.synchronize()
+
+    # Initialize RPD tracer
+    rpdTracerControl.setFilename(name=output_filename, append=False)
+    tracer = rpdTracerControl()
+    tracer.start()
+
+    # Benchmark with profiling
+    for _ in range(num_iterations):
+        _ = kernel_fn(*args)
+    torch.cuda.synchronize()
+
+    # Stop profiling and get results
+    tracer.stop()
+    tracer.flush()
+
+    # Calculate statistics from RPD trace
+    conn = sqlite3.connect(output_filename)
+    df_top = pd.read_sql_query("SELECT * from top", conn)
+    conn.close()
+
+    avg_time = df_top["Ave_us"][0] / 1e6  # Convert to seconds
+    throughput = calculate_throughput(
+        config.batch_size,
+        config.num_heads,
+        config.seq_len_q,
+        config.seq_len_k,
+        config.head_dim,
+        avg_time,
+    )
+
+    return TimingResult(
+        latency_ms=avg_time * 1_000_000,
+        throughput_tflops=throughput,
+        trace_file=output_filename,
+    )
+
+
+def measure_attention_latency(
+    config: AttentionConfig,
+    schedule_file: Optional[str] = None,
+    log_dir: Optional[Path] = None,
+    iteration: Optional[int] = None,
+    logger: Optional[logging.Logger] = None,
+) -> float:
+    """Measure the latency of vanilla attention kernel with given schedule.
+
+    Args:
+        config: Attention configuration
+        schedule_file: Optional path to schedule file to use. If None, uses default schedule
+        log_dir: Optional directory to save RPD traces
+        iteration: Optional iteration number for trace file naming
+
+    Returns:
+        Average latency in seconds
+    """
+    shape = get_attention_shape(config)
+
+    # Get the kernel and hyperparameters
+    (
+        base_attention,
+        hyperparams,
+        dynamic_symbols,
+    ) = get_vanilla_attention_kernel(
+        shape, config.mfma_variant, config.dynamic_dims, is_v_transposed=True
+    )
+
+    # Update hyperparameters with scheduling parameters
+    hyperparams.update(get_default_scheduling_params())
+
+    # Create input tensors
+    q_shape = (config.num_heads, config.seq_len_q, config.head_dim)
+    k_shape = (config.num_heads, config.seq_len_k, config.head_dim)
+    v_shape = (config.num_heads, config.seq_len_k, config.head_dim_kv)
+    o_shape = (config.num_heads, config.seq_len_q, config.head_dim_kv)
+
+    torch.manual_seed(0)
+    q = device_randn(q_shape, dtype=torch.float16)
+    k = device_randn(k_shape, dtype=torch.float16)
+    v = device_randn(v_shape, dtype=torch.float16)
+    output = device_zeros(o_shape, dtype=torch.float32)
+
+    # Set up compilation options
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        schedule=SchedulingType.MODULO,
+        use_scheduling_barriers=True,
+        dynamic_symbols=dynamic_symbols,
+        waves_per_eu=2,
+        denorm_fp_math_f32="preserve-sign",
+        benchmark_batch_size=config.num_iterations,
+        benchmark_repetitions=1,
+    )
+
+    if schedule_file is not None:
+        options.override_schedule = schedule_file
+
+    options = set_default_run_config(options)
+
+    try:
+        compiled_kernel = wave_compile(options, base_attention)
+    except Exception as e:
+        # If compilation fails, return infinity to indicate invalid result
+        # This prevents the tuning process from crashing
+        if logger is not None:
+            logger.warning(f"Compilation failed for iteration {iteration}: {e}")
+        return float("inf")  # Return infinity to indicate compilation failure
+
+    # Prepare kernel arguments
+    kernel_args = (q, k, v.permute([0, 2, 1]), output)
+
+    # Measure performance
+    trace_file = log_dir / "traces" / f"trace_{iteration:04d}.rpd"
+    trace_file.parent.mkdir(parents=True, exist_ok=True)
+
+    timing_result = measure_with_rpd(
+        compiled_kernel,
+        *kernel_args,
+        num_warmup=config.num_warmup,
+        num_iterations=config.num_iterations,
+        output_filename=str(trace_file),
+        config=config,
+    )
+
+    return timing_result.latency_ms / 1_000_000.0
+
+
+def setup_logging(config: AttentionConfig) -> Tuple[logging.Logger, Path]:
+    """Set up logging for the tuning process.
+
+    Args:
+        config: Attention configuration
+
+    Returns:
+        Tuple of (logger, log_dir)
+    """
+    # Create timestamp for unique directory
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    # Create directories
+    base_dir = Path("attention_tuning")
+    log_dir = base_dir / f"tune_{timestamp}"
+    schedules_dir = log_dir / "schedules"
+
+    # Create directories if they don't exist
+    log_dir.mkdir(parents=True, exist_ok=True)
+    schedules_dir.mkdir(parents=True, exist_ok=True)
+
+    # Set up logging
+    logger = logging.getLogger("attention_tuner")
+    logger.setLevel(logging.INFO)
+
+    # Clear any existing handlers to avoid duplicates
+    logger.handlers.clear()
+
+    # Disable propagation to root logger to prevent duplication
+    logger.propagate = False
+
+    # File handler for detailed log
+    log_file = log_dir / "tuning.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(logging.INFO)
+
+    # Console handler for immediate feedback
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+
+    # Create formatter
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    file_handler.setFormatter(formatter)
+    console_handler.setFormatter(formatter)
+
+    # Add handlers
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+
+    # Log initial configuration
+    def enum_to_str(obj):
+        if isinstance(obj, Enum):
+            return str(obj)
+        if isinstance(obj, tuple):
+            return tuple(enum_to_str(x) for x in obj)
+        return obj
+
+    config_dict = {k: enum_to_str(v) for k, v in asdict(config).items()}
+    logger.info("Starting attention kernel tuning")
+    logger.info(f"Configuration:\n{json.dumps(config_dict, indent=2)}")
+
+    return logger, log_dir
+
+
+def save_schedule(
+    schedule: Dict,
+    latency: float,
+    iteration: int,
+    schedules_dir: Path,
+    logger: logging.Logger,
+    graph: Optional[fx.Graph] = None,
+    initiation_interval: Optional[int] = None,
+    num_stages: Optional[int] = None,
+    resource_reservations: Optional[np.ndarray] = None,
+    resource_names: Optional[list[str]] = None,
+    original_schedule_file: Optional[str] = None,
+) -> None:
+    """Save a schedule to a JSON file and optionally to a schedule file.
+
+    Args:
+        schedule: The schedule to save
+        latency: The latency achieved with this schedule
+        iteration: The iteration number
+        schedules_dir: Directory to save schedules
+        logger: Logger instance
+        graph: Optional FX graph for schedule file format
+        initiation_interval: Optional initiation interval for schedule file format
+        num_stages: Optional number of stages for schedule file format
+        resource_reservations: Optional resource reservations for schedule file format
+        resource_names: Optional resource names for schedule file format
+        original_schedule_file: Optional original schedule file to preserve structure
+    """
+    # Save in JSON format
+    schedule_file = schedules_dir / f"schedule_{iteration:04d}.json"
+    schedule_data = {
+        "iteration": int(iteration),
+        "latency_us": float(latency_to_us(latency)),
+        "schedule": {str(k): int(v) for k, v in schedule.items()},
+    }
+
+    with open(schedule_file, "w") as f:
+        json.dump(schedule_data, f, indent=2)
+
+    # Save in schedule file format if all required parameters are provided
+    if all([graph, initiation_interval, num_stages]):
+        schedule_txt_file = schedules_dir / f"schedule_{iteration:04d}.txt"
+        dump_schedule(
+            schedule,
+            initiation_interval,
+            num_stages,
+            str(schedule_txt_file),
+            resource_reservations,
+            resource_names,
+            original_schedule_file,
+        )
+        logger.debug(f"Saved schedule for iteration {iteration} to {schedule_txt_file}")
+
+    logger.debug(f"Saved schedule for iteration {iteration} to {schedule_file}")
+
+
+class TuningLogger:
+    """Custom logger for the optimization process."""
+
+    def __init__(self, logger: logging.Logger, schedules_dir: Path):
+        self.logger = logger
+        self.schedules_dir = schedules_dir
+        self.best_latency = float("inf")
+        self.best_iteration = -1
+        self.history = []
+        self.current_iteration = 0
+        # Store additional parameters for schedule saving
+        self.graph = None
+        self.initiation_interval = None
+        self.num_stages = None
+        self.resource_reservations = None
+        self.resource_names = None
+        self.original_schedule_file = None
+
+    def set_schedule_params(
+        self,
+        graph: fx.Graph,
+        initiation_interval: int,
+        num_stages: int,
+        resource_reservations: Optional[np.ndarray] = None,
+        resource_names: Optional[list[str]] = None,
+        original_schedule_file: Optional[str] = None,
+    ) -> None:
+        """Set parameters needed for saving schedules in schedule file format.
+
+        Args:
+            graph: FX graph for schedule file format
+            initiation_interval: Initiation interval for schedule file format
+            num_stages: Number of stages for schedule file format
+            resource_reservations: Optional resource reservations for schedule file format
+            resource_names: Optional resource names for schedule file format
+            original_schedule_file: Optional original schedule file to preserve structure
+        """
+        self.graph = graph
+        self.initiation_interval = initiation_interval
+        self.num_stages = num_stages
+        self.resource_reservations = resource_reservations
+        self.resource_names = resource_names
+        self.original_schedule_file = original_schedule_file
+
+    def log_iteration(
+        self, iteration: int, schedule: Dict, latency: float, is_improvement: bool
+    ) -> None:
+        """Log an optimization iteration and save the schedule.
+
+        Args:
+            iteration: Current iteration number
+            schedule: Current schedule
+            latency: Achieved latency
+            is_improvement: Whether this is an improvement
+        """
+        # Always save the schedule, regardless of whether it's an improvement
+        schedule_filename = f"schedule_{iteration:04d}"
+        save_schedule(
+            schedule,
+            latency,
+            iteration,
+            self.schedules_dir,
+            self.logger,
+            self.graph,
+            self.initiation_interval,
+            self.num_stages,
+            self.resource_reservations,
+            self.resource_names,
+            self.original_schedule_file,
+        )
+
+        self.history.append(
+            {
+                "iteration": int(iteration),
+                "latency_us": float(latency_to_us(latency)),
+                "is_improvement": bool(is_improvement),
+                "schedule_file": str(f"{schedule_filename}.json"),
+                "schedule_txt_file": str(f"{schedule_filename}.txt"),
+            }
+        )
+
+        if is_improvement:
+            self.best_latency = latency
+            self.best_iteration = iteration
+            self.logger.info(
+                f"Iteration {iteration}: Found improvement! "
+                f"Latency: {format_latency_us(latency)}"
+            )
+        else:
+            self.logger.debug(
+                f"Iteration {iteration}: No improvement. "
+                f"Latency: {format_latency_us(latency)}"
+            )
+
+    def log_summary(self) -> None:
+        """Log a summary of the tuning process."""
+        self.logger.info("\nTuning Summary:")
+        self.logger.info(f"Best latency: {format_latency_us(self.best_latency)}")
+        self.logger.info(f"Best iteration: {self.best_iteration}")
+        self.logger.info(f"Total iterations: {len(self.history)}")
+
+        # Save history
+        history_file = self.schedules_dir.parent / "tuning_history.json"
+        with open(history_file, "w") as f:
+            json.dump(self.history, f, indent=2)
+
+        self.logger.info(f"Tuning history saved to {history_file}")
+
+
+def get_custom_operation_type_val(custom: "CustomOp") -> str:
+    """Get the string value of the operation type for a custom operation.
+
+    Args:
+        custom: The custom operation to get the type value for
+
+    Returns:
+        The string value of the operation type (e.g. "read_shared", "write_global", etc.)
+    """
+    op_type = get_custom_operation_type(custom)
+    return op_type.value if op_type is not None else Operation.NOOP.value
+
+
+def create_optimizer_logger() -> logging.Logger:
+    """Create a separate logger for the optimizer to avoid duplication."""
+    optimizer_logger = logging.getLogger("attention_optimizer")
+    optimizer_logger.setLevel(logging.INFO)
+    optimizer_logger.handlers.clear()
+    optimizer_logger.propagate = False
+
+    # Add console handler for optimizer logging
+    optimizer_console_handler = logging.StreamHandler()
+    optimizer_console_handler.setLevel(logging.INFO)
+    optimizer_formatter = logging.Formatter(
+        "%(message)s"
+    )  # Simpler format for optimizer
+    optimizer_console_handler.setFormatter(optimizer_formatter)
+    optimizer_logger.addHandler(optimizer_console_handler)
+
+    return optimizer_logger
+
+
+def create_compilation_options(
+    hyperparams: Dict,
+    dynamic_symbols: Dict,
+    config: AttentionConfig,
+    schedule_file: Optional[str] = None,
+) -> WaveCompileOptions:
+    """Create compilation options with common parameters."""
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        schedule=SchedulingType.MODULO,
+        use_scheduling_barriers=True,
+        dynamic_symbols=dynamic_symbols,
+        waves_per_eu=2,
+        denorm_fp_math_f32="preserve-sign",
+        benchmark_batch_size=config.num_iterations,
+        benchmark_repetitions=1,
+    )
+
+    if schedule_file is not None:
+        options.override_schedule = schedule_file
+
+    return set_default_run_config(options)
+
+
+def create_validator(
+    initial_schedule: Dict,
+    initiation_interval: int,
+    nodes: List,
+    edges: List,
+    resource_names: Optional[List[str]] = None,
+) -> ScheduleModifier:
+    """Create a schedule validator with common parameters."""
+    return ScheduleModifier(
+        initial_schedule=initial_schedule,
+        T=initiation_interval,
+        nodes=nodes,
+        resource_limits=(
+            np.array([2] * len(resource_names))
+            if resource_names
+            else np.array([2, 2, 2, 2, 2])
+        ),
+        node_rrt_getter=lambda node: (
+            node.rrt
+            if hasattr(node, "rrt")
+            else np.zeros((1, len(resource_names) if resource_names else 5))
+        ),
+        raw_edges_list=edges,
+        num_resource_types=len(resource_names) if resource_names else 5,
+    )
+
+
+def save_final_results(
+    config: AttentionConfig,
+    initial_latency: float,
+    initial_schedule: Dict,
+    result: OptimizationResult,
+    log_dir: Path,
+    logger: logging.Logger,
+    tuning_logger: TuningLogger,
+) -> None:
+    """Save final results to JSON file with references to schedule files."""
+    # Convert improvement history to standard Python floats
+    improvement_history = [
+        float(latency_to_us(float(h))) for h in result.improvement_history
+    ]
+
+    # Convert config to JSON-serializable format
+    config_dict = {k: enum_to_str(v) for k, v in asdict(config).items()}
+
+    # Get the best iteration from tuning logger
+    best_iteration = tuning_logger.best_iteration
+    if best_iteration == 0:
+        best_schedule_filename = "schedule_0000"
+    else:
+        best_schedule_filename = f"schedule_{best_iteration:04d}"
+
+    final_results = {
+        "config": config_dict,
+        "initial_latency_us": float(latency_to_us(initial_latency)),
+        "initial_schedule_file": "initial_schedule.txt",
+        "best_latency_us": float(latency_to_us(result.latency)),
+        "best_schedule_file": f"{best_schedule_filename}.txt",
+        "best_schedule_json_file": f"{best_schedule_filename}.json",
+        "best_iteration": int(best_iteration),
+        "total_iterations": int(result.iterations),
+        "improvement_history": improvement_history,
+        "all_schedules": tuning_logger.history,
+    }
+
+    results_file = log_dir / "final_results.json"
+    with open(results_file, "w") as f:
+        json.dump(final_results, f, indent=2)
+
+    logger.info(f"Final results saved to {results_file}")
+    logger.info(
+        f"Best schedule saved to {log_dir / 'schedules' / f'{best_schedule_filename}.txt'}"
+    )
+
+
+def tune_attention(config: AttentionConfig) -> Tuple[Dict, float]:
+    """Tune the vanilla attention kernel using ScheduleOptimizer."""
+    # Set random seed for reproducibility if provided
+    if config.random_seed is not None:
+        random.seed(config.random_seed)
+        torch.manual_seed(config.random_seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed(config.random_seed)
+            torch.cuda.manual_seed_all(config.random_seed)
+
+    # Set up logging
+    logger, log_dir = setup_logging(config)
+    tuning_logger = TuningLogger(logger, log_dir / "schedules")
+
+    if RPD_AVAILABLE:
+        logger.info("Using RPD tracer for performance measurement")
+    else:
+        logger.warning("RPD tracer not available, falling back to CUDA events")
+
+    shape = get_attention_shape(config)
+
+    # Get initial kernel and hyperparameters
+    (
+        base_attention,
+        hyperparams,
+        dynamic_symbols,
+    ) = get_vanilla_attention_kernel(
+        shape, config.mfma_variant, config.dynamic_dims, is_v_transposed=True
+    )
+
+    # Update hyperparameters with scheduling parameters
+    hyperparams.update(get_default_scheduling_params())
+
+    # Compile the kernel once and dump the schedule
+    initial_schedule_file = str(log_dir / "initial_schedule.txt")
+    options = create_compilation_options(hyperparams, dynamic_symbols, config)
+    options.dump_schedule = initial_schedule_file
+    compiled_kernel = wave_compile(options, base_attention)
+
+    # Create a graph to hold the schedule nodes
+    graph = compiled_kernel.get_trace().region_graph.subgraphs["region_0"]
+
+    # Load the schedule using print_utils
+    (
+        initial_schedule,
+        initiation_interval,
+        num_stages,
+        nodes,
+        edges,
+        resource_reservations,
+        resource_names,
+    ) = load_schedule(initial_schedule_file, graph)
+
+    logger.info(f"Loaded schedule with II={initiation_interval}, stages={num_stages}")
+    logger.info(f"Found {len(nodes)} nodes and {len(edges)} edges")
+
+    # Create validator with loaded schedule data
+    validator = create_validator(
+        initial_schedule, initiation_interval, nodes, edges, resource_names
+    )
+
+    # Get initial schedule and compiled kernel
+    logger.info("Getting initial schedule...")
+    initial_latency = measure_attention_latency(
+        config,
+        schedule_file=initial_schedule_file,
+        log_dir=log_dir,
+        iteration=0,
+        logger=logger,
+    )
+
+    logger.info(f"Initial latency: {format_latency_us(initial_latency)}")
+
+    # Set up tuning logger with schedule parameters
+    tuning_logger.set_schedule_params(
+        graph,
+        initiation_interval,
+        num_stages,
+        resource_reservations,
+        resource_names,
+        initial_schedule_file,
+    )
+
+    # Save initial schedule
+    save_schedule(
+        initial_schedule,
+        initial_latency,
+        0,  # iteration 0 for initial schedule
+        log_dir / "schedules",
+        logger,
+        graph,
+        initiation_interval,
+        num_stages,
+        resource_reservations,
+        resource_names,
+        original_schedule_file=initial_schedule_file,
+    )
+
+    # Add initial schedule to tuning logger history
+    tuning_logger.history.append(
+        {
+            "iteration": 0,
+            "latency_us": float(latency_to_us(initial_latency)),
+            "is_improvement": True,  # Initial schedule is considered an improvement
+            "schedule_file": "schedule_0000.json",
+            "schedule_txt_file": "schedule_0000.txt",
+        }
+    )
+    tuning_logger.best_latency = initial_latency
+    tuning_logger.best_iteration = 0
+
+    # Create measurement function that captures config and compiled kernel
+    def measure_fn(schedule: Dict) -> float:
+        nonlocal initial_schedule_file
+        # Save the schedule to a temporary file
+        schedule_file = (
+            log_dir
+            / "schedules"
+            / f"temp_schedule_{tuning_logger.current_iteration:04d}.txt"
+        )
+        dump_schedule(
+            schedule,
+            initiation_interval,
+            num_stages,
+            str(schedule_file),
+            resource_reservations,
+            resource_names,
+            original_schedule_file=initial_schedule_file,
+        )
+
+        # Update initial_schedule_file to use the newly created schedule file
+        initial_schedule_file = str(schedule_file)
+
+        latency = measure_attention_latency(
+            config,
+            schedule_file=str(schedule_file),
+            log_dir=log_dir,
+            iteration=tuning_logger.current_iteration,
+            logger=logger,
+        )
+        return latency
+
+    # Create a separate logger for the optimizer to avoid duplication with main logger
+    optimizer_logger = create_optimizer_logger()
+
+    # Create progress file path
+    progress_file = log_dir / "tuning_progress.csv"
+
+    # Create and run optimizer with its own logger
+    optimizer = ScheduleOptimizer(
+        validator=validator,
+        measure_fn=measure_fn,
+        algorithm=OptimizationAlgorithm.HILL_CLIMBING,
+        logger=optimizer_logger,
+        progress_file=str(progress_file),
+        tuning_logger=tuning_logger,
+        random_seed=config.random_seed,
+    )
+
+    # Run optimization
+    result = optimizer.optimize(max_iterations=10, max_no_improvement=20, verbose=True)
+
+    # Save final results
+    save_final_results(
+        config,
+        initial_latency,
+        initial_schedule,
+        result,
+        log_dir,
+        logger,
+        tuning_logger,
+    )
+
+    return result.schedule, result.latency
+
+
+def main():
+    # Example configuration
+    config = AttentionConfig(
+        batch_size=1,
+        num_heads=32,
+        seq_len_q=512,
+        seq_len_k=512,
+        head_dim=64,
+        head_dim_kv=64,
+        mfma_variant=(MMAType.F32_32x32x8_F16, MMAType.F32_32x32x8_F16),
+        enable_scheduling=SchedulingType.MODULO,
+        dynamic_dims=False,
+        num_warmup=10,
+        num_iterations=100,
+        random_seed=42,  # Set seed for reproducible results
+    )
+
+    best_schedule, best_latency = tune_attention(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/iree/turbine/kernel/wave/tuner/utils.py
+++ b/iree/turbine/kernel/wave/tuner/utils.py
@@ -1,0 +1,29 @@
+# Copyright 2025 The IREE Authors
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from enum import Enum
+from typing import Any, Union, Tuple
+
+
+def latency_to_us(latency: float) -> float:
+    """Convert latency from seconds to microseconds."""
+    return latency * 1_000_000 if latency != float("inf") else float("inf")
+
+
+def format_latency_us(latency: float, precision: int = 2) -> str:
+    """Format latency in microseconds with specified precision."""
+    if latency == float("inf"):
+        return "inf"
+    return f"{latency_to_us(latency):.{precision}f} μs"
+
+
+def enum_to_str(obj: Union[Enum, Tuple, Any]) -> Any:
+    """Convert enum objects to strings for JSON serialization."""
+    if isinstance(obj, Enum):
+        return str(obj)
+    elif isinstance(obj, tuple):
+        return tuple(enum_to_str(x) for x in obj)
+    else:
+        return obj


### PR DESCRIPTION
This PR adds code to search over schedules for a given kernel. In this particular case, we choose attention and tweak the schedule of nodes in the graph to tweak performance. We also clean up the print utils to enable some of these changes. Finally, a new section has been added to the documentation describing the code and how it can be used.