### PR TITLE
[BOO] Update examples and test BatchNorm2d

### DIFF
--- a/iree/turbine/kernel/boo/fusion/apply.py
+++ b/iree/turbine/kernel/boo/fusion/apply.py
@@ -7,6 +7,7 @@
 from collections.abc import Sequence
 
 from torch import fx
+from operator import getitem
 
 from iree.turbine.kernel.boo.ops.graph import get_custom_graph_op
 from .schema import FusionSchema, ReplacementSchema
@@ -73,7 +74,7 @@ def _replace_with_call(
             [call]
             if len(nodes_to_replace) == 1
             else [
-                graph.call_method("__getitem__", args=(call, i))
+                graph.call_function(getitem, args=(call, i))
                 for i in range(len(nodes_to_replace))
             ]
         )

--- a/iree/turbine/kernel/boo/fusion/subgraph.py
+++ b/iree/turbine/kernel/boo/fusion/subgraph.py
@@ -67,13 +67,9 @@ def extract_fusion_subgraph_modules(
             for producer in curr_node.all_input_nodes:
                 if producer in visited_nodes:
                     continue
-                if producer.op != "call_function":
-                    continue
-                if producer.target not in node_spec.producers:
-                    continue
                 if producer in used_nodes:
                     continue
-                if not node_spec.check_filters(producer):
+                if not node_spec.is_fusable_producer(producer):
                     continue
                 # Insert producers at the front, since we want to preserve at least some weak ordering of nodes.
                 # Is it possible for this to generate an invalid ordering? (Maybe it's better to just sort node_list after).
@@ -90,13 +86,9 @@ def extract_fusion_subgraph_modules(
             for consumer in curr_node.users:
                 if consumer in visited_nodes:
                     continue
-                if consumer.op != "call_function":
-                    continue
-                if consumer.target not in node_spec.consumers:
-                    continue
                 if consumer in used_nodes:
                     continue
-                if not node_spec.check_filters(consumer):
+                if not node_spec.is_fusable_consumer(consumer):
                     continue
                 visited_nodes.add(consumer)
                 node_list.append(consumer)

--- a/iree/turbine/kernel/boo/ops/graph.py
+++ b/iree/turbine/kernel/boo/ops/graph.py
@@ -73,7 +73,15 @@ def get_custom_graph_op(
     call_function_names = "_".join(
         n.name for n in gm.graph.nodes if n.op == "call_function"
     )
-    op_name = f"fused_op_{call_function_names}_{hash}"
+
+    # Evidently, there is a limit to the number of characters in a path.
+    # We use this name for the file cache, so some modest limits need to be set.
+    # TODO: reorganize the file cache so this isn't problematic.
+    op_name = (
+        f"fused_op_{call_function_names}_{hash}"
+        if len(call_function_names) < 120
+        else f"fused_op_{hash}"
+    )
     logger.debug("Got hash str '%s' for GraphModule: \n %s", hash, gm_string)
 
     if not hasattr(torch.ops.boo, op_name):


### PR DESCRIPTION
This PR:

1. Enables using "iree_boo" backend on resnet 18 training example.
2. Fixes an issue with multi-output producer fusions. Testing resnet 18 with conv + batch norm fusion, I noticed `getitem` ops weren't getting fused into the graph and we were failing to handle the multi-output result.
3. Fixes an issue with op names getting too long for the OS to handle.
4. Adds tests for the path names and for `BatchNorm2d` with backward.
