### PR TITLE
[Wave] minor fixes to option handling

### DIFF
--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -185,6 +185,7 @@ class WaveCacheManager(object):
             options.dynamic_symbols,
             options.schedule,
             options.use_scheduling_barriers,
+            options.canonicalize,
         ]
 
         # Add kernel/helper function specific hashes.

--- a/iree/turbine/kernel/wave/cache.py
+++ b/iree/turbine/kernel/wave/cache.py
@@ -181,11 +181,33 @@ class WaveCacheManager(object):
         key = [
             arg_dtypes,
             processed_constraints,
+            # We include only those fields from `WaveCompileOptions` that may
+            # alter the generated IR.  We deliberately do not use the string
+            # representation of the `WaveCompileOptions` type since the computed
+            # cache key is itself a member field of the type.  We list the
+            # options here in the same order as they are defined in
+            # compile_options.py.
+            options.canonicalize,
+            options.func_name,
             options.subs,
             options.dynamic_symbols,
             options.schedule,
             options.use_scheduling_barriers,
-            options.canonicalize,
+            options.backend,
+            options.target,
+            options.gpu_native_math_precision,
+            options.iree_preprocessing_pass_pipeline,
+            options.override_mlir,
+            options.optimization_level,
+            options.denorm_fp_math_f32,
+            options.waves_per_eu,
+            options.use_buffer_load_ops,
+            options.use_buffer_store_ops,
+            options.use_stride_cache_swizzle,
+            options.use_fast_math,
+            options.minimize_shared_allocs,
+            options.reorder_allocs,
+            options.override_schedule,
         ]
 
         # Add kernel/helper function specific hashes.

--- a/iree/turbine/kernel/wave/compile.py
+++ b/iree/turbine/kernel/wave/compile.py
@@ -140,6 +140,9 @@ def wave_compile(options: WaveCompileOptions, kernel: "LaunchableWave") -> WaveK
             if options.wave_runtime:
                 binary_path = get_binary_path()
 
+            if options.print_mlir:
+                print(cached_kernel.asm)
+
             return WaveKernel(
                 options,
                 cached_kernel.vmfb,


### PR DESCRIPTION
This PR contains three small patches.

> [Wave] include canonicalization in the cache key
> 
> Prior to this patch, since the cache manager didn't include the
> canonicalization flag when computing the cache key, Wave occasionally
> retrieved an incorrect kernel from the cache.  Specifically, if the
> cached kernel was not run through canonicalization (since the flag is
> off by default) and if the programmer requested canonicalization, the
> programmer would still get the non-canonicalized (but cached) IR.
> 
> This patch fixes the problem by including canonicalization among the
> details that are included when computing the cache key.

and

> [Wave] support printing of cached IR
> 
> When Wave retrieves a cached kernel, we didn't check whether the
> programmer had requested that the IR be printed to the console,
> resulting in silent output despite the programmer's request to print the
> IR.  This patch introduces the check so that `print_mlir` has the
> desired effect, whether or not Wave is working with a cached or uncached
> kernel.

and

> [Wave] compute cache key using all options that may affect compilation
> 
> Several other options besides canonicalization may impact the generated
> IR and these were not included in the computation of the cache key,
> which would have the effect of retrieving an incorrect IR from the cache
> when these options changed from one compilation to the next.  This patch
> adds these new options to the function that computes the cache key.