### PR TITLE
[BOO] Address graph api replacement flakiness

### DIFF
--- a/iree/turbine/kernel/boo/fusion/apply.py
+++ b/iree/turbine/kernel/boo/fusion/apply.py
@@ -55,12 +55,12 @@ def _fusion_transform(
 
     _log_graph_module("Source Graph Module", gm)
 
-    subgraphs, _ = extract_fusion_subgraph_modules(gm, fusion_schema)
+    subgraphs, internal_matches = extract_fusion_subgraph_modules(gm, fusion_schema)
     subgraph_repl = []
     for sg in subgraphs:
         subgraph_repl.append(get_subgraph_replacement(sg))
 
-    replace_subgraphs(gm, subgraphs, subgraph_repl)
+    replace_subgraphs(gm, subgraphs, internal_matches, subgraph_repl)
 
     # TODO: update any metadata which may have been modified by the replacement.
 

--- a/tests/kernel/boo/fusion/subgraph_fusion_test.py
+++ b/tests/kernel/boo/fusion/subgraph_fusion_test.py
@@ -147,12 +147,6 @@ class SubgraphReplacementTest(unittest.TestCase):
             y = fused_m(x0, x1)
             self.assertEqual(list(y.shape), [16, 16])
 
-    @pytest.mark.xfail(
-        reason=(
-            "Bug with repeated replacement when the first matching graph does not require the same combination of input gradients. "
-            "Remove when issue https://github.com/iree-org/iree-turbine/issues/1014 is resolved."
-        )
-    )
     def testRepeatedReplacementBackward(self):
         with tempfile.TemporaryDirectory() as td:
             set_cache_dir(Path(td))


### PR DESCRIPTION
Modifies `extract_fusion_subgraph_modules` to return a list of `InternalMatch`, and then adds a filter in `replace_subgraphs` which restricts the scope of the replacement to the exact subgraph we want to replace.

Addresses issue #1014 