### PR TITLE
[Wave] Remove `mha` param from paged decode attention

### DIFF
--- a/iree/turbine/kernel/wave/templates/paged_decode_attention.py
+++ b/iree/turbine/kernel/wave/templates/paged_decode_attention.py
@@ -56,6 +56,12 @@ def get_paged_decode_attention_kernels(
     layer_scaling: Optional[float] = None,
     logit_cap: float = 0.0,
 ):
+    """
+    Supports multi-head attention (MHA), multi-query attention (MQA), and
+    grouped-query attention (GQA) depending on the number of query heads
+    compared to the number of key-value heads.
+    """
+
     multi_head_attention = shape.num_query_heads == shape.num_kv_heads
 
     wave_input_dtype = torch_dtype_to_wave(input_dtype)

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -447,7 +447,6 @@ def testPagedFlashDecodingMHA(
         num_kv_splits,
         input_dtype=dtype,
         output_dtype=dtype,
-        mha=True,
     )
     hyperparams_0.update(get_default_scheduling_params())
     hyperparams_1.update(get_default_scheduling_params())


### PR DESCRIPTION
Can be derived from `shape.num_query_heads == shape.num_kv_heads`, no need for user to specify.