### PR TITLE
[boo] Replace aten.convolution with boo convolution

### DIFF
--- a/iree/turbine/kernel/boo/fusion/replacement.py
+++ b/iree/turbine/kernel/boo/fusion/replacement.py
@@ -1,0 +1,68 @@
+from collections.abc import Callable
+
+import torch
+from torch import fx
+from torch.fx.node import Argument, Target
+
+
+from iree.turbine.kernel.boo import ops as boo_ops
+
+# 1 to 1 op replacements. The replacement function should return the new target
+# and arguments, or 'None' if it doesn't apply.
+ReplacementSchema = dict[
+    Target,
+    Callable[
+        [tuple[Argument, ...], dict[str, object]],  # (node.args, node.meta)
+        tuple[Callable, tuple[Argument, ...]] | None,  # (new_target, new_args) | None
+    ],
+]
+
+
+def apply_replacements(graph: fx.Graph, replacements: ReplacementSchema):
+    for node in graph.nodes:
+        if node.op == "call_function":
+            replacer_fn = replacements.get(node.target, lambda *_: None)
+            replacement = replacer_fn(node.args, node.meta)
+            if replacement is None:
+                continue
+            target, target_args = replacement
+            with graph.inserting_after(node):
+                call_boo = graph.call_function(target, target_args)
+            node.replace_all_uses_with(call_boo, propagate_meta=True)
+            graph.erase_node(node)
+
+
+def replace_aten_convolution(args: tuple[Argument, ...], meta: dict[str, object]):
+    "Replace 'torch.ops.aten.convolution' with custom BOO implementation."
+    (
+        input,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        _output_padding,
+        groups,
+    ) = args
+
+    # BOO convolution doesn't support transpose. 'output_padding' is ignored
+    # in non-transpose cases.
+    if transposed is not False:
+        return None
+
+    example_out = meta["val"]
+    assert isinstance(example_out, torch.Tensor)
+    output_is_channels_last = example_out.is_contiguous(
+        memory_format=torch.channels_last
+    )
+    return boo_ops.convolution_replacement, (
+        input,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        groups,
+        output_is_channels_last,
+    )

--- a/iree/turbine/kernel/boo/fusion/schema.py
+++ b/iree/turbine/kernel/boo/fusion/schema.py
@@ -6,7 +6,11 @@
 
 from dataclasses import dataclass
 from typing import Dict, Sequence
+
+import torch
 from torch.fx.node import Target
+
+from .replacement import ReplacementSchema, replace_aten_convolution
 
 
 @dataclass
@@ -18,8 +22,11 @@ class OpFusionSpec:
 
 FusionSchema = Dict[Target, OpFusionSpec]
 
-# TODO: identify advantageous fusions.
-DEFAULT_SUPPORTED_BOO_FUSIONS: FusionSchema = {}
+# TODO: extend this
+DEFAULT_SUPPORTED_BOO_FUSIONS: FusionSchema = {
+    torch.ops.aten.convolution.default: OpFusionSpec()
+}
 
-# TODO: set up custom implementation replacements.
-PRE_FUSION_DECOMPOSITIONS = {}
+DEFAULT_POST_FUSION_REPLACEMENTS: ReplacementSchema = {
+    torch.ops.aten.convolution.default: replace_aten_convolution
+}

--- a/iree/turbine/kernel/boo/ops/conv.py
+++ b/iree/turbine/kernel/boo/ops/conv.py
@@ -5,7 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
-from typing import Sequence, Tuple
+from collections.abc import Callable
+from typing import Any, Sequence, Tuple
 
 import torch
 

--- a/iree/turbine/kernel/boo/ops/graph.py
+++ b/iree/turbine/kernel/boo/ops/graph.py
@@ -66,7 +66,10 @@ def get_custom_graph_op(
     """Converts a graph module into a custom operator."""
     gm_string = str(gm.print_readable(print_output=False, include_stride=True))
     hash = sha1(gm_string.encode(), usedforsecurity=False).hexdigest()
-    op_name = f"fused_op_{hash}"
+    call_function_names = "_".join(
+        n.name for n in gm.graph.nodes if n.op == "call_function"
+    )
+    op_name = f"fused_op_{call_function_names}_{hash}"
     logger.debug("Got hash str '%s' for GraphModule: \n %s", hash, gm_string)
 
     if not hasattr(torch.ops.boo, op_name):

--- a/iree/turbine/transforms/general/custom_op_expansion.py
+++ b/iree/turbine/transforms/general/custom_op_expansion.py
@@ -44,6 +44,7 @@ from ...support.ir_imports import (
     SymbolTable,
     Value,
 )
+from ...support.logging import aot_logger as logger
 
 from ..rewriter import (
     Pass,
@@ -114,6 +115,7 @@ class ExpandCustomOpsPass(Pass):
             module_body=module_body,
             symbol_table=self.symbol_table,
         )
+        logger.debug("Generating custom op: %s", ksel)
         with kb.ip, kb.location:
             op_reg.generate(ksel, kb)
         assert kb.yielded, "Custom op generation did not yield_results()"

--- a/tests/kernel/boo/fusion/integration_test.py
+++ b/tests/kernel/boo/fusion/integration_test.py
@@ -1,0 +1,94 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+Testing functionality of the default BOO backend.
+"""
+import pytest
+import torch
+from torch import fx
+from torch._dynamo.testing import EagerAndRecordGraphs
+
+from iree.turbine.dynamo.backends import boo
+
+
+def test_custom_boo_conv_used():
+    """Test that we're using our custom convolution op"""
+    recorder = EagerAndRecordGraphs()
+    compiled_conv = torch.compile(
+        torch.ops.aten.convolution,
+        backend=boo.backend(nested_backend=recorder),
+    )
+
+    N, C, H, W = (1, 16, 4, 4)
+    F = 32
+    K = 3
+    input = torch.randn((N, C, H, W))
+    weight = torch.randn((F, C, K, K))
+    compiled_conv(
+        input,
+        weight,
+        None,  # bias
+        [1, 1],  # stride
+        [1, 1],  # padding
+        [1, 1],  # dilation
+        False,  # transposed
+        [10, 10],  # output_padding
+        1,  # groups
+    )
+
+    [compiled_module] = recorder.graphs
+    assert isinstance(compiled_module, fx.GraphModule)
+    [call_node] = [n for n in compiled_module.graph.nodes if n.op == "call_function"]
+    # Make sure we're using 'boo.ops.convolution_replacement'. We have to do a
+    # string check unfortunately, as the target is a fused custom op that we
+    # can't inspect.
+    call_node_target_str = str(call_node.target)
+    assert call_node_target_str.startswith("boo.fused_op_convolution_replacement_")
+
+
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="requires GPU"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "memory_format", [torch.contiguous_format, torch.channels_last]
+)
+def test_output_layout(device: str, memory_format: torch.memory_format):
+    """Test that we properly match the layout of pytorch's implementation."""
+    with torch.device(device):
+        conv = torch.ops.aten.convolution
+        boo_conv = torch.compile(conv, backend="iree_boo")
+        N, C, H, W = (1, 16, 4, 4)
+        F = 32
+        K = 3
+        input = torch.randn((N, C, H, W)).to(memory_format=memory_format)
+        weight = torch.randn((F, C, K, K)).to(memory_format=memory_format)
+        args = (
+            input,
+            weight,
+            None,  # bias
+            [1, 1],  # stride
+            [1, 1],  # padding
+            [1, 1],  # dilation
+            False,  # transposed
+            [10, 10],  # output_padding
+            1,  # groups
+        )
+
+        actual_result = boo_conv(*args)
+        expected_result = conv(*args)
+        assert isinstance(actual_result, torch.Tensor)
+        assert isinstance(expected_result, torch.Tensor)
+        assert actual_result.shape == expected_result.shape
+        assert actual_result.stride() == expected_result.stride()


### PR DESCRIPTION
This adds the functionality for doing `1-1` op replacements after subgraph fusion. By default we replace `aten.convolution` with our custom convolution op.