### PR TITLE
Pytorch 2.8

### DIFF
--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,4 +1,5 @@
---index-url https://download.pytorch.org/whl/cpu
-torch>=2.5,<2.8
+--index-url https://download.pytorch.org/whl/test/cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch>=2.6,<2.9
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,5 +1,6 @@
---index-url https://download.pytorch.org/whl/rocm6.3
+--index-url https://download.pytorch.org/whl/test/rocm6.3
+--extra-index-url https://download.pytorch.org/whl/rocm6.3
 --extra-index-url https://download.pytorch.org/whl/rocm6.2
-torch>=2.5,<2.8
+torch>=2.6,<2.9
 torchaudio
 torchvision

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ wheel
 
 # It is expected that you have installed a PyTorch version/variant specific
 # to your needs, so we only include a minimum version spec.
-torch>=2.5,<2.8
+torch>=2.6,<2.9
 torchaudio
 torchvision
 


### PR DESCRIPTION
Tracking the pytorch 2.8 release planned for 7/30/2025

This PR is mostly for tracking CI status.