### PR TITLE
[BOO] Allow inlining IR for layout customizable convolution

### DIFF
--- a/iree/turbine/kernel/boo/ops/conv.py
+++ b/iree/turbine/kernel/boo/ops/conv.py
@@ -21,7 +21,7 @@ from .library import define_schema, register_impl, register_meta, BOO_LIBRARY
 from .utils import *
 from .layout_customizable_conv import boo_layout_customizable_convolution
 
-from ....runtime.op_reg import CustomOp
+from ....runtime.op_reg import CustomOp, KernelSelection, KernelBuilder
 
 __all__ = [
     "boo_conv",
@@ -31,14 +31,54 @@ __all__ = [
 # Forward Convolution Implementations #
 
 
-@CustomOp.register(library=BOO_LIBRARY, register_meta=False)
+@CustomOp.register(library=BOO_LIBRARY)
 class convolution(CustomOp):
     signature = "convolution(Tensor x, Tensor w, Tensor? b, int[] stride, int[] padding, int[] dilation, int groups) -> Tensor"
 
-    def select(self, ksel):
-        raise NotImplementedError("convolution select NYI")
+    def select(self, ksel: KernelSelection):
+        # Declare args.
+        x = ksel.arg_tensor(0)
+        w = ksel.arg_tensor(1)
+        b = ksel.arg_optional_tensor(2)
+        stride = ksel.attr_list_int(3)
+        padding = ksel.attr_list_int(4)
+        dilation = ksel.attr_list_int(5)
+        groups = ksel.attr_int(6)
+        # Specialize args.
+        x.specialize_all_dims()
+        w.specialize_all_dims()
+        if b:
+            b.specialize_all_dims()
+            ksel.variant = "biased"
 
-    def generate(self, ksel, kb):
+        # Manually set memory_format specialization to correct meta impl for eager_execution.
+        num_spatial_dims = len(x.spec_dims) - 2
+        cl_mem_format = CHANNELS_LAST_MEMORY_FORMAT.get(num_spatial_dims)
+        output_mem_format = (
+            cl_mem_format
+            if cl_mem_format and w.t.is_contiguous(memory_format=cl_mem_format)
+            else torch.contiguous_format
+        )
+        self.conv_sig = ConvSignature(
+            input_shape=x.spec_dims,
+            kernel_shape=w.spec_dims,
+            bias=(b is not None),
+            dtype=x.t.dtype,
+            stride=stride.v,
+            padding=padding.v,
+            dilation=dilation.v,
+            groups=groups.v,
+        )
+        output_shape = self.conv_sig.output_shape
+        o_meta = torch.empty(
+            tuple(output_shape),
+            dtype=self.conv_sig.dtype,
+            memory_format=output_mem_format,
+            device="meta",
+        )
+        ksel.return_tensor(o_meta)
+
+    def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         raise NotImplementedError("convolution generate NYI")
 
     def eager_execute(self, *args):
@@ -117,41 +157,6 @@ def _boo_convolution_impl(
     conv = get_launchable(sig)
     result = conv(*args)
     return result if not w_cl else result.permute(contig_cl_perm)
-
-
-@register_meta("convolution")
-def _boo_convolution_meta(
-    x: torch.Tensor,
-    w: torch.Tensor,
-    b: None | torch.Tensor,
-    stride: Sequence[int],
-    padding: Sequence[int],
-    dilation: Sequence[int],
-    groups: int,
-) -> torch.Tensor:
-    sig = ConvSignature(
-        input_shape=x.shape,
-        kernel_shape=w.shape,
-        dtype=x.dtype,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        transposed=False,
-        output_padding=0,
-        groups=groups,
-        mode="fwd",
-    )
-    num_spatial_dims = len(x.shape) - 2
-    cl_memory_format = CHANNELS_LAST_MEMORY_FORMAT.get(num_spatial_dims)
-    memory_format = (
-        cl_memory_format
-        if cl_memory_format is not None
-        and w.is_contiguous(memory_format=cl_memory_format)
-        else torch.contiguous_format
-    )
-    return torch.empty(
-        sig.output_shape, dtype=sig.dtype, device=x.device, memory_format=memory_format
-    )
 
 
 # Backward Convolution Implementations #

--- a/iree/turbine/kernel/boo/ops/layout_customizable_conv.py
+++ b/iree/turbine/kernel/boo/ops/layout_customizable_conv.py
@@ -80,7 +80,7 @@ class layout_customizable_convolution(CustomOp):
             sample_args = sample_args + (ksel.arg_descs[2].t,)
         func_name = self.conv_sig.get_func_name()
         module_op = generate_custom_op_compatible_ir(
-            self.conv_sig.get_nn_module(use_custom=False),
+            self.conv_sig.get_nn_module(use_custom=True),
             args=sample_args,
             func_name=func_name,
         )

--- a/iree/turbine/kernel/boo/ops/utils.py
+++ b/iree/turbine/kernel/boo/ops/utils.py
@@ -219,9 +219,9 @@ def get_arg_spec_name_and_memory_format_permutations(
 def generate_custom_op_compatible_ir(
     module: torch.nn.Module, args: tuple[torch.Tensor, ...], func_name: str
 ) -> Operation:
-    e = export(module, args=args, func_name=func_name)
+    e = export(module, args=args, function_name=func_name)
     CompiledModule.run_pass_pipeline(
         e.compiled_module,
-        "builtin.module(torch-backend-to-linalg-on-tensors-backend-pipeline)",
+        "builtin.module(canonicalize, torch-func-backend-type-conversion)",
     )
     return e.mlir_module

--- a/iree/turbine/runtime/op_reg/impl_helper.py
+++ b/iree/turbine/runtime/op_reg/impl_helper.py
@@ -34,6 +34,7 @@ from ...support.ir_imports import (
     StringAttr,
     TypeAttr,
     Value,
+    util_d,
 )
 
 from ...transforms.merger import Merger
@@ -167,13 +168,16 @@ class JinjaTemplateLoader(TemplateLoader):
 
 
 def call_function(target_function: Operation, *operands: Value) -> Sequence[Value]:
-    """Emits a util.call for a util.func target function operation."""
+    """Emits a call op for a util.func or func.func target function operation."""
     target_symbol = FlatSymbolRefAttr.get(
         StringAttr(target_function.attributes["sym_name"]).value
     )
     ftype = FunctionType(TypeAttr(target_function.attributes["function_type"]).value)
+    call_op_name = (
+        "util.call" if isinstance(target_function, util_d.FuncOp) else "func.call"
+    )
     return Operation.create(
-        "util.call",
+        call_op_name,
         results=ftype.results,
         operands=operands,
         attributes={

--- a/tests/kernel/boo/ops/boo_conv_aot_test.py
+++ b/tests/kernel/boo/ops/boo_conv_aot_test.py
@@ -1,0 +1,43 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+import torch
+import iree.turbine.kernel.boo.ops as boo_ops
+import iree.turbine.aot as aot
+
+
+class SimpleAOTTest(unittest.TestCase):
+    def testAOTLayoutCustomizable(self):
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+        class SampleModule(torch.nn.Module):
+            def forward(self, x, w):
+                return (
+                    boo_ops.boo_layout_customizable_convolution(
+                        x, w, None, [1, 1], [0, 0], [1, 1], 1, "NHWC", "NHWC", "NHWC"
+                    )
+                    * 0.1
+                )
+
+        N = 2
+        C = 32
+        H = 16
+        W = 16
+        k = 1
+        f = 2
+        x = torch.randn([N, H, W, C], device=device)
+        w = torch.randn([f, k, k, C], device=device)
+        e = aot.export(SampleModule(), args=(x, w))
+        e.mlir_module.verify()
+        self.assertIn(
+            "call @conv_2d_float32_forward_2x16x16x32_nhwc_2x1x1x32_fhwc_nhwf_1x1s_0x0p_1x1d_1g",
+            str(e.mlir_module),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Boo ops now use `iree.turbine.runtime.op_reg.CustomOp` for library registration.

`layout_customizable_convolution` now has a `generate` method, which will allow inlining that IR for the fusion API. 

The next step is going to be replacing `aten::convolution` with a function which permutes channels_last inputs and applies layout customizable conv. These artificial permutations should ideally fold easily with the permutations introduced via `get_custom_graph_op`. Note: We need to manually do the replacement with `layout_customizable_convolution`, since once we are in mlir, we cannot specialize based on input layouts. 