### PR TITLE
[Wave] Fix paged decode attention for weird head sizes

### DIFF
--- a/iree/turbine/kernel/wave/expansion/expansion_utils.py
+++ b/iree/turbine/kernel/wave/expansion/expansion_utils.py
@@ -126,7 +126,9 @@ def get_dim_scaling(
 
     for dim in node.indexing_dims:
         if not_computed(dim) and is_static_dim(dim) and is_non_batch(dim):
-            dim_scaling[dim] = idxc.get_static_value(dim) // node.vector_shapes[dim]
+            dim_scaling[dim] = ceildiv(
+                idxc.get_static_value(dim), node.vector_shapes[dim]
+            )
 
     # For reduce ops, also include the reduction dimension.
     if isinstance(node, ReduceOp):

--- a/iree/turbine/kernel/wave/expansion/expansion_utils.py
+++ b/iree/turbine/kernel/wave/expansion/expansion_utils.py
@@ -134,9 +134,8 @@ def get_dim_scaling(
     if isinstance(node, ReduceOp):
         reduction_dim = node.reduction_dim
         if not_computed(reduction_dim) and is_static_dim(reduction_dim):
-            dim_scaling[reduction_dim] = (
-                idxc.get_static_value(reduction_dim)
-                // node.vector_shapes[reduction_dim]
+            dim_scaling[reduction_dim] = ceildiv(
+                idxc.get_static_value(reduction_dim), node.vector_shapes[reduction_dim]
             )
 
     return dim_scaling

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -168,6 +168,19 @@ def find_index_bounds(
         if bound is not None:
             bounds[dim] = get_min_expr(bounds.get(dim, None), bound)
 
+    for dim, vector_shape in vector_shapes.items():
+        if dim not in index:
+            continue
+
+        if vector_shape <= 1:
+            continue
+
+        if dim in bounds:
+            continue
+
+        if subs_idxc(dim) % subs_idxc(vector_shape) != 0:
+            bounds[dim] = sympy.Min(subs_idxc(dim), subs_idxc(vector_shape))
+
     if not bounds:
         return None
 

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -179,7 +179,7 @@ def find_index_bounds(
             continue
 
         if subs_idxc(dim) % subs_idxc(vector_shape) != 0:
-            bounds[dim] = sympy.Min(subs_idxc(dim), subs_idxc(vector_shape))
+            bounds[dim] = dim
 
     if not bounds:
         return None

--- a/iree/turbine/kernel/wave/utils/general_utils.py
+++ b/iree/turbine/kernel/wave/utils/general_utils.py
@@ -175,6 +175,10 @@ def find_index_bounds(
         if vector_shape <= 1:
             continue
 
+        # We are trying to get the bounds from the constraints, but we can have
+        # a situation with nontrivial vector sizes which are not part of the
+        # constraints (e.g K1 in paged decode attention). Try to infer bounds
+        # directly from the vector shape in this case.
         if dim in bounds:
             continue
 

--- a/lit_tests/kernel/wave/attention/decode_attention.py
+++ b/lit_tests/kernel/wave/attention/decode_attention.py
@@ -181,6 +181,65 @@ def test_paged_flash_decoding_small_query_heads():
 
 
 @run_test
+def test_paged_flash_decoding_small_head_size():
+    shape = paged_decode_attention_shape(
+        num_query_heads=128,
+        num_kv_heads=4,
+        head_size=13,
+        head_size_kv=13,
+        block_size=64,
+        num_seqs=8,
+    )
+    num_kv_splits = 8
+    mfma_variant = (tkw.MMAType.F32_16x16x16_F16, tkw.MMAType.F32_16x16x16_F16)
+    (
+        phase_0,
+        phase_1,
+        hyperparams_0,
+        hyperparams_1,
+        dynamic_symbols_0,
+        dynamic_symbols_1,
+    ) = get_paged_decode_attention_kernels(
+        shape,
+        mfma_variant,
+        num_kv_splits,
+    )
+
+    options = WaveCompileOptions(
+        subs=hyperparams_0,
+        canonicalize=True,
+        run_bench=False,
+        schedule=SchedulingType.NONE,
+        use_scheduling_barriers=False,
+        dynamic_symbols=dynamic_symbols_0,
+        compile_to_mlir=True,
+    )
+    phase_0 = wave_compile(options, phase_0)
+    print(phase_0.asm)
+
+    # CHECK-LABEL:          test_paged_flash_decoding_small_head_size
+    # CHECK:                func.func @phase_0
+    # Check we are generating comparison against 13
+    # CHECK:                   %[[C13:.*]] = arith.constant 13 : index
+    # CHECK:                   %[[COND:.*]] = arith.cmpi slt, %{{.*}}, %[[C13]] : index
+    # CHECK:                   %[[COND_SPLAT:.*]] = vector.splat %[[COND]] : vector<4xi1>
+    # CHECK:                   %[[COND_AND:.*]] = arith.andi %[[COND_SPLAT]], %{{.*}} : vector<4xi1>
+
+    # CHECK:                   %[[ELEM0:.*]] = vector.extract %[[COND_AND]][0] : i1 from vector<4xi1>
+    # CHECK:                   %[[ELEM0_SPLAT:.*]] = vector.splat %[[ELEM0:.*]] : vector<1xi1>
+    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM0_SPLAT]], %{{.*}}
+    # CHECK:                   %[[ELEM1:.*]] = vector.extract %[[COND_AND]][1] : i1 from vector<4xi1>
+    # CHECK:                   %[[ELEM1_SPLAT:.*]] = vector.splat %[[ELEM1:.*]] : vector<1xi1>
+    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM1_SPLAT]], %{{.*}}
+    # CHECK:                   %[[ELEM2:.*]] = vector.extract %[[COND_AND]][2] : i1 from vector<4xi1>
+    # CHECK:                   %[[ELEM2_SPLAT:.*]] = vector.splat %[[ELEM2:.*]] : vector<1xi1>
+    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM2_SPLAT]], %{{.*}}
+    # CHECK:                   %[[ELEM3:.*]] = vector.extract %[[COND_AND]][3] : i1 from vector<4xi1>
+    # CHECK:                   %[[ELEM3_SPLAT:.*]] = vector.splat %[[ELEM3:.*]] : vector<1xi1>
+    # CHECK:                   vector.maskedload %{{.*}}[%{{.*}}], %[[ELEM3_SPLAT]], %{{.*}}
+
+
+@run_test
 def test_flash_decoding():
     shape = (8, 128, 128, 64, 256)
     mfma_variant = tkw.MMAType.F32_16x16x16_F16
@@ -207,7 +266,8 @@ def test_flash_decoding():
     phase_0 = wave_compile(options, phase_0)
     print(phase_0.asm)
 
-    # CHECK-LABEL:           func.func @phase_0
+    # CHECK-LABEL:          test_flash_decoding
+    # CHECK:                 func.func @phase_0
     # CHECK-NOT:               {{.*}} = scf.for
     # CHECK-COUNT-9:           {{.*}} = vector.maskedload
     # CHECK-COUNT-1:           vector.store

--- a/tests/kernel/wave/attention/paged_attention_test.py
+++ b/tests/kernel/wave/attention/paged_attention_test.py
@@ -44,6 +44,7 @@ from typing import List, Optional
 # (NUM_Q_HEADS, NUM_KV_HEADS, HEAD_SIZE, HEAD_SIZE_KV, BLOCK_SIZE, NUM_SEQS, SEQ_LEN)
 shapes = [(16, 1, 64, 64, 32, 2, 100)]
 shapes += [(6, 1, 128, 128, 32, 1, 100)]
+shapes += [(64, 1, 13, 13, 32, 1, 100)]
 shapes += [(16, 2, 64, 64, 32, 1, 100)]  # (16 // 2) < 16
 shapes += [(16, 1, 64, 64, 32, 2, 3)]  # small SEQ_LEN test
 shapes += [(64, 1, 80, 80, 32, 2, 128)]


### PR DESCRIPTION
There were 2 issues:
* Expansion was generating less nodes than needed when dim size is not divisible by vector size
* Masking code wasn't generating properly for non-trivial vector sizes when corresponding dimension is not part of the constraints.