### PR TITLE
[Wave] Force non-masked ops in decode second stage

### DIFF
--- a/iree/turbine/kernel/wave/generate_bounds_exprs.py
+++ b/iree/turbine/kernel/wave/generate_bounds_exprs.py
@@ -46,6 +46,9 @@ def generate_bounds_exprs(trace: CapturedTrace, constraints: list[Constraint]):
     nodes = trace.walk(is_read_write)
     for node in nodes:
         node = get_custom(node)
+        if node.bounds is not None:
+            continue
+
         vector_shapes = node.vector_shapes or hardware_constraint.vector_shapes
         is_shared_mem = is_shared_mem_access(node)
         bounds = find_index_bounds(constraints, node.index, vector_shapes)

--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -417,8 +417,10 @@ def get_paged_decode_attention_kernels(
             partial_sum: tkl.Register[S, B, tkl.f32],
             acc: tkl.Register[S, B, N, tkl.f32],
         ):
-            x_j = tkw.read(logits)
-            xm_j = tkw.read(logits_max)
+            # TODO: U iterator has tile size 1 and is always smaller than U,
+            # so force the non-masked ops here by setting bounds to empty.
+            x_j = tkw.read(logits, bounds={})
+            xm_j = tkw.read(logits_max, bounds={})
             m_j = tkw.maximum(xm_j, partial_max)
             old_scale = tkw.exp2(partial_max - m_j)
             new_scale = tkw.exp2(xm_j - m_j)

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -238,7 +238,7 @@ def test_flash_decoding():
 
     # CHECK-LABEL:       func.func @phase_1
     # CHECK:               scf.for
-    # CHECK-COUNT-2:           vector.maskedload
+    # CHECK-COUNT-2:           vector.load
     # CHECK-COUNT-1:           arith.maximumf
     # CHECK-COUNT-1:           arith.subf
     # CHECK-COUNT-1:           math.exp2

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -95,7 +95,7 @@ def test_paged_flash_decoding():
     # CHECK-LABEL:       func.func @phase_1
     # CHECK-COUNT-2:       memref.load
     # CHECK:               scf.for
-    # CHECK-COUNT-2:           vector.maskedload
+    # CHECK-COUNT-2:           vector.load
     # CHECK-COUNT-1:           arith.maximumf
     # CHECK-COUNT-1:           arith.subf
     # CHECK-COUNT-1:           math.exp2
@@ -238,7 +238,7 @@ def test_flash_decoding():
 
     # CHECK-LABEL:       func.func @phase_1
     # CHECK:               scf.for
-    # CHECK-COUNT-2:           vector.load
+    # CHECK-COUNT-2:           vector.maskedload
     # CHECK-COUNT-1:           arith.maximumf
     # CHECK-COUNT-1:           arith.subf
     # CHECK-COUNT-1:           math.exp2

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -165,7 +165,7 @@ def test_paged_flash_decoding_small_query_heads():
     # CHECK-LABEL:       func.func @phase_1
     # CHECK-COUNT-2:       memref.load
     # CHECK:               scf.for
-    # CHECK-COUNT-2:           vector.maskedload
+    # CHECK-COUNT-2:           vector.load
     # CHECK-COUNT-1:           arith.maximumf
     # CHECK-COUNT-1:           arith.subf
     # CHECK-COUNT-1:           math.exp2


### PR DESCRIPTION
Add ability to override mask expression for read/write op. Bounds/masking expressions are usually generated by `generate_bounds_exprs` pass, ignore the op if it has bounds expr already set. Bounds exprs have format `{A: A_BOUND, B: B_BOUND, ...}` and setting it to empty dict will make mask always true.

Paged decode second stage U iterator is always smaller than U bounds, so force the non-masked read op until we have a better analysis.