### PR TITLE
[BOO] Fix setup for tuning specs path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     package_data={
         "iree.turbine": [
             "ops/templates/*.mlir",
-            "kernel/boo/conv_exports/tuning_specs.mlir",
+            "kernel/boo/runtime/tuning_specs.mlir",
         ],  # Include MLIR templates
     },
     entry_points={


### PR DESCRIPTION
This file was moved a while ago, so boo has just been silently broken unless installed from a cloned repo.

I'd like to find a way to test this soon, but we need to fix this immediately. 