### PR TITLE
Disable broken CI runner

### DIFF
--- a/.github/workflows/ci-tk.yaml
+++ b/.github/workflows/ci-tk.yaml
@@ -112,7 +112,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [3.11]
-        os: [ubuntu-22.04, linux-mi300-1gpu-ossci-iree-org, nodai-amdgpu-mi250-x86-64]
+        # TODO: reenable mi250 runner when fixed.
+        # os: [ubuntu-22.04, linux-mi300-1gpu-ossci-iree-org, nodai-amdgpu-mi250-x86-64]
+        os: [ubuntu-22.04, linux-mi300-1gpu-ossci-iree-org]
     runs-on: ${{matrix.os}}
     timeout-minutes: 60
     needs: build_llvm_linux


### PR DESCRIPTION
This runner has been down for over 2 weeks with a system error (see https://github.com/iree-org/iree-turbine/actions/runs/16127205662/job/45506873739?pr=1012#step:2:33 for example), leading to all PRs landing in an overall "failing". This is dangerous as it creates a habit of ignoring CI failures and ultimately defies the purpose of having CI. Disabling this runner until it can be fixed.