### PR TITLE
[boo] Integrate boo fusion as a `torch.compile` backend

### DIFF
--- a/iree/turbine/dynamo/backends/boo.py
+++ b/iree/turbine/dynamo/backends/boo.py
@@ -12,21 +12,34 @@ from iree.turbine.kernel.boo.fusion.schema import (
 
 
 def backend(
+    *,
+    nested_backend: str | CompilerFn = "eager",
     fusion_schema: FusionSchema = DEFAULT_SUPPORTED_BOO_FUSIONS,
-    backend: str | CompilerFn = "eager",
 ):
-    backend_fn = make_boxed_compiler(torch._dynamo.lookup_backend(backend))
+    """
+    A 'torch.compile' backend that selectively offloads operations to IREE.
+    Alternatively, 'torch.compile(..., backend="iree_boo")' can be used.
+
+    After offloading is performed, the graph is further optimized using
+    'nested_backend'. Any valid 'torch.compile' backend can be specified.
+
+    'fusion_schema' may be used to control which operations are fused and
+    offloaded.
+    """
+    nested_backend_fn = make_boxed_compiler(
+        torch._dynamo.lookup_backend(nested_backend)
+    )
 
     def fw_compiler(model: fx.GraphModule, example_args):
         fusion_transform(model, fusion_schema=fusion_schema)
-        return backend_fn(model, example_args)
+        return nested_backend_fn(model, example_args)
 
     return aot_autograd(
         fw_compiler=fw_compiler,
         # Skip boo compilation for the backwards pass for now.
-        bw_compiler=backend_fn,
+        bw_compiler=nested_backend_fn,
     )
 
 
 default_backend = backend()
-inductor_backend = backend(backend="inductor")
+inductor_backend = backend(nested_backend="inductor")

--- a/iree/turbine/dynamo/backends/boo.py
+++ b/iree/turbine/dynamo/backends/boo.py
@@ -1,0 +1,32 @@
+from functorch.compile import make_boxed_compiler
+import torch
+from torch import fx
+from torch._dynamo.backends.common import aot_autograd
+from torch._dynamo.backends.registry import CompilerFn
+
+from iree.turbine.kernel.boo.fusion.apply import fusion_transform
+from iree.turbine.kernel.boo.fusion.schema import (
+    FusionSchema,
+    DEFAULT_SUPPORTED_BOO_FUSIONS,
+)
+
+
+def backend(
+    fusion_schema: FusionSchema = DEFAULT_SUPPORTED_BOO_FUSIONS,
+    backend: str | CompilerFn = "eager",
+):
+    backend_fn = make_boxed_compiler(torch._dynamo.lookup_backend(backend))
+
+    def fw_compiler(model: fx.GraphModule, example_args):
+        fusion_transform(model, fusion_schema=fusion_schema)
+        return backend_fn(model, example_args)
+
+    return aot_autograd(
+        fw_compiler=fw_compiler,
+        # Skip boo compilation for the backwards pass for now.
+        bw_compiler=backend_fn,
+    )
+
+
+default_backend = backend()
+inductor_backend = backend(backend="inductor")

--- a/iree/turbine/kernel/boo/fusion/apply.py
+++ b/iree/turbine/kernel/boo/fusion/apply.py
@@ -4,14 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import torch
-from torch.fx.graph_module import GraphModule
-from .schema import FusionSchema, DEFAULT_SUPPORTED_BOO_FUSIONS
+from collections.abc import Sequence
+
+from torch import fx
+
+from iree.turbine.kernel.boo.ops.graph import get_custom_graph_op
+from .schema import FusionSchema
 from .subgraph import (
+    FusedSubgraph,
     extract_fusion_subgraph_modules,
-    replace_subgraphs,
-    get_subgraph_replacement,
-    _log_graph_module,
 )
 from ....support.logging import aot_logger as logger
 
@@ -20,54 +21,48 @@ __all__ = [
 ]
 
 
-def fusion_transform(
-    module: torch.nn.Module,
-    args: tuple[torch.Tensor, ...],
-    *,
-    fusion_schema: FusionSchema = DEFAULT_SUPPORTED_BOO_FUSIONS,
-) -> torch.nn.Module:
-    """Applies fusions to the underlying fx graph for module by offloading subgraphs to IREE compiler/runtime.
+def fusion_transform(module: fx.GraphModule, *, fusion_schema: FusionSchema) -> None:
+    """Applies fusions to the underlying fx graph of a GraphModule by offloading subgraphs to IREE compiler/runtime."""
 
-    This function expects the model to contain exclusively tensor arguments and no keyword arguments.
+    logger.debug("Source Graph Module:\n%s", str(module))
 
-    This currently uses dynamo to export a graph, from which we auto-generate custom boo ops to replace fusable subgraphs.
-    """
+    subgraphs = extract_fusion_subgraph_modules(module, fusion_schema)
+    subgraph_replacements: list[tuple[FusedSubgraph, fx.Node]] = []
+    for subgraph in subgraphs:
+        custom_op = get_custom_graph_op(subgraph.module, force_single_dispatch=False)
+        # Insert call as early as possible, to maintain topological order.
+        insert_pt = sorted(subgraph.arguments)[-1]
+        with module.graph.inserting_after(insert_pt):
+            call = module.graph.call_function(custom_op, tuple(subgraph.arguments))
+        # Delay replacement until we've inserted all calls, so that the
+        # references in 'subgraphs[i].arguments' are still valid.
+        subgraph_replacements.append((subgraph, call))
 
-    if not all([isinstance(a, torch.Tensor) for a in args]):
-        raise ValueError("fusion_transform expects model arguments to be tensors.")
+    for subgraph, call in subgraph_replacements:
+        _replace_with_call(module.graph, subgraph.results, call)
+        for node in reversed(sorted(subgraph.matched_nodes)):
+            module.graph.erase_node(node)
 
-    exported_program = torch.export.export(module, args=args)
+    module.recompile()
+    module.graph.lint()
 
-    return _fusion_transform(exported_program, fusion_schema=fusion_schema)
+    logger.debug("Converted module:\n%s", str(module))
 
 
-def _fusion_transform(
-    exported_program: torch.export.ExportedProgram,
-    *,
-    fusion_schema: FusionSchema = DEFAULT_SUPPORTED_BOO_FUSIONS,
-) -> torch.nn.Module:
-    """Applies fusions to the underlying fx graph of an ExportedProgram by offloading subgraphs to IREE compiler/runtime.
-
-    This function currently expects the ExportedProgram to only contain tensor arguments with static dims.
-    """
-
-    gm: GraphModule = exported_program.graph_module
-
-    _log_graph_module("Source Graph Module", gm)
-
-    subgraphs, _ = extract_fusion_subgraph_modules(gm, fusion_schema)
-    subgraph_repl = []
-    for sg in subgraphs:
-        subgraph_repl.append(get_subgraph_replacement(sg))
-
-    replace_subgraphs(gm, subgraphs, subgraph_repl)
-
-    # TODO: update any metadata which may have been modified by the replacement.
-
-    logger.debug("Converted exported program:\n%s", str(exported_program))
-
-    converted_module = exported_program.module()
-
-    logger.debug("Converted module:\n%s", str(converted_module))
-
-    return converted_module
+def _replace_with_call(
+    graph: fx.Graph,
+    nodes_to_replace: Sequence[fx.Node],
+    call: fx.Node,
+):
+    assert call.op == "call_function"
+    with graph.inserting_after(call):
+        outputs = (
+            [call]
+            if len(nodes_to_replace) == 1
+            else [
+                graph.call_method("__getitem__", args=(call, i))
+                for i in range(len(nodes_to_replace))
+            ]
+        )
+    for node_to_replace, call_output in zip(nodes_to_replace, outputs, strict=True):
+        node_to_replace.replace_all_uses_with(call_output)

--- a/iree/turbine/kernel/boo/fusion/apply.py
+++ b/iree/turbine/kernel/boo/fusion/apply.py
@@ -24,7 +24,7 @@ __all__ = [
 def fusion_transform(module: fx.GraphModule, *, fusion_schema: FusionSchema) -> None:
     """Applies fusions to the underlying fx graph of a GraphModule by offloading subgraphs to IREE compiler/runtime."""
 
-    logger.debug("Source Graph Module:\n%s", str(module))
+    _log_graph_module("Source module", module)
 
     subgraphs = extract_fusion_subgraph_modules(module, fusion_schema)
     subgraph_replacements: list[tuple[FusedSubgraph, fx.Node]] = []
@@ -46,7 +46,7 @@ def fusion_transform(module: fx.GraphModule, *, fusion_schema: FusionSchema) -> 
     module.recompile()
     module.graph.lint()
 
-    logger.debug("Converted module:\n%s", str(module))
+    _log_graph_module("Converted module", module)
 
 
 def _replace_with_call(
@@ -66,3 +66,7 @@ def _replace_with_call(
         )
     for node_to_replace, call_output in zip(nodes_to_replace, outputs, strict=True):
         node_to_replace.replace_all_uses_with(call_output)
+
+
+def _log_graph_module(label: str, gm: fx.GraphModule):
+    logger.debug("%s:\n%s", label, gm.print_readable(print_output=False))

--- a/iree/turbine/kernel/boo/ops/graph.py
+++ b/iree/turbine/kernel/boo/ops/graph.py
@@ -8,6 +8,7 @@ from hashlib import sha1
 from typing import Sequence, Callable
 
 import torch
+from torch.fx import Node
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Target
 from torch.fx.passes.shape_prop import TensorMetadata

--- a/iree/turbine/kernel/boo/ops/graph.py
+++ b/iree/turbine/kernel/boo/ops/graph.py
@@ -5,38 +5,24 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from hashlib import sha1
-from typing import Sequence, Callable
+from typing import Sequence
 
 import torch
-from torch.fx import Node
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Target
 from torch.fx.passes.shape_prop import TensorMetadata
 
-from torch._functorch.partitioners import default_partition
-from torch.autograd import Function
-
-from iree.compiler.extras.fx_importer import FxImporter
-
 from .library import *
-from .utils import is_boo_backward_enabled, get_arg_spec_name
+from .utils import get_arg_spec_name
 from ..runtime import get_launchable
-from ....dynamo.passes import turbine_cpu_pass_pipeline
-from ....transforms.general.custom_op_expansion import ExpandCustomOpsPass
 from ....support.logging import aot_logger as logger
-from ....support.ir_imports import Operation
 
 __all__ = [
-    "get_io_from_gm",
-    "get_schema",
     "get_custom_graph_op",
-    "define_custom_graph_op",
-    "get_mlir_module",
-    "get_autograd_function",
 ]
 
 
-def get_io_from_gm(
+def _get_io_from_gm(
     gm: GraphModule,
 ) -> tuple[list[Target], list[TensorMetadata | None]]:
     """Returns input nodes and output TensorMetadata from the graph module."""
@@ -56,7 +42,7 @@ def get_io_from_gm(
     return inputs, meta_outputs
 
 
-def get_schema(
+def _get_schema(
     inputs: Sequence[Target], outputs: Sequence[TensorMetadata | None]
 ) -> str:
     """Generate a schema from the result of `get_io_from_gm`."""
@@ -70,21 +56,6 @@ def get_schema(
     return schema
 
 
-def get_mlir_module(gm: GraphModule) -> Operation:
-    """Generates torch-mlir IR from a graph module."""
-    sample_args = tuple(
-        [n.meta.get("val") for n in gm.graph.nodes if n.op == "placeholder"]
-    )
-    if any([arg is None for arg in sample_args]):
-        raise ValueError("Provided gm does not have sufficient metadata.")
-    gm = turbine_cpu_pass_pipeline(gm, sample_args)
-    imp = FxImporter()
-    imp.import_graph_module(gm)
-    exp_ops = ExpandCustomOpsPass(imp.module_op)
-    exp_ops.run()
-    return imp.module_op
-
-
 def get_custom_graph_op(
     gm: GraphModule, *, force_single_dispatch: bool = False
 ) -> torch._ops.OpOverloadPacket:
@@ -94,20 +65,22 @@ def get_custom_graph_op(
     logger.debug("Got hash str '%s' for GraphModule: \n %s", hash, str(gm))
 
     if not hasattr(torch.ops.boo, op_name):
-        define_custom_graph_op(gm, op_name, force_single_dispatch=force_single_dispatch)
+        _define_custom_graph_op(
+            gm, op_name, force_single_dispatch=force_single_dispatch
+        )
 
     return get_library_op(op_name)
 
 
-def define_custom_graph_op(
+def _define_custom_graph_op(
     gm: GraphModule, op_name: str, *, force_single_dispatch: bool = False
 ):
     """Defines a custom op from the graph module with given op_name in the boo library."""
-    inputs, outputs = get_io_from_gm(gm)
+    inputs, outputs = _get_io_from_gm(gm)
     # TODO: handle this better
-    is_none_output = maybe_trim_none_outputs(gm)
+    is_none_output = _maybe_trim_none_outputs(gm)
     has_a_none_output = any(is_none_output)
-    schema = get_schema(inputs, outputs)
+    schema = _get_schema(inputs, outputs)
     define_schema(op_name, schema)
 
     @register_impl(op_name)
@@ -145,7 +118,7 @@ def define_custom_graph_op(
         return outputs
 
 
-def maybe_trim_none_outputs(gm: GraphModule) -> list[bool]:
+def _maybe_trim_none_outputs(gm: GraphModule) -> list[bool]:
     """Removes None outputs from graph. The ith return indicates whether output[i] was None."""
 
     output_nodes = [n for n in gm.graph.nodes if n.op == "output"]
@@ -167,58 +140,3 @@ def maybe_trim_none_outputs(gm: GraphModule) -> list[bool]:
     gm.graph.lint()
     gm.recompile()
     return none_output
-
-
-def get_autograd_function(
-    joint_gm: torch.fx.GraphModule,
-    sample_args: None | tuple[torch.Tensor, ...],
-    num_fwd_outputs: int,
-    *,
-    force_single_dispatch: bool = False,
-) -> Callable:
-    """From a joint forward/backward graph module, creates an autograd function for calling iree custom graph ops for forward and backward."""
-    fwd_g, bwd_g = default_partition(
-        joint_module=joint_gm,
-        _joint_inputs=sample_args,
-        num_fwd_outputs=num_fwd_outputs,
-    )
-    logger.debug(
-        "Partitioned joint graph module into:\nForward:\n%s\nBackward:\n%s",
-        str(fwd_g.print_readable(print_output=False)),
-        str(bwd_g.print_readable(print_output=False)),
-    )
-
-    fwd_launch = get_custom_graph_op(fwd_g, force_single_dispatch=force_single_dispatch)
-    # We should handle backward custom graph ops slightly differently.
-    # An option could be using the fusion schema to determine which backward ops to hand off to IREE.
-    # With the current approach, it doesn't make sense to force the backward into a single dispatch.
-    bwd_launch = (
-        get_custom_graph_op(bwd_g, force_single_dispatch=False)
-        if is_boo_backward_enabled()
-        else bwd_g.forward
-    )
-
-    class _GeneratedGraphOp(Function):
-        @staticmethod
-        def forward(ctx, *args):
-            all_outputs = fwd_launch(*args)
-            if isinstance(all_outputs, torch.Tensor):
-                all_outputs = (all_outputs,)
-            fwd_outputs = all_outputs[:num_fwd_outputs]
-            stash_outputs = all_outputs[num_fwd_outputs:]
-            ctx.save_for_backward(*stash_outputs)
-            return fwd_outputs[0] if num_fwd_outputs == 1 else fwd_outputs
-
-        @staticmethod
-        def backward(ctx, *grad_outputs):
-            stashed_tensors = ctx.saved_tensors
-            all_outputs = bwd_launch(*stashed_tensors, *grad_outputs)
-            return all_outputs
-
-    def _f(*args):
-        return _GeneratedGraphOp.apply(*args)
-
-    # Hacky function rename to make the replacement graph more descriptive.
-    _f.__name__ = f"generated_autograd_{fwd_launch._qualified_op_name}"
-
-    return _f

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,8 @@ setup(
         "torch_dynamo_backends": [
             "turbine_cpu = iree.turbine.dynamo.backends.base:backend",
             "iree_turbine = iree.turbine.dynamo.backends.base:backend",
+            "iree_boo = iree.turbine.dynamo.backends.boo:default_backend",
+            "iree_boo_inductor = iree.turbine.dynamo.backends.boo:inductor_backend",
         ],
     },
     install_requires=[

--- a/tests/kernel/boo/fusion/subgraph_fusion_test.py
+++ b/tests/kernel/boo/fusion/subgraph_fusion_test.py
@@ -90,7 +90,10 @@ class SubgraphReplacementTest(unittest.TestCase):
 
             recorder = EagerAndRecordGraphs()
             compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=fusion_schema, backend=recorder)
+                m,
+                backend=boo.backend(
+                    fusion_schema=fusion_schema, nested_backend=recorder
+                ),
             )
             assert isinstance(compiled_m, torch.nn.Module)
 
@@ -135,7 +138,7 @@ class SubgraphReplacementTest(unittest.TestCase):
             }
             recorder = EagerAndRecordGraphs()
             compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=schema, backend=recorder)
+                m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
             )
             assert isinstance(compiled_m, torch.nn.Module)
 
@@ -162,7 +165,7 @@ class SubgraphReplacementTest(unittest.TestCase):
             }
             recorder = EagerAndRecordGraphs()
             compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=schema, backend=recorder)
+                m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
             )
             assert isinstance(compiled_m, torch.nn.Module)
             y = compiled_m(x0, x1)
@@ -187,7 +190,7 @@ class SubgraphReplacementTest(unittest.TestCase):
 
             recorder = EagerAndRecordGraphs()
             compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=schema, backend=recorder)
+                m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
             )
 
             y = compiled_m(x)

--- a/tests/kernel/boo/ops/graph_ops_test.py
+++ b/tests/kernel/boo/ops/graph_ops_test.py
@@ -10,7 +10,6 @@ import tempfile
 from pathlib import Path
 
 import torch
-from torch._functorch.aot_autograd import aot_export_joint_simple
 
 from iree.turbine.kernel.boo.ops import get_custom_graph_op
 from iree.turbine.kernel.boo.runtime import set_cache_dir, LaunchableRuntimeCache

--- a/tests/kernel/boo/ops/graph_ops_test.py
+++ b/tests/kernel/boo/ops/graph_ops_test.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import torch
 from torch._functorch.aot_autograd import aot_export_joint_simple
 
-from iree.turbine.kernel.boo.ops import get_custom_graph_op, get_autograd_function
+from iree.turbine.kernel.boo.ops import get_custom_graph_op
 from iree.turbine.kernel.boo.runtime import set_cache_dir, LaunchableRuntimeCache
 
 
@@ -65,35 +65,6 @@ class GraphOpsTest(unittest.TestCase):
             )
             assert expected_dir_name_0 in cache_subdir_names
             assert expected_dir_name_1 in cache_subdir_names
-
-    def testAutogradOp(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            m = SampleModule(16, 32)
-            x = torch.ones([3, 3, 16, 16])
-
-            # Export a graph.
-            exported = torch.export.export(m, args=(x,))
-            gm = exported.graph_module
-
-            # Get a joint graph (exploiting the fact that gm.forward has flattened args).
-            sample_args = (m.linear.weight, m.linear.bias, x)
-            joint_gm = aot_export_joint_simple(
-                gm.forward, sample_args, trace_joint=True
-            )
-
-            # Get an autograd custom op from the joint graph module.
-            autograd_f = get_autograd_function(joint_gm, None, 1)
-
-            y = autograd_f(*sample_args)
-
-            assert m.linear.weight.grad is None
-            assert m.linear.bias.grad is None
-
-            y[0].sum().backward()
-
-            assert m.linear.weight.grad.shape == m.linear.weight.shape
-            assert m.linear.bias.grad.shape == m.linear.bias.shape
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This changes the `boo` fusion code to integrate a `torch.compile` backend that runs after AOTAutograd. This greatly simplifies things on our end, since pytorch now:
- handles capturing the forward and backwards passes, and provides these to us as separate graphs for compilation
- identifies values in the forwards pass that are required in the backwards pass, making them explicit outputs of the forward graph
- recompiles the graph as necessary, e.g. due to input shape changes

closes #1037, #1014