### PR TITLE
[BOO] Enable filtering based on functions provided to the fusion schema

### DIFF
--- a/iree/turbine/kernel/boo/fusion/schema.py
+++ b/iree/turbine/kernel/boo/fusion/schema.py
@@ -5,10 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from dataclasses import dataclass
-from typing import Dict, Sequence
+from typing import Callable, Dict, Sequence
 
 import torch
-from torch.fx.node import Target
+from torch.fx.node import Target, Node
 
 from .replacement import ReplacementSchema, replace_aten_convolution
 
@@ -16,16 +16,38 @@ from .replacement import ReplacementSchema, replace_aten_convolution
 @dataclass
 class OpFusionSpec:
     recursive: bool = True
+    """Whether to recursively fuse in producers and consumers."""
     make_single_dispatch: bool = False
+    """Whether to force compile a fused op into a single dispatch."""
+    match_filters: Sequence[Callable[[Node], bool]] = ()
+    """A sequence of filter functions to restrict what gets included in the subgraph.
+    If any of these return false, the node is not included in the fused subgraph."""
     producers: Sequence[Target] = ()
+    """Producer nodes we want to fuse with."""
     consumers: Sequence[Target] = ()
+    """Consumer nodes we want to fuse with."""
+
+    def check_filters(self, node: Node):
+        return all([f(node) for f in self.match_filters])
 
 
 FusionSchema = Dict[Target, OpFusionSpec]
 
+
+def _conv_transpose_filter(node: Node) -> bool:
+    if node.target != torch.ops.aten.convolution.default:
+        return True
+    transposed = node.args[-3]
+    return transposed == False
+
+
 # TODO: extend this
 DEFAULT_SUPPORTED_BOO_FUSIONS: FusionSchema = {
-    torch.ops.aten.convolution.default: OpFusionSpec(make_single_dispatch=True),
+    torch.ops.aten.convolution.default: OpFusionSpec(
+        make_single_dispatch=True,
+        match_filters=(_conv_transpose_filter,),
+        consumers=(torch.ops.aten.relu.default, torch.ops.aten.sigmoid.default),
+    ),
 }
 
 DEFAULT_POST_FUSION_REPLACEMENTS: ReplacementSchema = {

--- a/iree/turbine/kernel/boo/fusion/subgraph.py
+++ b/iree/turbine/kernel/boo/fusion/subgraph.py
@@ -51,6 +51,10 @@ def extract_fusion_subgraph_modules(
         node_spec = fusion_schema.get(root.target, None)
         if node_spec is None:
             continue
+
+        if not node_spec.check_filters(root):
+            continue
+
         node_list = [root]
 
         # Walk producers from root and include them in the subgraph
@@ -68,6 +72,8 @@ def extract_fusion_subgraph_modules(
                 if producer.target not in node_spec.producers:
                     continue
                 if producer in used_nodes:
+                    continue
+                if not node_spec.check_filters(producer):
                     continue
                 # Insert producers at the front, since we want to preserve at least some weak ordering of nodes.
                 # Is it possible for this to generate an invalid ordering? (Maybe it's better to just sort node_list after).
@@ -89,6 +95,8 @@ def extract_fusion_subgraph_modules(
                 if consumer.target not in node_spec.consumers:
                     continue
                 if consumer in used_nodes:
+                    continue
+                if not node_spec.check_filters(consumer):
                     continue
                 visited_nodes.add(consumer)
                 node_list.append(consumer)


### PR DESCRIPTION
Adds another item to `OpFusionSpec` : `match_filters`, where we can specify a sequence of `Callable[[Node], bool]` to determine whether to give nodes to IREE.

In particular, it will not start making a subgraph if the root node fails to match the filters, and the filters can be used to additionally restrict the nodes we fuse into the subgraph.