### PR TITLE
[boo][driver] Replace Tracy with torch profiler

### DIFF
--- a/iree/turbine/kernel/boo/driver/README.md
+++ b/iree/turbine/kernel/boo/driver/README.md
@@ -67,29 +67,7 @@ convbfp16 -n 128 -c 35 -H 48 -W 32 -k 35 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1
 ...
 ```
 
-The `--time 1` (or `-t 1` for short) option to collect timing is implemented by launching the kernel in a subprocess, which is then traced using `tracy`. Note: you can output `min_time (us)` to a csv file with `--csv=results.csv`.
-
-### Requirements for collecting timing info:
-
-#### pip installed `iree-base-runtime`:
-
-- set `IREE_PY_RUNTIME=tracy` in your environment.
-- build `tracy-csvexport` and add it to your `PATH`:
-
-```
-git clone https://github.com/wolfpld/tracy.git
-cd tracy/csvexport
-cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --parallel --config Release
-export PATH="$PWD/build/:$PATH"
-```
-
-#### local iree build with python bindings:
-
-- You may need to configure cmake with `-DTRACY_DELAYED_INIT=ON -DTRACY_MANUAL_LIFETIME=ON` to work around issues with the tracy client being closed before traces are captured.
-- Make sure `PYTHONPATH` is set to your locally built compiler and runtime python bindings. E.g. `source <build-dir>/.env && export PYTHONPATH`.
-- Build `iree-tracy-capture`. Use `-DIREE_BUILD_TRACY=ON` when building IREE, and include `<build-dir>/tracy` in your `PATH` environment variable.
-- Build `tracy-csvexport`. See https://iree.dev/developers/performance/profiling-with-tracy/#building-the-tracy-csvexport-tool
+The `--time 1` (or `-t 1` for short) option to collect timing is implemented by launching the kernel, which is then profiled using `torch.profiler`. Only the actual IREE kernel dispatch time is reported. Note: you can output `min_time (us)` to a csv file with `--csv=results.csv`.
 
 #### Misc requirements Q&A:
 
@@ -101,7 +79,3 @@ export PATH="$PWD/build/:$PATH"
   ```
 
   Please note that this is an OS bug, for context of this bug please refer to [here](https://github.com/pytorch/pytorch/issues/2575#issuecomment-1640566350).
-
-2. I run into `buffer overflow detected: terminated`, what's wrong?
-
-  **A:** Ensure that you consistently use the `iree-tracy-capture` built alongside the IREE compiler. You should either use both from `iree-base-runtime` or from local built setup, but do not combine different sources. This is a known issue when use the locally built iree compiler together with `tracy-capture` from upstream. To determine whether a failure is triggered by `tracy-capture`, try running Boo driver with `-t 0` and see if the problem still exists.

--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -4,24 +4,23 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from collections import defaultdict
 import gc
 import argparse
 from typing import Callable, Sequence
 import os
-import random
 import shlex
 import statistics
-import torch
 
-# NOTE: must not import anything form iree.turbine here because that *may*
-# cause IREE runtime to be loaded, which affects Tracy's ability to collect
-# kernel trace data. This has some negative implications, like the impossibility
-# to easily fetch the list of available ops or parser options or other
-# per-operation aspects and other unnecessary coupling, but it is caused, at
-# least in part, by IREE shipping two runtimes (clean and tracy-enabled) via PIP
-# and not doing that in local builds. See
-# https://github.com/iree-org/iree-turbine/pull/987#discussion_r2175341728
-# for more context.
+import torch
+from torch.autograd.profiler_util import FunctionEvent
+from torch.profiler import DeviceType, ProfilerActivity, profile
+
+from iree.turbine.kernel.boo.conv_exports.miopen_parser import ConvParser
+from iree.turbine.kernel.boo.driver.launch import get_launchable
+from iree.turbine.kernel.boo.exports.parser import OpCLIParser
+from iree.turbine.kernel.boo.gemm_exports.miopen_parser import GEMMParser
+from iree.turbine.kernel.boo.layer_norm_exports.miopen_parser import LayerNormParser
 
 
 def main():
@@ -80,7 +79,7 @@ command-line arguments are appended to the arguments from the file.
             continue
 
         try:
-            zones, func_name = trace_gpu(func)
+            zones, func_name = profile_gpu(func)
         except Exception as exc:
             print(f">>> ERROR: {exc}")
             csv_file.write("N.A.\n")
@@ -91,8 +90,7 @@ command-line arguments are appended to the arguments from the file.
             csv_file.write("failed to collect timing info\n")
             continue
         for zone_name in dispatch_zone_names:
-            # Convert from nanoseconds to microseconds
-            times = [t / 1000 for t in zones[zone_name]]
+            times = zones[zone_name]
             s = ">>> "
             s += f"min={min(times):.2f}us "
             s += f"max={max(times):.2f}us "
@@ -107,38 +105,12 @@ command-line arguments are appended to the arguments from the file.
         elif len(dispatch_zone_names) > 1:
             csv_file.write("multiple dispatches\n")
         else:
-            csv_file.write(f"{min(zones[dispatch_zone_names[0]]) / 1000:.2f}\n")
+            csv_file.write(f"{min(zones[dispatch_zone_names[0]]):.2f}\n")
 
 
 def run(cli_args: Sequence[str], gpu_id: int):
-    # In order to be properly traced only the subprocesses should import
-    # 'iree.runtime', so all turbine imports need to be kept local.
-
-    from iree.turbine.kernel.boo.exports.parser import OpCLIParser
-
-    def dispatch(cli_args: Sequence[str]) -> type[OpCLIParser]:
-        if any("conv" in x for x in cli_args):
-            from iree.turbine.kernel.boo.conv_exports.miopen_parser import ConvParser
-
-            return ConvParser
-        if any("layernorm" in x for x in cli_args):
-            from iree.turbine.kernel.boo.layer_norm_exports.miopen_parser import (
-                LayerNormParser,
-            )
-
-            return LayerNormParser
-        if any("gemm" in x for x in cli_args):
-            from iree.turbine.kernel.boo.gemm_exports.miopen_parser import (
-                GEMMParser,
-            )
-
-            return GEMMParser
-        raise ValueError("unsupported operation kind in " + shlex.join(cli_args))
-
-    from iree.turbine.kernel.boo.driver.launch import get_launchable
-
     print(shlex.join(cli_args))
-    parser_cls = dispatch(cli_args)
+    parser_cls = _dispatch(cli_args)
     parser = parser_cls.get_miopen_parser()
     parser.add_argument(
         "--iter", type=int, help="Number of iterations to run", default=100
@@ -204,71 +176,28 @@ def run(cli_args: Sequence[str], gpu_id: int):
     return sig.func_name
 
 
-TRACY_PORT = str(random.randint(40_000, 50_000))
+def profile_gpu(func: Callable[[], str]) -> tuple[dict[str, list[int]], str]:
+    """Profile 'func' and return the GPU zone execution times, in microseconds."""
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        result = func()
+    event_list = prof.events()
+    assert event_list is not None
+    events = defaultdict[str, list[int]](list)
+    for event in event_list:
+        assert isinstance(event, FunctionEvent)
+        if event.device_type == DeviceType.CUDA:
+            events[event.name].append(event.self_device_time_total)
+    return events, result
 
 
-def trace_gpu(func: Callable[[], str]) -> tuple[dict[str, list[int]], str]:
-    """Profile 'func' under Tracy, and return the GPU zone execution times."""
-    from multiprocessing import Process, Queue
-    import os
-    import subprocess
-    from subprocess import Popen
-    import sys
-    from tempfile import TemporaryDirectory
-
-    with TemporaryDirectory() as temp_dir:
-        trace_path = f"{temp_dir}/out.trace"
-        with Popen(
-            ["iree-tracy-capture", "-o", trace_path, "-f", "-p", TRACY_PORT],
-            stdout=subprocess.PIPE,
-            stderr=sys.stderr,
-            text=True,
-        ) as tracy:
-            queue = Queue()
-
-            def proc_fn():
-                os.environ["TRACY_PORT"] = TRACY_PORT
-                try:
-                    queue.put(func())
-                except Exception as exc:
-                    queue.put(str(exc))
-                    raise
-
-            process = Process(target=proc_fn)
-            process.start()
-            process.join()
-            result = queue.get_nowait()
-            if process.exitcode != 0:
-                raise ValueError(result)
-            try:
-                # Tracy will never exit if it fails to connect, so kill the process after some time.
-                out, err = tracy.communicate(timeout=5)
-            except subprocess.TimeoutExpired as e:
-                tracy.kill()
-                raise ValueError("Tracy failed to connect.") from e
-        if tracy.returncode:
-            raise ValueError(f"Tracy failed:\n{out}\n{err}")
-
-        csvexport = subprocess.run(
-            ["tracy-csvexport", "--gpu", trace_path],
-            capture_output=True,
-            check=True,
-            text=True,
-        )
-
-    import csv
-
-    reader = csv.reader(csvexport.stdout.splitlines())
-    header = next(reader)
-    column = {name: idx for idx, name in enumerate(header)}
-
-    zones: dict[str, list[int]] = {}
-    for row in reader:
-        name = row[column["name"]]
-        time = int(row[column["GPU execution time"]])
-        zones.setdefault(name, []).append(time)
-
-    return zones, result
+def _dispatch(cli_args: Sequence[str]) -> type[OpCLIParser]:
+    if any("conv" in x for x in cli_args):
+        return ConvParser
+    if any("layernorm" in x for x in cli_args):
+        return LayerNormParser
+    if any("gemm" in x for x in cli_args):
+        return GEMMParser
+    raise ValueError("unsupported operation kind in " + shlex.join(cli_args))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Under the hood `torch.profiler` is using ROCTracer to collect timing information. Removing the tracy dependency greatly simplifies IREE python bindings setup, and avoids various workarounds we've needed.

ROCTracer consistently reports execution times that are _shorter_ than tracy; on average by 5 - 10 microseconds.

Note that you'll likely see warnings like:
```
[W722 11:30:12.244194100 collection.cpp:1085] Warning: ROCTracer produced duplicate flow start: 5 (function operator())
```
which seems to come from some issue with the pytorch+roctracer integration: https://github.com/ROCm/roctracer/issues/111