### PR TITLE
[Wave] Enable async kernel execution with iree runtime and fully switch to `Launchable`

### DIFF
--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -199,6 +199,9 @@ def isolated_test_call(
                     [b.as_mlir_type() for b in sig.kernel_buffer_output_bindings]
                 )
                 barrier = hal_d.tensor_barrier(out_types, out, signal_fence=out_fence)
+                if len(out_types) == 1:
+                    barrier = [barrier]
+
                 view_type = IrType.parse("!hal.buffer_view")
                 for i, b in enumerate(sig.kernel_buffer_output_bindings):
                     shape = b.kernel_buffer_type.symbolic_shape

--- a/iree/turbine/kernel/compiler/host_codegen.py
+++ b/iree/turbine/kernel/compiler/host_codegen.py
@@ -164,7 +164,7 @@ def isolated_test_call(
                     arguments[i] = hal_d.tensor_import(
                         arg_type,
                         arg,
-                        wait_fence=None,
+                        wait_fence=in_fence,
                         target_encoding=arg_type,
                         target_dims=target_dims,
                     )

--- a/iree/turbine/kernel/compiler/ir.py
+++ b/iree/turbine/kernel/compiler/ir.py
@@ -46,6 +46,7 @@ from iree.compiler.dialects import (
     flow as flow_d,
     func as func_d,
     gpu as gpu_d,
+    hal as hal_d,
     iree_codegen as iree_codegen_d,
     llvm as llvm_d,
     math as math_d,

--- a/iree/turbine/kernel/compiler/ir.py
+++ b/iree/turbine/kernel/compiler/ir.py
@@ -54,6 +54,7 @@ from iree.compiler.dialects import (
     rocdl as rocdl_d,
     scf as scf_d,
     stream as stream_d,
+    tensor as tensor_d,
     transform as transform_d,
     vector as vector_d,
 )

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -59,7 +59,7 @@ class WaveKernel:
 
             self.launchable = Launchable.from_vm_module(
                 loader,
-                entry_point=options.func_name,
+                entry_point=options.func_name + "$async",
             )
 
     def __call__(self, *args, **kwargs):

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -2,6 +2,7 @@ from typing import Any, Optional, Callable
 
 import torch
 import glob
+from itertools import chain
 from copy import copy
 from .._support.indexing import IndexingContext
 from .._support.location_config import LocationCaptureLevel
@@ -111,9 +112,8 @@ class WaveKernel:
                 self.gpu_func,
             )
         else:
-            self.launchable(
-                *kernel_inputs, *kernel_outputs, *scalar_args, *dynamic_symbols
-            )
+            tensors = [t.data for t in chain(kernel_inputs, kernel_outputs)]
+            self.launchable(*tensors, *scalar_args, *dynamic_symbols)
 
             if self.options.run_bench:
                 benchmark_flags = {}
@@ -125,8 +125,8 @@ class WaveKernel:
                     )
                 benchmark_results = benchmark_module(
                     self.options,
-                    kernel_inputs,
-                    kernel_outputs,
+                    [t.data for t in kernel_inputs],
+                    [t.data for t in kernel_outputs],
                     dynamic_symbols,
                     self.executable,
                     self.func_name,

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -189,6 +189,7 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
         options.func_name,
         options.dynamic_symbols,
         location_capture_config=options.location_capture_config,
+        async_dispatch=True,
     )
     asm = mb.module_op.get_asm(
         enable_debug_info=options.location_capture_config.level

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -141,17 +141,24 @@ class WaveKernel:
 
     def invoke_with_profile(self, *args, **kwargs):
         import cProfile
+        import timeit
 
         # Warmup
         for _ in range(self.options.profile_python_warmup):
             self.invoke(*args, **kwargs)
 
-        with cProfile.Profile() as pr:
-            for _ in range(self.options.profile_python_repetitions):
-                res = self.invoke(*args, **kwargs)
+        # with cProfile.Profile() as pr:
+        #     for _ in range(self.options.profile_python_repetitions):
+        #         res = self.invoke(*args, **kwargs)
 
-        pr.print_stats(sort="cumulative")
-        return res
+        # pr.print_stats(sort="cumulative")
+        repetitions = self.options.profile_python_repetitions
+        time = timeit.timeit(
+            lambda: self.invoke(*args, **kwargs),
+            number=repetitions,
+        )
+        print(f"Time: {time:.3f}s, {time / repetitions:.6f}s per iteration")
+        return self.invoke(*args, **kwargs)
 
 
 def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveKernel:

--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -43,6 +43,9 @@ class WaveCompileOptions:
     capture_trace: bool = False
     bench_with_constant_weights: bool = False
     bench_file: str = None
+    profile_python_wrapper: bool = False
+    profile_python_warmup: int = 1
+    profile_python_repetitions: int = 1000
 
     # === Cache options ===
     kernel_hash: str = None

--- a/iree/turbine/kernel/wave/compile_options.py
+++ b/iree/turbine/kernel/wave/compile_options.py
@@ -44,6 +44,7 @@ class WaveCompileOptions:
     bench_with_constant_weights: bool = False
     bench_file: str = None
     profile_python_wrapper: bool = False
+    profile_python_cprofile: bool = True  # If False, use timeit.timeit()
     profile_python_warmup: int = 1
     profile_python_repetitions: int = 1000
 
@@ -66,7 +67,8 @@ class WaveCompileOptions:
     optimization_level: bool = True
     denorm_fp_math_f32: str = None
     waves_per_eu: int = None
-    wave_runtime: str = None
+    wave_runtime: bool = False
+    iree_launch_async: bool = True
     use_buffer_load_ops: bool = False
     use_buffer_store_ops: bool = False
     use_stride_cache_swizzle: bool = False

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -3,20 +3,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from dataclasses import dataclass
 import torch
 import functools
-import iree.runtime as rt
-from typing import Callable, Optional, Any
-import ctypes
+from typing import Callable, Any
 from ..compile_options import WaveCompileOptions
-from ..profiling import benchmark_module
 from itertools import chain
-from warnings import warn
 from iree.turbine.kernel.lang import IndexSymbol
-
-# Cache for the system context and vm function.
-RUNTIME_CACHE: dict[str, tuple[rt.SystemContext, rt.VmFunction]] = {}
 
 
 @functools.lru_cache
@@ -24,159 +16,19 @@ def compute_grid(kernel_dynamic_dims: tuple[int], grid_fn: Callable):
     return [int(x) for x in grid_fn(list(kernel_dynamic_dims))]
 
 
-def _write_file(name, mode, data):
+def write_file(name, mode, data):
     with open(name, mode) as file:
         file.write(data)
 
 
-@functools.lru_cache
-def get_device_uuid(device_list: list[str], device_str: str) -> tuple[int, str]:
-    """
-    Checks all torch.Tensor are on the same device, and get UUID from Torch device.
-    """
-    if len(set(device_list)) != 1:
-        raise ValueError(f"Found multiple device on input tensors:{set(device_list)}")
-    device = device_list[0]
-    if device.type != "cuda":
-        raise ValueError("Expected all argument tensors to be in GPU.")
-    uuid = str(torch.cuda.get_device_properties(device).uuid)
-    device_str = f"{device_str}://GPU-{uuid}"
-    return device_str
-
-
-def _inplace_invoke(
-    vm_context, device, entry_function, inputs, outputs, scalar_args, dynamic_dims
-):
-    linearized_arg_len = (
-        len(inputs) + len(outputs) + len(scalar_args) + len(dynamic_dims)
-    )
-    # ret_list is 0 because we modify/write result in place.
-    arg_list = rt.VmVariantList(linearized_arg_len)
-    ret_list = rt.VmVariantList(0)
-
-    def push_tensor_to_arg_list(arg_tensor: torch.Tensor):
-        if not arg_tensor.is_contiguous():
-            arg_tensor = arg_tensor.contiguous()
-        capsule = torch.to_dlpack(arg_tensor)
-        arg_tensor_bv = device.from_dlpack_capsule(capsule)
-        arg_list.push_ref(arg_tensor_bv)
-
-    # Linearize arguments, In linearized arg_list, we first push in all inputs,
-    # then all the outputs, and lastly all the dynamic dims.
-    for input in chain(inputs, outputs, scalar_args, dynamic_dims):
-        if isinstance(input, torch.Tensor):
-            push_tensor_to_arg_list(input)
-        elif isinstance(input, int):
-            arg_list.push_int(input)
-        elif isinstance(input, float):
-            warn("Currently, `push_float` is not working on the iree side")
-            arg_list.push_float(input)
-        else:
-            raise ValueError(f"Unsupported input type: {type(input)}")
-
-    try:
-        vm_context.invoke(entry_function, arg_list, ret_list)
-    except ValueError as e:
-        raise RuntimeError(
-            f"Error invoking IREE\n{entry_function}\n"
-            f"{arg_list=}\n"
-            f"inputs: {', '.join([str(i.shape) for i in inputs])}\n"
-            f"outputs: {', '.join([str(o.shape) for o in outputs])}"
-        ) from e
-
-
-def _print_bench_result(result, filename):
+def print_bench_result(result, filename):
     import json
 
     res = json.dumps(result, sort_keys=True, indent=4)
     if filename is not None:
-        _write_file(filename, "w", res)
+        write_file(filename, "w", res)
     else:
         print(res)
-
-
-def invoke_vmfb(
-    vmfb: bytes,
-    options: WaveCompileOptions,
-    kernel_inputs: list[torch.Tensor],
-    kernel_outputs: list[torch.Tensor],
-    scalar_args: list[int | float] = [],
-    bound_scalar_symbols: dict[IndexSymbol, int] = {},
-    dynamic_symbols: list[int] = [],
-    gpu_func: Optional[Any] = None,
-):
-    if options.wave_runtime:
-        invoke_with_wave_runtime(
-            options,
-            kernel_inputs,
-            kernel_outputs,
-            scalar_args,
-            bound_scalar_symbols,
-            dynamic_symbols,
-            gpu_func,
-        )
-        return
-
-    device = options.device
-    if options.run_bench:
-        benchmark_flags = {}
-        # If we use 1000 for bench_batch_size during compilation, and set this batch size to 1,
-        # then the latency is in milliseconds.
-        benchmark_flags["batch_size"] = 1
-
-        if options.benchmark_repetitions is not None:
-            benchmark_flags["benchmark_repetitions"] = int(
-                options.benchmark_repetitions
-            )
-
-    # Select device as the GPU, where input tensors are coming from.
-    device_list = tuple(
-        input.device
-        for input in kernel_inputs + kernel_outputs
-        if isinstance(input, torch.Tensor)
-    )
-    device = get_device_uuid(device_list, device)
-
-    rt_config = rt.Config(device)
-    device = rt_config.device
-    vm_instance = rt_config.vm_instance
-
-    if options.kernel_hash and options.kernel_hash in RUNTIME_CACHE:
-        ctx, func = RUNTIME_CACHE[options.kernel_hash]
-    else:
-        mod = rt.VmModule.copy_buffer(vm_instance, vmfb)
-        vm_modules = [
-            mod,
-            rt.create_hal_module(vm_instance, device),
-        ]
-        ctx = rt.SystemContext(
-            vm_modules=vm_modules,
-            config=rt_config,
-        )
-        func = mod.lookup_function(options.func_name)
-        if options.kernel_hash:
-            RUNTIME_CACHE[options.kernel_hash] = (ctx, func)
-
-    _inplace_invoke(
-        ctx.vm_context,
-        device,
-        func,
-        kernel_inputs,
-        kernel_outputs,
-        scalar_args,
-        dynamic_symbols,
-    )
-
-    if options.run_bench:
-        benchmark_results = benchmark_module(
-            options,
-            kernel_inputs,
-            kernel_outputs,
-            vmfb,
-            options.func_name,
-            **benchmark_flags,
-        )
-        _print_bench_result(benchmark_results, options.bench_file)
 
 
 def invoke_with_wave_runtime(

--- a/iree/turbine/kernel/wave/utils/run_utils.py
+++ b/iree/turbine/kernel/wave/utils/run_utils.py
@@ -93,6 +93,5 @@ def get_default_arch() -> str:
 def set_default_run_config(options: WaveCompileOptions) -> WaveCompileOptions:
     """Return default config for running."""
     options.backend = "rocm"
-    options.device = "hip"
     options.target = get_default_arch()
     return options

--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -537,6 +537,7 @@ def _device_import_torch_tensor_cuda_hip(
     # The None passed to tensor.__dlpack__ indicates we are doing no stream synchronization here.
     # We launch kernels through IREE runtime on the same stream as pytorch. If using multiple
     # streams, the user is expected to properly manage stream synchronization.
+    # `__dlpack__` will fail on tensor with gradients, so detach.
     capsule = t.detach().__dlpack__(None)
     bv = device.hal_device.from_dlpack_capsule(capsule)
     return bv

--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -537,8 +537,7 @@ def _device_import_torch_tensor_cuda_hip(
     # The None passed to tensor.__dlpack__ indicates we are doing no stream synchronization here.
     # We launch kernels through IREE runtime on the same stream as pytorch. If using multiple
     # streams, the user is expected to properly manage stream synchronization.
-    # `__dlpack__` will fail on tensor with gradients, so detach.
-    capsule = t.detach().__dlpack__(None)
+    capsule = t.__dlpack__(None)
     bv = device.hal_device.from_dlpack_capsule(capsule)
     return bv
 

--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -537,7 +537,7 @@ def _device_import_torch_tensor_cuda_hip(
     # The None passed to tensor.__dlpack__ indicates we are doing no stream synchronization here.
     # We launch kernels through IREE runtime on the same stream as pytorch. If using multiple
     # streams, the user is expected to properly manage stream synchronization.
-    capsule = t.__dlpack__(None)
+    capsule = t.detach().__dlpack__(None)
     bv = device.hal_device.from_dlpack_capsule(capsule)
     return bv
 

--- a/lit_tests/kernel/wave/codegen.py
+++ b/lit_tests/kernel/wave/codegen.py
@@ -2179,7 +2179,7 @@ def test_scalar_codegen_f32():
 
     # Final dispatch args dtype
     # CHECK: flow.dispatch @scalar_codegen_f32::@scalar_codegen_f32(
-    # CHECK-SAME: %arg0, %arg1, %arg2, %arg3)
+    # CHECK-SAME: %{{.*}}, %{{.*}}, %arg2, %arg3)
 
 
 @run_test
@@ -2232,7 +2232,7 @@ def test_scalar_codegen_i32():
 
     # Final dispatch args dtype
     # CHECK: flow.dispatch @scalar_codegen_i32::@scalar_codegen_i32(
-    # CHECK-SAME: %arg0, %arg1, %arg2, %arg3)
+    # CHECK-SAME: %{{.*}}, %{{.*}}, %arg2, %arg3)
 
 
 #  This kernel copies of data from a into b if tid.x < threshold.

--- a/lit_tests/kernel/wave/location.py
+++ b/lit_tests/kernel/wave/location.py
@@ -73,7 +73,7 @@ def test_location_local_scope():
     # CHECK: vector.load {{.*}} loc("{{.*}}location.py":{{[0-9]+}}
     # CHECK: arith.addf {{.*}} loc("{{.*}}location.py":{{[0-9]+}}
     #
-    # CHECK: @isolated_benchmark(%{{.*}} loc("a"("{{.*}}location.py":{{[0-9]+}}{{.*}} loc("b"("{{.*}}location.py":{{[0-9]+}}
+    # CHECK: @isolated_benchmark$async(%{{.*}} loc("a"("{{.*}}location.py":{{[0-9]+}}{{.*}} loc("b"("{{.*}}location.py":{{[0-9]+}}
 
 
 @run_test
@@ -100,7 +100,7 @@ def test_location_global_scope():
     # CHECK-LABEL: @add_loc_global_scope
     # CHECK: vector.load {{.*}} loc(#[[loc_load:.+]])
     # CHECK: arith.addf {{.*}} loc(#[[loc_addf:.+]])
-    # CHECK: @isolated_benchmark(%{{.*}} loc("a"(#[[loc_arg]])), %{{.*}} loc("b"(#[[loc_arg]])))
+    # CHECK: @isolated_benchmark$async(%{{.*}} loc("a"(#[[loc_arg]])), %{{.*}} loc("b"(#[[loc_arg]])), %{{.*}} loc(unknown), %{{.*}} loc(unknown))
     # CHECK-DAG: #[[loc_load]] = loc("{{.*}}location.py":{{[0-9]+}}
     # CHECK-DAG: #[[loc_addf]] = loc("{{.*}}location.py":{{[0-9]+}}
 

--- a/lit_tests/kernel/wave/sharktank_integration.py
+++ b/lit_tests/kernel/wave/sharktank_integration.py
@@ -170,6 +170,7 @@ class WaveBhsdFlashAttentionSharktankOp(CustomOp):
             func_name=wave_kernel_name,
             compile_to_mlir=True,
             canonicalize=False,
+            iree_launch_async=False,
         )
         options = set_default_run_config(options)
         with Context() as ctx:


### PR DESCRIPTION
Drop our `invoke_vmfb` code entirely, use `turbine.runtime.Lauchable` and udate dispatch codegen to support async launch.

Before:
```
  func.func @isolated_benchmark(%arg0: tensor<8x?x128x6xf32>, %arg1: tensor<8x?x6xf32>, %arg2: tensor<?xi32>, %arg3: tensor<?x6x128xf16>, %arg4: index) -> tensor<?x6x128xf16> {
    %0 = flow.dispatch @phase_1::@phase_1[%arg4](%arg0, %arg1, %arg2, %arg3, %arg4) : (tensor<8x?x128x6xf32>{%arg4}, tensor<8x?x6xf32>{%arg4}, tensor<?xi32>{%arg4}, tensor<?x6x128xf16>{%arg4}, index) -> %arg3{%arg4}
    return %0 : tensor<?x6x128xf16>
  }
```
After:
```
  func.func @isolated_benchmark$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.buffer_view, %arg4: index, %arg5: !hal.fence, %arg6: !hal.fence) -> !hal.buffer_view {
    %0 = hal.tensor.import wait(%arg5) => %arg0 : !hal.buffer_view -> tensor<8x?x128x6xf32>{%arg4}
    %1 = hal.tensor.import wait(%arg5) => %arg1 : !hal.buffer_view -> tensor<8x?x6xf32>{%arg4}
    %2 = hal.tensor.import wait(%arg5) => %arg2 : !hal.buffer_view -> tensor<?xi32>{%arg4}
    %3 = hal.tensor.import wait(%arg5) => %arg3 : !hal.buffer_view -> tensor<?x6x128xf16>{%arg4}
    %4 = flow.dispatch @phase_1::@phase_1[%arg4](%0, %1, %2, %3, %arg4) : (tensor<8x?x128x6xf32>{%arg4}, tensor<8x?x6xf32>{%arg4}, tensor<?xi32>{%arg4}, tensor<?x6x128xf16>{%arg4}, index) -> %3{%arg4}
    %5 = hal.tensor.barrier join(%4 : tensor<?x6x128xf16>) => %arg6 : !hal.fence
    %6 = hal.tensor.export %5 : tensor<?x6x128xf16>{%arg4} -> !hal.buffer_view
    return %6 : !hal.buffer_view
  }
```

Also, add some python profiling code to `WaveKernel` launch func.

Launch overhead for the iree runtime is still bad (around x5 of `wave_runtime`) but ability to run kernels async is overall improvement.