### PR TITLE
[BOO] Clean up graph op implementation

### DIFF
--- a/tests/kernel/boo/ops/graph_ops_test.py
+++ b/tests/kernel/boo/ops/graph_ops_test.py
@@ -47,11 +47,14 @@ class GraphOpsTest(unittest.TestCase):
             # Get a graph op (note, model params are pytree flattened as args).
             graph_op = get_custom_graph_op(gm)
 
-            # Apply created graph op on various shaped inputs.
+            # Apply the graph op.
             y = graph_op(m.linear.weight, m.linear.bias, x)
             assert list(y.shape) == [3, 3, 16, 32]
+            # Since we exported with static dims, applying to an input with a different shape should throw an error.
             new_x = torch.ones([4, 3, 32, 16])
-            with pytest.raises(ValueError):
+            with pytest.raises(
+                ValueError, match=r"INVALID_ARGUMENT; tensor shape dimension 0 mismatch"
+            ):
                 new_y = graph_op(m.linear.weight, m.linear.bias, new_x)
 
             # Verify caching.

--- a/tests/kernel/boo/ops/graph_ops_test.py
+++ b/tests/kernel/boo/ops/graph_ops_test.py
@@ -6,6 +6,7 @@
 
 import unittest
 import tempfile
+import pytest
 
 from pathlib import Path
 
@@ -50,8 +51,8 @@ class GraphOpsTest(unittest.TestCase):
             y = graph_op(m.linear.weight, m.linear.bias, x)
             assert list(y.shape) == [3, 3, 16, 32]
             new_x = torch.ones([4, 3, 32, 16])
-            new_y = graph_op(m.linear.weight, m.linear.bias, new_x)
-            assert list(new_y.shape) == [4, 3, 32, 32]
+            with pytest.raises(ValueError):
+                new_y = graph_op(m.linear.weight, m.linear.bias, new_x)
 
             # Verify caching.
             op_name = graph_op._qualified_op_name.split("::")[-1]
@@ -59,11 +60,7 @@ class GraphOpsTest(unittest.TestCase):
             expected_dir_name_0 = (
                 op_name + "_32x16xfloat32_32xfloat32_3x3x16x16xfloat32"
             )
-            expected_dir_name_1 = (
-                op_name + "_32x16xfloat32_32xfloat32_4x3x32x16xfloat32"
-            )
             assert expected_dir_name_0 in cache_subdir_names
-            assert expected_dir_name_1 in cache_subdir_names
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since we are doing AOT graph fusion, the graph ops we insert do not need to specialize based on memory format or shapes at runtime.

This adds some comments, factors out some useful layout management utilities, and moves layout inference and name getting outside the op implementation.

Something to consider:

Although it should be possible to get the `Launchable` itself ahead-of-time, it's a bit subtle since the example args we get from the source graph module are in a fake mode which is specific to the existing dynamo context of `torch.compile`. There might be some way to locally disable the existing dynamo/fake_mode context for the `get_launchable` sample args, but I figure we could address this in a follow-up.

At least the `get_launchable` call during runtime should really just be looking up the `func_name` in the `LaunchableRuntimeCache`, which should result in fairly minimal CPU overhead.

Another idea: instead of using dynamo to export the layout managed module, we could modify the source graph module by explicitly adding the required permute nodes, then use `FxImporter` directly. This would require some handling of the replacement strategy (e.g. `aten::convolution` -> `boo::layout_customizable_convolution`) to actually trace out the replacement function (e.g. `convolution_replacement`), since these function calls would not get expanded by the `FxImporter`. Might be worth looking into, since the fewer times we use `torch.export`, the better.