### PR TITLE
[BOO] Add more fusion tests

### DIFF
--- a/tests/kernel/boo/fusion/subgraph_fusion_test.py
+++ b/tests/kernel/boo/fusion/subgraph_fusion_test.py
@@ -6,6 +6,7 @@
 
 import unittest
 import tempfile
+import pytest
 
 from typing import Sequence
 from pathlib import Path
@@ -13,6 +14,7 @@ from pathlib import Path
 import torch
 from torch import fx
 from torch._dynamo.testing import EagerAndRecordGraphs
+from torch.profiler import profile, ProfilerActivity
 
 from iree.turbine.dynamo.backends import boo
 from iree.turbine.kernel.boo.fusion import OpFusionSpec, FusionSchema
@@ -166,6 +168,7 @@ class SubgraphReplacementTest(unittest.TestCase):
             recorder = EagerAndRecordGraphs()
             compiled_m = torch.compile(
                 m,
+                dynamic=False,
                 backend=boo.backend(
                     fusion_schema=fusion_schema, nested_backend=recorder
                 ),
@@ -310,6 +313,52 @@ class SubgraphReplacementTest(unittest.TestCase):
                     err_msg += f"Parameter {name} unexpectedly has zero gradient.\n"
 
             self.assertFalse(found_zero_grad, msg=err_msg)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU.")
+    def testNestedCompilerInductor(self):
+        with tempfile.TemporaryDirectory() as td:
+            set_cache_dir(Path(td))
+            device = torch.device("cuda:0")
+
+            schema: FusionSchema = {
+                torch.ops.aten.convolution.default: OpFusionSpec(
+                    recursive=True, consumers=(torch.ops.aten.sigmoid.default,)
+                )
+            }
+
+            mx = SampleModule3().to(device=device)
+            mx.eval()
+            my = SampleModule3().to(device=device)
+            my.eval()
+
+            @torch.compile(
+                dynamic=False,
+                backend=boo.backend(nested_backend="inductor", fusion_schema=schema),
+            )
+            def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                x1 = mx(x)
+                y1 = my(y)
+                z = (x1 + y1 + 2.0) / 16.0
+                return z
+
+            gen = torch.Generator(device=device)
+            gen.manual_seed(13)
+            x = torch.randn([2, 3, 16, 16], generator=gen, device=device)
+            y = torch.randn([1, 3, 16, 16], generator=gen, device=device)
+
+            # Do a warmup compile/run.
+            with torch.no_grad():
+                _ = f(x, y)
+
+            # Profile the next run.
+            with torch.no_grad() and profile(
+                activities=[ProfilerActivity.CUDA]
+            ) as prof:
+                z = f(x, y)
+
+            key_averages = str(prof.key_averages())
+            self.assertIn("fused_op", key_averages)
+            self.assertIn("triton_poi_fused_add_div", key_averages)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds two tests:

- Test for re-compile on new input shape.
- Test for boo fusion + inductor

Note: for re-compile to work properly, `dynamic=False` needs to be set, otherwise we need to properly handle dynamic shapes.