### PR TITLE
[boo] Fix missing compile flag when tuning spec is disabled

### DIFF
--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -186,7 +186,8 @@ def run(cli_args: Sequence[str], gpu_id: int):
             gc.collect()
 
     torch.cuda.synchronize()
-    results = results or ()
+    if results is None:
+        results = ()
     if isinstance(results, torch.Tensor):
         results = (results,)
     for i, result in enumerate(results):


### PR DESCRIPTION
`--iree-llvmgpu-set-workgroup-distribution-along=x` is currently only being set when the tuning spec is enabled.