### PR TITLE
[BOO] Enable `make_single_dispatch` specification in `FusionSchema`.

### DIFF
--- a/iree/turbine/kernel/boo/fusion/apply.py
+++ b/iree/turbine/kernel/boo/fusion/apply.py
@@ -40,7 +40,9 @@ def fusion_transform(
 
     subgraph_replacements: list[tuple[FusedSubgraph, fx.Node]] = []
     for subgraph in subgraphs:
-        custom_op = get_custom_graph_op(subgraph.module, force_single_dispatch=False)
+        custom_op = get_custom_graph_op(
+            subgraph.module, force_single_dispatch=subgraph.single_dispatch
+        )
         # Insert call as early as possible, to maintain topological order.
         insert_pt = sorted(subgraph.arguments)[-1]
         with module.graph.inserting_after(insert_pt):

--- a/iree/turbine/kernel/boo/fusion/schema.py
+++ b/iree/turbine/kernel/boo/fusion/schema.py
@@ -16,6 +16,7 @@ from .replacement import ReplacementSchema, replace_aten_convolution
 @dataclass
 class OpFusionSpec:
     recursive: bool = True
+    make_single_dispatch: bool = False
     producers: Sequence[Target] = ()
     consumers: Sequence[Target] = ()
 
@@ -24,7 +25,7 @@ FusionSchema = Dict[Target, OpFusionSpec]
 
 # TODO: extend this
 DEFAULT_SUPPORTED_BOO_FUSIONS: FusionSchema = {
-    torch.ops.aten.convolution.default: OpFusionSpec()
+    torch.ops.aten.convolution.default: OpFusionSpec(make_single_dispatch=True),
 }
 
 DEFAULT_POST_FUSION_REPLACEMENTS: ReplacementSchema = {

--- a/iree/turbine/kernel/boo/fusion/subgraph.py
+++ b/iree/turbine/kernel/boo/fusion/subgraph.py
@@ -18,6 +18,8 @@ from ....support.logging import aot_logger as logger
 class FusedSubgraph(NamedTuple):
     module: GraphModule
     """Module containing the subgraph to be fused."""
+    single_dispatch: bool
+    """Whether to force compile the subgraph as a single dispatch."""
     matched_nodes: list[Node]
     """Nodes in the orignal graph that were matched."""
     arguments: list[Node]
@@ -138,6 +140,7 @@ def extract_fusion_subgraph_modules(
         subgraphs.append(
             FusedSubgraph(
                 module=GraphModule(src_gm, subgraph),
+                single_dispatch=node_spec.make_single_dispatch,
                 matched_nodes=subgraph_matched_nodes,
                 arguments=subgraph_arguments,
                 results=subgraph_results,


### PR DESCRIPTION
Enables specifying whether to make a single dispatch for subgraphs extracted based on the `OpFusionSpec` in a `FusionSchema`.