### PR TITLE
[Wave] Fix documentation formatting

### DIFF
--- a/docs/core/runtime.rst
+++ b/docs/core/runtime.rst
@@ -1,5 +1,5 @@
 `iree.turbine.runtime`
-=====================
+======================
 
 .. automodule:: iree.turbine.runtime
   :imported-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ IREE Turbine documentation
 Welcome to the documentation for https://github.com/iree-org/iree-turbine!
 
 API reference material
-=================
+======================
 
 .. toctree::
    :maxdepth: 1
@@ -21,15 +21,15 @@ API reference material
    kernel/*
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Wave
    :glob:
 
-   wave/*
+   wave/wave
 
 
 Project documentation
-=================
+=====================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/wave/aplp.rst
+++ b/docs/wave/aplp.rst
@@ -1,14 +1,14 @@
 .. default-role:: code
 
 All Pairs Longest Paths for Software Pipelining
-=========================================================
+===============================================
 
 This document explains the Rust library designed for All-Pairs Longest Path (APLP) computation, specifically tailored for software pipelining. The library consists of two main modules: `prune.rs` for optimizing path representations and `lib.rs` for the core APLP logic and Python FFI (Foreign Function Interface) using PyO3.
 
 The "paths" are represented as pairs `(delay, iter_diff)`, which define a line :math:`L(S) = \text{delay} - \text{iter_diff} \cdot S`, where :math:`S` is the symbolic initiation interval. The goal of pruning is to find the upper envelope of these lines.
 
 prune.rs: Path Pruning Logic
--------------------------------
+----------------------------
 
 The `prune.rs` module contains the `prune_envelope` function, which is responsible for taking a list of candidate paths (each represented as a `(delay: f32, iter_diff: f32)` tuple) for a single pair of nodes and returning a minimal list of paths that form the upper envelope. This means that for any given initiation interval `S`, one of the paths in the pruned list will provide the maximum (longest) path value.
 
@@ -31,7 +31,8 @@ The function implements a variation of Andrew's monotone chain algorithm, which 
 
     * `slope (m) = -iter_diff`
     * `intercept (c) = delay`
-    So, the line equation becomes :math:`L(S) = c + m \cdot S`.
+
+      So, the line equation becomes :math:`L(S) = c + m \cdot S`.
 5.  **Filter Unique Slopes:** For lines with the same slope, only the one with the highest intercept is kept, as it will always be above or equal to others with the same slope. The lines are then sorted by slope `m` in ascending order.
 6.  **Build Upper Envelope (Monotone Chain Scan):** This is the core adaptation of Andrew's algorithm.
 
@@ -132,16 +133,21 @@ This function implements the Floyd-Warshall algorithm to compute APLP.
 2.  **Floyd-Warshall Iteration:**
     * The algorithm iterates `k_idx` from `0` to `node_count - 1` (representing the intermediate node).
     * **Parallelization (Rayon):** For each `k_idx`, the computation of rows `i_idx` is parallelized using `rayon::into_par_iter()`.
-        * An `Arc` (Atomically Reference Counted pointer) is used to safely share the `d_current_vec_vec` matrix (from the previous `k` iteration) among worker threads.
-        * Each worker thread processes one or more rows `i_idx`.
+
+    * An `Arc` (Atomically Reference Counted pointer) is used to safely share the `d_current_vec_vec` matrix (from the previous `k` iteration) among worker threads.
+    * Each worker thread processes one or more rows `i_idx`.
+
     * **Inner Loops (Worker Thread):** For each pair of nodes `(i_idx, j_idx)`:
         * It considers paths from `i_idx` to `k_idx` and from `k_idx` to `j_idx`.
         * If such sub-paths exist, they are combined:
+
             `new_delay = d_ik + d_kj`
             `new_iter_diff = id_ik + id_kj`
+
         * These newly formed paths are added to the existing list of paths for `(i_idx, j_idx)`.
         * The combined list is then pruned using `prune::prune_envelope`.
         * The result is stored in a `d_next_rows` structure.
+
     * After all rows `i_idx` are processed for the current `k_idx`, `d_current_arc` is updated to point to the newly computed matrix (from `d_next_rows`).
 3.  **Result:** After all `k_idx` iterations, the final `d_current_arc` contains the APLP results.
 
@@ -166,39 +172,39 @@ The `#[pymodule]` macro defines the Python module. The `perform_aplp_pyo3` funct
 
     graph TD
         subgraph PythonSide [Python Caller]
-            PyInput["Input: node_count, list_of_edge_tuples"]
+        PyInput["Input: node_count, list_of_edge_tuples"]
         end
 
         subgraph RustFFI [Rust: perform_aplp_pyo3]
-            direction LR
-            ConvertPyInput["Convert Python list of edge tuples to Vec<PyRawEdge>"]
-            CallInternal["Call compute_aplp_internal(node_count, rust_edges)"]
-            ConvertRustOutput["Convert Rust D_matrix to Python Dict"]
+        direction LR
+        ConvertPyInput["Convert Python list of edge tuples to Vec<PyRawEdge>"]
+        CallInternal["Call compute_aplp_internal(node_count, rust_edges)"]
+        ConvertRustOutput["Convert Rust D_matrix to Python Dict"]
         end
 
         subgraph RustInternalCompute [Rust: compute_aplp_internal]
+        direction TB
+        InitD["Initialize D matrix: D[i][i] = [(0,0)], direct edges + prune"]
+        LoopK["Loop k from 0 to V-1 (Intermediate Node)"]
+        subgraph ParallelForRowI [For each k: Parallelize 'i' Loop]
             direction TB
-            InitD["Initialize D matrix: D[i][i] = [(0,0)], direct edges + prune"]
-            LoopK["Loop k from 0 to V-1 (Intermediate Node)"]
-            subgraph ParallelForRowI [For each k: Parallelize 'i' Loop]
+            MapI["map_with(d_current_arc, i_idx)"]
+            subgraph WorkerForRowI ["Worker for row 'i'"]
                 direction TB
-                MapI["map_with(d_current_arc, i_idx)"]
-                subgraph WorkerForRowI ["Worker for row 'i'"]
-                    direction TB
-                    LoopJ["Loop j from 0 to V-1 (Destination Node)"]
-                    CombinePaths["Combine D[i][k] + D[k][j]"]
-                    AddToExisting["Add to existing D[i][j] paths"]
-                    Prune["Call prune_envelope()"]
-                    StoreResult["Store pruned D_next[i][j]"]
-                end
-                MapI --> WorkerForRowI
+                LoopJ["Loop j from 0 to V-1 (Destination Node)"]
+                CombinePaths["Combine D[i][k] + D[k][j]"]
+                AddToExisting["Add to existing D[i][j] paths"]
+                Prune["Call prune_envelope()"]
+                StoreResult["Store pruned D_next[i][j]"]
             end
-            InitD --> LoopK
-            LoopK --> ParallelForRowI
-            ParallelForRowI --> CollectResults["Collect results into D_next matrix"]
-            CollectResults --> UpdateD["Update D_current = D_next"]
-            UpdateD --> LoopK
-            LoopK -- After all k --> FinalDMatrix["Final D_matrix"]
+            MapI --> WorkerForRowI
+        end
+        InitD --> LoopK
+        LoopK --> ParallelForRowI
+        ParallelForRowI --> CollectResults["Collect results into D_next matrix"]
+        CollectResults --> UpdateD["Update D_current = D_next"]
+        UpdateD --> LoopK
+        LoopK -- After all k --> FinalDMatrix["Final D_matrix"]
         end
 
         subgraph FinalDMatrix

--- a/docs/wave/fused_softmax.rst
+++ b/docs/wave/fused_softmax.rst
@@ -4,7 +4,7 @@ Fused Softmax Tutorial
 This tutorial demonstrates how to implement Fused Softmax using Wave.
 
 Softmax Function
-----------------
+-----------------
 
 The softmax function is defined as:
 
@@ -20,7 +20,7 @@ Note:
 **Rows = samples**, **Columns = classes**
 
 Fused Softmax
--------------
+--------------
 
 A *fused* softmax implementation combines the exponentiation, summation, and normalization into a single kernel. This avoids intermediate memory reads/writes, reducing latency and improving performance.
 
@@ -30,17 +30,17 @@ The function:
 
    test_fused_softmax(...)
 
-is defined in `wave_e2e_test.py`. It loads the softmax kernel with the correct constraints and compares the result with PyTorch’s built-in `softmax` function. Input shapes are defined in `test_param.json`.
+is defined in `wave_e2e_test.py`. It loads the softmax kernel with the correct constraints and compares the result with PyTorch's built-in `softmax` function. Input shapes are defined in `test_param.json`.
 
 Key GPU Programming Terms in Wave
----------------------------------
+-----------------------------------
 
 - **Thread**: Smallest unit of execution in GPU.
 - **Wave**: A group of threads (typically 32 or 64) that processes a tile. Equivalent to a CUDA warp.
 - **Workgroup**: A group of waves. The grid is divided into workgroups, each of which may include one or more waves.
 
 Constraint Creation
--------------------
+--------------------
 
 .. code-block:: python
 

--- a/docs/wave/gemm_tutorial.rst
+++ b/docs/wave/gemm_tutorial.rst
@@ -1,5 +1,5 @@
 GEMM Tutorial
-============
+=============
 
 This tutorial demonstrates how to implement a high-performance matrix multiplication (GEMM) kernel using Wave. We'll walk through the implementation step by step, explaining the key concepts and optimizations.
 
@@ -15,7 +15,7 @@ The GEMM kernel we'll implement computes C = A @ B.T, where:
 We'll use Wave's symbolic programming model and hardware-aware abstractions to create an efficient implementation.
 
 Implementation
--------------
+--------------
 
 First, we need to import the necessary modules and define our symbolic dimensions:
 
@@ -92,7 +92,7 @@ Now, let's define our GEMM kernel with appropriate constraints:
         tkw.write(repeat, c)
 
 Testing the Implementation
-------------------------
+--------------------------
 
 Let's create a test function to verify our GEMM implementation:
 
@@ -139,7 +139,7 @@ Let's create a test function to verify our GEMM implementation:
         print("GEMM test passed!")
 
 Key Components
--------------
+--------------
 
 1. **Memory Types and Data Types**:
 
@@ -182,7 +182,7 @@ Key Components
    - Write final result to global memory
 
 Performance Considerations
-------------------------
+--------------------------
 
 1. **Tile Size Selection**:
 

--- a/docs/wave/getting_started.rst
+++ b/docs/wave/getting_started.rst
@@ -1,10 +1,10 @@
 Getting Started with Wave
-========================
+=========================
 
 This guide will help you get up and running with Wave, a high-performance machine learning programming language designed for accelerating ML kernel development.
 
 Prerequisites
-------------
+--------------
 
 Before installing Wave, ensure you have the following prerequisites:
 
@@ -15,7 +15,7 @@ Before installing Wave, ensure you have the following prerequisites:
 5. Rust 1.70 or later
 
 Installation
------------
+-------------
 
 1. Install PyTorch with ROCm support:
 
@@ -38,7 +38,7 @@ Installation
 
 
 Next Steps
----------
+-----------
 
 - Read the :doc:`system_architecture` guide to understand Wave's compilation pipeline
 - Check out the :doc:`gemm_tutorial` for a more complex example

--- a/docs/wave/minimize_global_loads.rst
+++ b/docs/wave/minimize_global_loads.rst
@@ -1,5 +1,5 @@
 Global Load Minimization
-=======================
+========================
 
 This document explains Wave's global load minimization optimization, which is a crucial pass in the compilation pipeline that reduces memory traffic by optimizing how data is loaded from global memory.
 
@@ -128,7 +128,7 @@ The diagram above shows how the optimization transforms the computation graph:
    - Better memory access coalescing
 
 How It Works
------------
+------------
 
 The optimization process consists of several key steps:
 
@@ -183,7 +183,7 @@ The global load minimization pass will transform this kernel to:
 2. Add proper synchronization
 
 Key Transformations
------------------
+-------------------
 
 1. **Memory Access Coalescing**
 
@@ -200,7 +200,7 @@ Key Transformations
 
 
 Performance Impact
-----------------
+------------------
 
 The global load minimization optimization typically provides:
 
@@ -216,14 +216,14 @@ The global load minimization optimization typically provides:
 
 
 IR Transformation
-----------------
+-----------------
 
 The optimization transforms the IR to optimize memory access patterns. Here's a simplified view of the key changes:
 
 Before Optimization:
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: mlir
+.. code-block:: text
 
     func.func @gemm(%a: !stream.binding<memref<MxKxf16>>,
                    %b: !stream.binding<memref<NxKxf16>>,
@@ -247,9 +247,9 @@ Before Optimization:
     }
 
 After Optimization:
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: mlir
+.. code-block:: text
 
     func.func @gemm(%a: !stream.binding<memref<MxKxf16>>,
                    %b: !stream.binding<memref<NxKxf16>>,
@@ -277,7 +277,7 @@ After Optimization:
 For more details on the implementation, see the source code in `iree/turbine/kernel/wave/minimize_global_loads.py`.
 
 Related Optimizations
--------------------
+---------------------
 
 The global load minimization pass works in conjunction with other Wave optimizations:
 

--- a/docs/wave/pingpong_reordering.rst
+++ b/docs/wave/pingpong_reordering.rst
@@ -1,5 +1,5 @@
 Schedule Reordering Module
-=========================
+==========================
 
 This module implements a ping-pong scheduling algorithm for optimizing wave-level parallelism in GPU kernels. The algorithm enables two waves within the same SIMD group to run in parallel by carefully orchestrating their execution phases and synchronization.
 Most of the module and algorithm described below can be found in ``iree-turbine/iree/turbine/kernel/wave/schedule_reordering.py``
@@ -35,10 +35,10 @@ The scheduling algorithm implements a ping-pong pattern where two waves alternat
    * After synchronization, both waves can proceed to the next iteration
 
 Implementation Details
----------------------
+-----------------------
 
 Operation Classification
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The algorithm classifies operations into four main categories:
 
@@ -48,7 +48,7 @@ The algorithm classifies operations into four main categories:
 * MMAs: Matrix multiplication operations
 
 Graph Reordering
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 The reordering process follows these steps:
 
@@ -72,7 +72,7 @@ The reordering process follows these steps:
    * Ensures correct execution order while enabling parallel wave execution
 
 Scheduling Strategy
------------------
+-------------------
 
 The module supports different scheduling strategies:
 
@@ -86,7 +86,7 @@ The strategy selection is based on:
 * Wave count requirements
 
 Key Functions
-------------
+-------------
 
 .. function:: schedule_reordering(trace, constraints, scheduling_type)
 
@@ -109,7 +109,7 @@ Key Functions
    maintaining correct execution order.
 
 Hardware Requirements
--------------------
+---------------------
 
 The algorithm requires specific hardware characteristics:
 
@@ -120,7 +120,7 @@ The algorithm requires specific hardware characteristics:
 The current implementation specifically targets configurations with 8 waves per block.
 
 Example Configuration
--------------------
+---------------------
 
 The default configuration for two-cluster ping-pong scheduling:
 

--- a/docs/wave/schedule.rst
+++ b/docs/wave/schedule.rst
@@ -1,10 +1,10 @@
 Schedule File Format
-==================
+====================
 
 The schedule file format is used to store and load scheduling information for wave kernels. It provides a human-readable representation of the schedule, including metadata, resource usage, and operation timing.
 
 File Structure
--------------
+--------------
 
 The schedule file consists of three main sections:
 
@@ -13,7 +13,7 @@ The schedule file consists of three main sections:
 3. Schedule Table (required)
 
 Metadata Section
---------------
+----------------
 
 The metadata section appears at the top of the file and contains two required pieces of information:
 
@@ -27,7 +27,7 @@ Where:
 - ``<num_stages>`` is the number of pipeline stages
 
 Resource Reservation Table (RRT)
------------------------------
+--------------------------------
 
 The RRT section is optional and provides information about resource usage across the initiation interval. It is formatted as a table with the following structure:
 
@@ -47,7 +47,7 @@ The RRT section is optional and provides information about resource usage across
 The RRT shows how many resources of each type are used in each cycle of the initiation interval. This helps in understanding resource utilization and potential bottlenecks.
 
 Schedule Table
--------------
+--------------
 
 The schedule table provides detailed information about each operation in the schedule. It is formatted as a pipe-delimited table with the following columns:
 
@@ -122,7 +122,7 @@ In this example:
 - Each operation's dependencies are listed in the User Sort Keys column
 
 Using Schedule Files
-------------------
+--------------------
 
 Schedule files can be used in two ways:
 

--- a/docs/wave/schedule_modifier.rst
+++ b/docs/wave/schedule_modifier.rst
@@ -1,10 +1,10 @@
 Schedule Validator
-================
+==================
 
 The ScheduleValidator is a component that validates and optimizes operation schedules while maintaining resource and dependency constraints. It ensures that operations are scheduled in a way that respects both hardware resource limitations and data dependencies between operations.
 
 Key Features
------------
+------------
 
 - Validates and repairs schedules to maintain resource constraints
 - Handles both forward and backward schedule repairs using a directional constraint enforcement strategy
@@ -13,7 +13,7 @@ Key Features
 - Maintains dependency relationships between operations
 
 Components
----------
+----------
 
 1. ResourceUsageTracker
 
@@ -38,12 +38,12 @@ Components
    - Avoids unnecessary cascading repairs by processing nodes in order
 
 Directional Constraint Enforcement
---------------------------------
+----------------------------------
 
 The repair algorithm uses a directional strategy to efficiently maintain schedule validity:
 
 Forward Repair
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 When moving nodes forward in time:
 
@@ -57,7 +57,7 @@ When moving nodes forward in time:
   * Note: Moving a node forward can violate successor constraints, but we handle this by processing nodes in order
 
 Backward Repair
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 When moving nodes backward in time:
 
@@ -78,7 +78,7 @@ specific order (forward or backward) and handle any constraint violations when w
 reach the affected nodes in that order.
 
 Worked Example
--------------
+--------------
 
 Let's walk through an example using a simple graph with 4 operations (a, b, c, d) and 2 resource types:
 
@@ -106,7 +106,7 @@ Let's walk through an example using a simple graph with 4 operations (a, b, c, d
     ]
 
 Initial Schedule
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 The initial schedule places operations with some spacing to allow for moves:
 
@@ -120,7 +120,7 @@ The initial schedule places operations with some spacing to allow for moves:
     }
 
 Creating the Validator
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 We create a ScheduleValidator with:
 
@@ -141,7 +141,7 @@ We create a ScheduleValidator with:
     )
 
 Attempting a Move
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Let's try to move operation 'c' to cycle 2, which would require backward repair:
 

--- a/docs/wave/shared_memory.rst
+++ b/docs/wave/shared_memory.rst
@@ -8,7 +8,7 @@ The goal is to assign a starting memory offset to each allocation such that the 
 The heuristic provides a fast, approximate solution to this problem. It does not guarantee optimality but often performs well in practice.
 
 The Allocation Data
-------------------
+--------------------
 
 We will use the following set of allocations for this explanation:
 
@@ -73,7 +73,7 @@ The heuristic proceeds as follows:
 5.  **Repeat:** Steps 2-4 are repeated for all allocations in the sorted order.
 
 Tracing the Heuristic for the Example Data
-----------------------------------------
+-------------------------------------------
 
 Let's trace the steps for our ``allocations_data``:
 

--- a/docs/wave/system_architecture.rst
+++ b/docs/wave/system_architecture.rst
@@ -1,10 +1,10 @@
 Wave System Architecture
-=======================
+========================
 
 This document provides a detailed explanation of Wave's compilation pipeline and optimization passes.
 
 Architecture Overview
--------------------
+----------------------
 
 Wave provides a layered architecture that bridges high-level Python code with low-level GPU execution:
 

--- a/docs/wave/wave.rst
+++ b/docs/wave/wave.rst
@@ -1,8 +1,8 @@
 Wave: High-Performance Machine Learning Programming Language
-=======================================
+=============================================================================
 
 Motivation
----------
+-----------
 
 Wave is a high-level programming language designed to accelerate the development and optimization of machine learning kernels. it aims to dramatically improve kernel author velocity in two critical dimensions:
 
@@ -20,7 +20,7 @@ Wave is particularly focused on the machine learning domain, with deep integrati
 The language bridges the gap between high-level ML programming and low-level GPU performance by providing a flexible and expressive programming model that maintains close control over hardware resources while enabling rapid innovation in the ML space.
 
 Core Design Principles
---------------------
+-----------------------
 
 Wave is built around several key design principles that guide its architecture and implementation:
 
@@ -59,8 +59,14 @@ For more detailed information about Wave's architecture and optimization passes,
    :maxdepth: 2
    :caption: Contents:
 
+   getting_started
    system_architecture
    shared_memory
    runtime
    gemm_tutorial
    minimize_global_loads
+   pingpong_reordering
+   schedule
+   schedule_modifier
+   fused_softmax
+   aplp


### PR DESCRIPTION
This PR moves all the wave docs under the top level wave.rst file. It also fixes compile time warnings.