### PR TITLE
[boo] Add a pytest fixture for enabling the file cache

### DIFF
--- a/iree/turbine/kernel/boo/runtime/cache.py
+++ b/iree/turbine/kernel/boo/runtime/cache.py
@@ -4,16 +4,19 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from collections.abc import Generator
+import contextlib
 import os
 import shutil
 
 from pathlib import Path
-from typing import Union, OrderedDict
+from typing import Any, Union, OrderedDict
 
 from ....runtime import Launchable
 
 __all__ = [
     "set_cache_dir",
+    "use_cache_dir",
     "clear_cache",
     "is_cache_enabled",
     "toggle_cache_on",
@@ -50,6 +53,26 @@ def toggle_cache_on(enabled: int):
         BOO_CACHE_ON = enabled
         return
     raise ValueError(f"expected `enabled` to be either 0 or 1, got {enabled}")
+
+
+@contextlib.contextmanager
+def use_cache_dir(cache_dir: Path | str) -> Generator[Path, Any, None]:
+    """
+    Context manager that enables the BOO file cache in the specified directory.
+    Previous cache settings are restored afterwards.
+    """
+    global BOO_CACHE_ON
+    global BOO_CACHE_DIR
+    prev_cache_on = BOO_CACHE_ON
+    prev_cache_dir = BOO_CACHE_DIR
+    try:
+        cache_dir = Path(cache_dir)
+        BOO_CACHE_ON = 1
+        BOO_CACHE_DIR = cache_dir
+        yield cache_dir
+    finally:
+        BOO_CACHE_ON = prev_cache_on
+        BOO_CACHE_DIR = prev_cache_dir
 
 
 ## runtime launchable cache

--- a/tests/kernel/boo/conftest.py
+++ b/tests/kernel/boo/conftest.py
@@ -4,7 +4,7 @@ from iree.turbine.kernel.boo.runtime import set_cache_dir, use_cache_dir
 
 
 @pytest.fixture(autouse=True)
-def _isolate_tests(tmp_path):
+def _isolate_tests(tmp_path: Path):
     # Ensure each test has its own cache directory, in case the cache is enabled.
     set_cache_dir(tmp_path / ".cache" / "turbine_kernels" / "boo")
 

--- a/tests/kernel/boo/conftest.py
+++ b/tests/kernel/boo/conftest.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import pytest
+from iree.turbine.kernel.boo.runtime import set_cache_dir, use_cache_dir
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tests(tmp_path):
+    # Ensure each test has its own cache directory, in case the cache is enabled.
+    set_cache_dir(tmp_path / ".cache" / "turbine_kernels" / "boo")
+
+
+@pytest.fixture
+def boo_cache_dir(tmp_path: Path):
+    # Enable the cache for the duration of the test.
+    with use_cache_dir(tmp_path / ".boo_cache") as cache_dir:
+        yield cache_dir

--- a/tests/kernel/boo/conftest.py
+++ b/tests/kernel/boo/conftest.py
@@ -1,3 +1,8 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from pathlib import Path
 import pytest
 from iree.turbine.kernel.boo.runtime import set_cache_dir, use_cache_dir

--- a/tests/kernel/boo/driver/cache_prepopulator_test.py
+++ b/tests/kernel/boo/driver/cache_prepopulator_test.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from iree.turbine.kernel.boo.runtime import set_cache_dir, clear_cache
 import pytest
 import torch
@@ -22,41 +21,37 @@ def _marked_xfail(*args):
 
 
 @pytest.mark.parametrize("add_gpu_only", (_marked_xfail(True), False))
-def testPopulator(add_gpu_only: bool):
-    with TemporaryDirectory() as td:
-        cache_dir = Path(td)
-        set_cache_dir(cache_dir=cache_dir)
+def testPopulator(add_gpu_only: bool, boo_cache_dir: Path):
+    from iree.turbine.kernel.boo.driver.preload import CachePopulator
 
-        from iree.turbine.kernel.boo.driver.preload import CachePopulator
+    commands = [
+        "convbfp16 -n 128 -c 128 -H 24 -W 48 -k 384 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --iter 100 --in_layout NHWC --out_layout NHWC --fil_layout NHWC",
+        "convbfp16 -n 128 -c 35 -H 48 -W 32 -k 35 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --iter 100 --in_layout NHWC --out_layout NHWC --fil_layout NHWC",
+    ]
+    if add_gpu_only:
+        commands.append("layernorm --input 2x3x4x5")
+        commands.append("gemm --a_w 32 --a_h 64 --b_w 128")
 
-        commands = [
-            "convbfp16 -n 128 -c 128 -H 24 -W 48 -k 384 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --iter 100 --in_layout NHWC --out_layout NHWC --fil_layout NHWC",
-            "convbfp16 -n 128 -c 35 -H 48 -W 32 -k 35 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --iter 100 --in_layout NHWC --out_layout NHWC --fil_layout NHWC",
-        ]
-        if add_gpu_only:
-            commands.append("layernorm --input 2x3x4x5")
-            commands.append("gemm --a_w 32 --a_h 64 --b_w 128")
+    pop = CachePopulator(commands=commands)
+    pop.run()
 
-        pop = CachePopulator(commands=commands)
-        pop.run()
+    expected = 4 if add_gpu_only else 2
+    assert (
+        len(pop.signatures) == expected
+    ), f"Number of signatures should be {expected}."
+    assert pop.commands is None, "Commands should be cleared."
+    assert pop.commands_file is None, "Commands_file should be None."
 
-        expected = 4 if add_gpu_only else 2
+    for sig in pop.signatures:
+        name = sig.func_name
+        sub_dir = set_cache_dir() / name
         assert (
-            len(pop.signatures) == expected
-        ), f"Number of signatures should be {expected}."
-        assert pop.commands is None, "Commands should be cleared."
-        assert pop.commands_file is None, "Commands_file should be None."
+            sub_dir.is_dir()
+        ), f"CachePopulator must generate sub directory {sub_dir}."
+        mlir_file = sub_dir / f"{name}.mlir"
+        assert mlir_file.is_file(), f"Expected mlir file at {mlir_file}"
+        count = len([f for f in sub_dir.glob("*.vmfb")])
+        assert count > 0, "Expected at least one vmfb."
 
-        for sig in pop.signatures:
-            name = sig.func_name
-            sub_dir = set_cache_dir() / name
-            assert (
-                sub_dir.is_dir()
-            ), f"CachePopulator must generate sub directory {sub_dir}."
-            mlir_file = sub_dir / f"{name}.mlir"
-            assert mlir_file.is_file(), f"Expected mlir file at {mlir_file}"
-            count = len([f for f in sub_dir.glob("*.vmfb")])
-            assert count > 0, "Expected at least one vmfb."
-
-        clear_cache()
-        assert not cache_dir.is_dir(), f"Expected cache dir to be cleared."
+    clear_cache()
+    assert not boo_cache_dir.is_dir(), f"Expected cache dir to be cleared."

--- a/tests/kernel/boo/fusion/integration_test.py
+++ b/tests/kernel/boo/fusion/integration_test.py
@@ -7,95 +7,81 @@
 Testing functionality of the default BOO backend.
 """
 import pytest
-import tempfile
-
-from pathlib import Path
-
 import torch
-
 from torch import fx
 from torch._dynamo.testing import EagerAndRecordGraphs
 
 from iree.turbine.dynamo.backends import boo
-from iree.turbine.kernel.boo.runtime import set_cache_dir
 
 
 def test_custom_boo_conv_used():
     """Test that we're using our custom convolution op"""
-    with tempfile.TemporaryDirectory() as td:
-        set_cache_dir(Path(td))
-        recorder = EagerAndRecordGraphs()
-        compiled_conv = torch.compile(
-            torch.ops.aten.convolution,
-            dynamic=False,
-            backend=boo.backend(nested_backend=recorder),
-        )
+    recorder = EagerAndRecordGraphs()
+    compiled_conv = torch.compile(
+        torch.ops.aten.convolution,
+        dynamic=False,
+        backend=boo.backend(nested_backend=recorder),
+    )
 
-        N, C, H, W = (1, 16, 4, 4)
-        F = 32
-        K = 3
-        input = torch.randn((N, C, H, W))
-        weight = torch.randn((F, C, K, K))
-        compiled_conv(
-            input,
-            weight,
-            None,  # bias
-            [1, 1],  # stride
-            [1, 1],  # padding
-            [1, 1],  # dilation
-            False,  # transposed
-            [10, 10],  # output_padding
-            1,  # groups
-        )
+    N, C, H, W = (1, 16, 4, 4)
+    F = 32
+    K = 3
+    input = torch.randn((N, C, H, W))
+    weight = torch.randn((F, C, K, K))
+    compiled_conv(
+        input,
+        weight,
+        None,  # bias
+        [1, 1],  # stride
+        [1, 1],  # padding
+        [1, 1],  # dilation
+        False,  # transposed
+        [10, 10],  # output_padding
+        1,  # groups
+    )
 
-        [compiled_module] = recorder.graphs
-        assert isinstance(compiled_module, fx.GraphModule)
-        [call_node] = [
-            n for n in compiled_module.graph.nodes if n.op == "call_function"
-        ]
-        # Make sure we're using 'boo.ops.convolution_replacement'. We have to do a
-        # string check unfortunately, as the target is a fused custom op that we
-        # can't inspect.
-        call_node_target_str = str(call_node.target)
-        assert call_node_target_str.startswith("boo.fused_op_convolution_replacement_")
+    [compiled_module] = recorder.graphs
+    assert isinstance(compiled_module, fx.GraphModule)
+    [call_node] = [n for n in compiled_module.graph.nodes if n.op == "call_function"]
+    # Make sure we're using 'boo.ops.convolution_replacement'. We have to do a
+    # string check unfortunately, as the target is a fused custom op that we
+    # can't inspect.
+    call_node_target_str = str(call_node.target)
+    assert call_node_target_str.startswith("boo.fused_op_convolution_replacement_")
 
 
 def test_filter_transpose_conv():
     """Test that we don't offload transpose conv to IREE/BOO."""
-    with tempfile.TemporaryDirectory() as td:
-        set_cache_dir(Path(td))
-        recorder = EagerAndRecordGraphs()
-        compiled_conv = torch.compile(
-            torch.ops.aten.convolution,
-            dynamic=False,
-            backend=boo.backend(nested_backend=recorder),
-        )
+    recorder = EagerAndRecordGraphs()
+    compiled_conv = torch.compile(
+        torch.ops.aten.convolution,
+        dynamic=False,
+        backend=boo.backend(nested_backend=recorder),
+    )
 
-        N, C, H, W = (1, 16, 4, 4)
-        F = 32
-        K = 3
-        output_shape = (N, F, H - K + 1, W - K + 1)
-        grad_output = torch.randn(output_shape)
-        weight = torch.randn((F, C, K, K))
-        compiled_conv(
-            grad_output,
-            weight,
-            None,  # bias
-            [1, 1],  # stride
-            [1, 1],  # padding
-            [1, 1],  # dilation
-            True,  # transposed
-            [0, 0],  # output_padding
-            1,  # groups
-        )
+    N, C, H, W = (1, 16, 4, 4)
+    F = 32
+    K = 3
+    output_shape = (N, F, H - K + 1, W - K + 1)
+    grad_output = torch.randn(output_shape)
+    weight = torch.randn((F, C, K, K))
+    compiled_conv(
+        grad_output,
+        weight,
+        None,  # bias
+        [1, 1],  # stride
+        [1, 1],  # padding
+        [1, 1],  # dilation
+        True,  # transposed
+        [0, 0],  # output_padding
+        1,  # groups
+    )
 
-        [compiled_module] = recorder.graphs
-        assert isinstance(compiled_module, fx.GraphModule)
-        [call_node] = [
-            n for n in compiled_module.graph.nodes if n.op == "call_function"
-        ]
-        # Make sure we didn't replace the aten convolution.
-        assert call_node.target == torch.ops.aten.convolution.default
+    [compiled_module] = recorder.graphs
+    assert isinstance(compiled_module, fx.GraphModule)
+    [call_node] = [n for n in compiled_module.graph.nodes if n.op == "call_function"]
+    # Make sure we didn't replace the aten convolution.
+    assert call_node.target == torch.ops.aten.convolution.default
 
 
 @pytest.mark.parametrize(
@@ -115,8 +101,7 @@ def test_filter_transpose_conv():
 )
 def test_output_layout(device: str, memory_format: torch.memory_format):
     """Test that we properly match the layout of pytorch's implementation."""
-    with torch.device(device) and tempfile.TemporaryDirectory() as td:
-        set_cache_dir(Path(td))
+    with torch.device(device):
         conv = torch.ops.aten.convolution
         boo_conv = torch.compile(conv, dynamic=False, backend="iree_boo")
         N, C, H, W = (1, 16, 4, 4)

--- a/tests/kernel/boo/fusion/subgraph_fusion_test.py
+++ b/tests/kernel/boo/fusion/subgraph_fusion_test.py
@@ -4,7 +4,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import tempfile
 import pytest
 
 from typing import Sequence
@@ -18,7 +17,6 @@ from torch.profiler import profile, ProfilerActivity
 from iree.turbine.dynamo.backends import boo
 from iree.turbine.kernel.boo.fusion import OpFusionSpec, FusionSchema
 from iree.turbine.kernel.boo.runtime import (
-    set_cache_dir,
     LaunchableRuntimeCache,
 )
 
@@ -103,345 +101,314 @@ class SampleModule3(torch.nn.Module):
 
 
 class TestSubgraphReplacement:
-    def testLinearLayoutHandling(self):
+    def testLinearLayoutHandling(self, boo_cache_dir: Path):
         LaunchableRuntimeCache.clear()
-        with tempfile.TemporaryDirectory() as td:
-            cache_dir = Path(td) / "testLinearLayoutHandling"
-            set_cache_dir(cache_dir)
-            schema: FusionSchema = {torch.ops.aten.addmm.default: OpFusionSpec()}
-            recorder = EagerAndRecordGraphs()
-            m = torch.compile(
-                torch.nn.Linear(in_features=64, out_features=16),
-                dynamic=False,
-                backend=boo.backend(
-                    nested_backend=recorder,
-                    fusion_schema=schema,
-                ),
-            )
-            x = torch.randn([32, 64])
-            m(x)
-            mlir_files = list(cache_dir.glob("*/*.mlir"))
-            assert len(mlir_files) == 1, f"Expected one mlir file, got {mlir_files}."
-            mlir_string = mlir_files[0].read_text()
-            assert "linalg.transpose" in mlir_string
+        schema: FusionSchema = {torch.ops.aten.addmm.default: OpFusionSpec()}
+        recorder = EagerAndRecordGraphs()
+        m = torch.compile(
+            torch.nn.Linear(in_features=64, out_features=16),
+            dynamic=False,
+            backend=boo.backend(
+                nested_backend=recorder,
+                fusion_schema=schema,
+            ),
+        )
+        x = torch.randn([32, 64])
+        m(x)
+        mlir_files = list(boo_cache_dir.glob("*/*.mlir"))
+        assert len(mlir_files) == 1, f"Expected one mlir file, got {mlir_files}."
+        mlir_string = mlir_files[0].read_text()
+        assert "linalg.transpose" in mlir_string
 
     def testReplacementWithPytorchBackward(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            m = SampleModule(in_features=16, out_features=32)
-            x = torch.ones([3, 4, 16, 16])
+        m = SampleModule(in_features=16, out_features=32)
+        x = torch.ones([3, 4, 16, 16])
 
-            fusion_schema: FusionSchema = {
-                torch.ops.aten.addmm.default: OpFusionSpec(
-                    recursive=True,
-                    consumers=(
-                        torch.ops.aten.relu.default,
-                        torch.ops.aten.view.default,
-                    ),
+        fusion_schema: FusionSchema = {
+            torch.ops.aten.addmm.default: OpFusionSpec(
+                recursive=True,
+                consumers=(
+                    torch.ops.aten.relu.default,
+                    torch.ops.aten.view.default,
                 ),
-            }
+            ),
+        }
 
-            recorder = EagerAndRecordGraphs()
-            compiled_m = torch.compile(
-                m,
-                backend=boo.backend(
-                    fusion_schema=fusion_schema, nested_backend=recorder
-                ),
-            )
-            assert isinstance(compiled_m, torch.nn.Module)
+        recorder = EagerAndRecordGraphs()
+        compiled_m = torch.compile(
+            m,
+            backend=boo.backend(fusion_schema=fusion_schema, nested_backend=recorder),
+        )
+        assert isinstance(compiled_m, torch.nn.Module)
 
-            y = compiled_m(x)
+        y = compiled_m(x)
 
-            [fused_m] = recorder.graphs
-            assert isinstance(fused_m, fx.GraphModule)
-            fused_m_print = str(fused_m)
+        [fused_m] = recorder.graphs
+        assert isinstance(fused_m, fx.GraphModule)
+        fused_m_print = str(fused_m)
 
-            assert "torch.ops.boo.fused_op_" in fused_m_print
-            assert "torch.ops.aten.addmm" not in fused_m_print
-            assert "torch.ops.aten.relu" not in fused_m_print
+        assert "torch.ops.boo.fused_op_" in fused_m_print
+        assert "torch.ops.aten.addmm" not in fused_m_print
+        assert "torch.ops.aten.relu" not in fused_m_print
 
-            assert compiled_m.linear.weight.data_ptr() == m.linear.weight.data_ptr()
-            assert compiled_m.linear.bias.data_ptr() == m.linear.bias.data_ptr()
+        assert compiled_m.linear.weight.data_ptr() == m.linear.weight.data_ptr()
+        assert compiled_m.linear.bias.data_ptr() == m.linear.bias.data_ptr()
 
-            y.sum().backward()
+        y.sum().backward()
 
-            assert compiled_m.linear.weight.grad is not None
-            assert compiled_m.linear.bias.grad is not None
+        assert compiled_m.linear.weight.grad is not None
+        assert compiled_m.linear.bias.grad is not None
 
     def testReplacementWithRecompile(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            m = SampleModule(in_features=16, out_features=32)
-            x1 = torch.ones([3, 4, 16, 16])
-            x2 = torch.ones([3, 4, 32, 16])
+        m = SampleModule(in_features=16, out_features=32)
+        x1 = torch.ones([3, 4, 16, 16])
+        x2 = torch.ones([3, 4, 32, 16])
 
-            fusion_schema: FusionSchema = {
-                torch.ops.aten.addmm.default: OpFusionSpec(
-                    recursive=True,
-                    consumers=(
-                        torch.ops.aten.relu.default,
-                        torch.ops.aten.view.default,
-                    ),
+        fusion_schema: FusionSchema = {
+            torch.ops.aten.addmm.default: OpFusionSpec(
+                recursive=True,
+                consumers=(
+                    torch.ops.aten.relu.default,
+                    torch.ops.aten.view.default,
                 ),
-            }
+            ),
+        }
 
-            recorder = EagerAndRecordGraphs()
-            compiled_m = torch.compile(
-                m,
-                dynamic=False,
-                backend=boo.backend(
-                    fusion_schema=fusion_schema, nested_backend=recorder
-                ),
-            )
+        recorder = EagerAndRecordGraphs()
+        compiled_m = torch.compile(
+            m,
+            dynamic=False,
+            backend=boo.backend(fusion_schema=fusion_schema, nested_backend=recorder),
+        )
 
-            y1 = compiled_m(x1)
+        y1 = compiled_m(x1)
 
-            compiled_m.eval()
-            with torch.no_grad():
-                y2 = compiled_m(x2)
+        compiled_m.eval()
+        with torch.no_grad():
+            y2 = compiled_m(x2)
 
-            [gm1, gm2] = recorder.graphs
+        [gm1, gm2] = recorder.graphs
 
-            outputs1 = gm1.graph.find_nodes(op="output")
-            assert len(outputs1) == 1
-            output_node1 = outputs1[0]
-            # We aren't in inference mode for the first application.
-            # This graph should return three outputs: (linear result, pre-transposed result, None)
-            assert len(output_node1.args[0]) == 3
+        outputs1 = gm1.graph.find_nodes(op="output")
+        assert len(outputs1) == 1
+        output_node1 = outputs1[0]
+        # We aren't in inference mode for the first application.
+        # This graph should return three outputs: (linear result, pre-transposed result, None)
+        assert len(output_node1.args[0]) == 3
 
-            outputs2 = gm2.graph.find_nodes(op="output")
-            assert len(outputs2) == 1
-            # The second application should not have the extra outputs being stashed for backwards.
-            output_node2 = outputs2[0]
-            assert len(output_node2.args[0]) == 1
+        outputs2 = gm2.graph.find_nodes(op="output")
+        assert len(outputs2) == 1
+        # The second application should not have the extra outputs being stashed for backwards.
+        output_node2 = outputs2[0]
+        assert len(output_node2.args[0]) == 1
 
     def testReplacementRecursiveFusion(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            m = SampleModule1(in_features=16, out_features=16)
-            x0 = torch.randn([16, 16])
-            x1 = torch.randn([16, 16])
-            schema: FusionSchema = {
-                torch.ops.aten.addmm.default: OpFusionSpec(
-                    recursive=True,
-                    producers=(torch.ops.aten.relu.default, torch.ops.aten.add.Tensor),
-                )
-            }
-            recorder = EagerAndRecordGraphs()
-            compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        m = SampleModule1(in_features=16, out_features=16)
+        x0 = torch.randn([16, 16])
+        x1 = torch.randn([16, 16])
+        schema: FusionSchema = {
+            torch.ops.aten.addmm.default: OpFusionSpec(
+                recursive=True,
+                producers=(torch.ops.aten.relu.default, torch.ops.aten.add.Tensor),
             )
-            assert isinstance(compiled_m, torch.nn.Module)
+        }
+        recorder = EagerAndRecordGraphs()
+        compiled_m = torch.compile(
+            m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        )
+        assert isinstance(compiled_m, torch.nn.Module)
 
-            y = compiled_m(x0, x1)
+        y = compiled_m(x0, x1)
 
-            [fused_m] = recorder.graphs
-            assert "torch.ops.boo.fused_op_" in str(fused_m)
-            assert "torch.ops.aten.relu" not in str(fused_m)
-            assert "torch.ops.aten.addmm" not in str(fused_m)
-            assert "torch.ops.aten.add.Tensor" not in str(fused_m)
-            assert list(y.shape) == [16, 16]
+        [fused_m] = recorder.graphs
+        assert "torch.ops.boo.fused_op_" in str(fused_m)
+        assert "torch.ops.aten.relu" not in str(fused_m)
+        assert "torch.ops.aten.addmm" not in str(fused_m)
+        assert "torch.ops.aten.add.Tensor" not in str(fused_m)
+        assert list(y.shape) == [16, 16]
 
     def testReplacementChannelsLastConv(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            m = SampleModule3().to(memory_format=torch.channels_last)
-            x = torch.ones([2, 3, 16, 16], requires_grad=False)
-            schema: FusionSchema = {
-                torch.ops.aten.convolution.default: OpFusionSpec(
-                    recursive=True,
-                    consumers=(torch.ops.aten.sigmoid.default,),
-                )
-            }
-            expected_y = m(x)
-            recorder = EagerAndRecordGraphs()
-            compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        m = SampleModule3().to(memory_format=torch.channels_last)
+        x = torch.ones([2, 3, 16, 16], requires_grad=False)
+        schema: FusionSchema = {
+            torch.ops.aten.convolution.default: OpFusionSpec(
+                recursive=True,
+                consumers=(torch.ops.aten.sigmoid.default,),
             )
-            y = compiled_m(x)
-            [fwd_gm] = recorder.graphs
-            assert "torch.ops.aten." not in str(fwd_gm)
-            assert list(y.shape) == list(expected_y.shape)
-            assert list(y.stride()) == list(expected_y.stride())
+        }
+        expected_y = m(x)
+        recorder = EagerAndRecordGraphs()
+        compiled_m = torch.compile(
+            m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        )
+        y = compiled_m(x)
+        [fwd_gm] = recorder.graphs
+        assert "torch.ops.aten." not in str(fwd_gm)
+        assert list(y.shape) == list(expected_y.shape)
+        assert list(y.stride()) == list(expected_y.stride())
 
     def testReplacementMultiOutputNode(self):
         schema: FusionSchema = {
             torch.ops.aten._native_batch_norm_legit_functional.default: OpFusionSpec(),
         }
         LaunchableRuntimeCache.clear()
-        with tempfile.TemporaryDirectory() as td:
-            cache_dir = Path(td)
-            set_cache_dir(cache_dir)
-            recorder = EagerAndRecordGraphs()
-            backend = boo.backend(nested_backend=recorder, fusion_schema=schema)
-            m = torch.compile(
-                torch.nn.BatchNorm2d(num_features=16), dynamic=False, backend=backend
-            )
+        recorder = EagerAndRecordGraphs()
+        backend = boo.backend(nested_backend=recorder, fusion_schema=schema)
+        m = torch.compile(
+            torch.nn.BatchNorm2d(num_features=16), dynamic=False, backend=backend
+        )
 
-            x = torch.randn([2, 16, 32, 32])
+        x = torch.randn([2, 16, 32, 32])
 
-            y = m(x)
+        y = m(x)
 
-            assert len(recorder.graphs) == 1, "Expected one graph."
-            assert "torch.ops.boo.fused_op" in str(
-                recorder.graphs[0]
-            ), "Expected a boo op in graph."
-            assert m.num_batches_tracked == 1, "Expected one tracked batch."
+        assert len(recorder.graphs) == 1, "Expected one graph."
+        assert "torch.ops.boo.fused_op" in str(
+            recorder.graphs[0]
+        ), "Expected a boo op in graph."
+        assert m.num_batches_tracked == 1, "Expected one tracked batch."
 
-            y.sum().backward()
+        y.sum().backward()
 
-            assert len(recorder.graphs) == 2, "Expected two graphs after backward call."
-            assert "torch.ops.boo" not in str(
-                recorder.graphs[-1]
-            ), "Expected no boo ops in backward graph."
-            assert (
-                isinstance(m.weight.grad, torch.Tensor)
-                and torch.max(torch.abs(m.weight.grad)).item() != 0
-            ), "Expected some weight gradient."
-            assert (
-                isinstance(m.bias.grad, torch.Tensor)
-                and torch.max(torch.abs(m.bias.grad)).item() != 0
-            ), "Expected some bias gradient."
+        assert len(recorder.graphs) == 2, "Expected two graphs after backward call."
+        assert "torch.ops.boo" not in str(
+            recorder.graphs[-1]
+        ), "Expected no boo ops in backward graph."
+        assert (
+            isinstance(m.weight.grad, torch.Tensor)
+            and torch.max(torch.abs(m.weight.grad)).item() != 0
+        ), "Expected some weight gradient."
+        assert (
+            isinstance(m.bias.grad, torch.Tensor)
+            and torch.max(torch.abs(m.bias.grad)).item() != 0
+        ), "Expected some bias gradient."
 
-    def testReplacementSingleDispatch(self):
+    def testReplacementSingleDispatch(self, boo_cache_dir: Path):
         LaunchableRuntimeCache.clear()
-        with tempfile.TemporaryDirectory() as td:
-            cache_dir = Path(td) / "testReplacementSingleDispatch"
-            set_cache_dir(cache_dir)
-            x = torch.ones([2, 3, 16, 16], requires_grad=False)
-            w = torch.ones([4, 3, 1, 1], requires_grad=False)
-            schema: FusionSchema = {
-                torch.ops.aten.convolution.default: OpFusionSpec(
-                    recursive=True,
-                    make_single_dispatch=True,
-                    consumers=(torch.ops.aten.sigmoid.default,),
-                )
-            }
+        x = torch.ones([2, 3, 16, 16], requires_grad=False)
+        w = torch.ones([4, 3, 1, 1], requires_grad=False)
+        schema: FusionSchema = {
+            torch.ops.aten.convolution.default: OpFusionSpec(
+                recursive=True,
+                make_single_dispatch=True,
+                consumers=(torch.ops.aten.sigmoid.default,),
+            )
+        }
 
-            @torch.compile(backend=boo.backend(fusion_schema=schema))
-            def forward(x, w):
-                return torch.ops.aten.sigmoid(torch.ops.aten.conv2d(x, w, None))
+        @torch.compile(backend=boo.backend(fusion_schema=schema))
+        def forward(x, w):
+            return torch.ops.aten.sigmoid(torch.ops.aten.conv2d(x, w, None))
 
-            y = forward(x, w)
-            cached_items = list(cache_dir.glob("*/*.mlir"))
-            assert (
-                len(cached_items) == 1
-            ), f"Expected one cached items, got {cached_items}."
-            mlir_file = cached_items[0]
-            name = mlir_file.stem
-            contents = mlir_file.read_text()
-            assert (
-                "make-single-dispatch" in contents
-            ), f"Expected single dispatch for kernel {name}."
+        y = forward(x, w)
+        cached_items = list(boo_cache_dir.glob("*/*.mlir"))
+        assert len(cached_items) == 1, f"Expected one cached items, got {cached_items}."
+        mlir_file = cached_items[0]
+        name = mlir_file.stem
+        contents = mlir_file.read_text()
+        assert (
+            "make-single-dispatch" in contents
+        ), f"Expected single dispatch for kernel {name}."
 
     def testReplacementNonRecursiveFusion(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            m = SampleModule1(in_features=16, out_features=16)
-            x0 = torch.randn([16, 16])
-            x1 = torch.randn([16, 16])
-            schema: FusionSchema = {
-                torch.ops.aten.addmm.default: OpFusionSpec(
-                    recursive=False,
-                    producers=(torch.ops.aten.relu.default, torch.ops.aten.add.Tensor),
-                )
-            }
-            recorder = EagerAndRecordGraphs()
-            compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        m = SampleModule1(in_features=16, out_features=16)
+        x0 = torch.randn([16, 16])
+        x1 = torch.randn([16, 16])
+        schema: FusionSchema = {
+            torch.ops.aten.addmm.default: OpFusionSpec(
+                recursive=False,
+                producers=(torch.ops.aten.relu.default, torch.ops.aten.add.Tensor),
             )
-            assert isinstance(compiled_m, torch.nn.Module)
-            y = compiled_m(x0, x1)
-            [fused_m] = recorder.graphs
+        }
+        recorder = EagerAndRecordGraphs()
+        compiled_m = torch.compile(
+            m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        )
+        assert isinstance(compiled_m, torch.nn.Module)
+        y = compiled_m(x0, x1)
+        [fused_m] = recorder.graphs
 
-            assert "torch.ops.aten.addmm" not in str(fused_m)
-            assert "torch.ops.boo.fused_op_" in str(fused_m)
-            assert "torch.ops.aten.relu" in str(fused_m)
-            assert list(y.shape) == [16, 16]
+        assert "torch.ops.aten.addmm" not in str(fused_m)
+        assert "torch.ops.boo.fused_op_" in str(fused_m)
+        assert "torch.ops.aten.relu" in str(fused_m)
+        assert list(y.shape) == [16, 16]
 
     def testRepeatedReplacementBackward(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            m = SampleModule2()
-            x = torch.ones([2, 3, 16, 16], requires_grad=False)
-            schema: FusionSchema = {
-                torch.ops.aten.convolution.default: OpFusionSpec(
-                    recursive=True,
-                    consumers=(torch.ops.aten.sigmoid.default,),
-                )
-            }
-
-            recorder = EagerAndRecordGraphs()
-            compiled_m = torch.compile(
-                m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        m = SampleModule2()
+        x = torch.ones([2, 3, 16, 16], requires_grad=False)
+        schema: FusionSchema = {
+            torch.ops.aten.convolution.default: OpFusionSpec(
+                recursive=True,
+                consumers=(torch.ops.aten.sigmoid.default,),
             )
+        }
 
-            y = compiled_m(x)
-            y.sum().backward()
+        recorder = EagerAndRecordGraphs()
+        compiled_m = torch.compile(
+            m, backend=boo.backend(fusion_schema=schema, nested_backend=recorder)
+        )
 
-            # Only the backward module should contain aten ops.
-            forward_module, backward_module = recorder.graphs
-            assert "torch.ops.aten." in str(backward_module)
-            assert "torch.ops.aten." not in str(forward_module)
+        y = compiled_m(x)
+        y.sum().backward()
 
-            assert isinstance(
-                compiled_m.get_parameter("layer0.0.weight").grad, torch.Tensor
-            ), f"Expected `layer0.0.weight.grad` to be a torch.Tensor, got {type(compiled_m.get_parameter('layer0.0.weight').grad)}"
-            assert isinstance(
-                compiled_m.get_parameter("layer0.0.bias").grad, torch.Tensor
-            ), f"Expected `layer0.0.bias.grad` to be a torch.Tensor, got {type(compiled_m.get_parameter('layer0.0.bias').grad)}"
-            found_zero_grad = False
-            err_msg = ""
-            for name, param in m.named_parameters():
-                param_grad_is_zero = param.grad.abs().sum().item() == 0.0
-                if param_grad_is_zero:
-                    found_zero_grad = True
-                    err_msg += f"Parameter {name} unexpectedly has zero gradient.\n"
+        # Only the backward module should contain aten ops.
+        forward_module, backward_module = recorder.graphs
+        assert "torch.ops.aten." in str(backward_module)
+        assert "torch.ops.aten." not in str(forward_module)
 
-            assert not found_zero_grad, err_msg
+        assert isinstance(
+            compiled_m.get_parameter("layer0.0.weight").grad, torch.Tensor
+        ), f"Expected `layer0.0.weight.grad` to be a torch.Tensor, got {type(compiled_m.get_parameter('layer0.0.weight').grad)}"
+        assert isinstance(
+            compiled_m.get_parameter("layer0.0.bias").grad, torch.Tensor
+        ), f"Expected `layer0.0.bias.grad` to be a torch.Tensor, got {type(compiled_m.get_parameter('layer0.0.bias').grad)}"
+        found_zero_grad = False
+        err_msg = ""
+        for name, param in m.named_parameters():
+            param_grad_is_zero = param.grad.abs().sum().item() == 0.0
+            if param_grad_is_zero:
+                found_zero_grad = True
+                err_msg += f"Parameter {name} unexpectedly has zero gradient.\n"
+
+        assert not found_zero_grad, err_msg
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU.")
     def testNestedCompilerInductor(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            device = torch.device("cuda:0")
+        device = torch.device("cuda:0")
 
-            schema: FusionSchema = {
-                torch.ops.aten.convolution.default: OpFusionSpec(
-                    recursive=True, consumers=(torch.ops.aten.sigmoid.default,)
-                )
-            }
-
-            mx = SampleModule3().to(device=device)
-            mx.eval()
-            my = SampleModule3().to(device=device)
-            my.eval()
-
-            @torch.compile(
-                dynamic=False,
-                backend=boo.backend(nested_backend="inductor", fusion_schema=schema),
+        schema: FusionSchema = {
+            torch.ops.aten.convolution.default: OpFusionSpec(
+                recursive=True, consumers=(torch.ops.aten.sigmoid.default,)
             )
-            def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-                x1 = mx(x)
-                y1 = my(y)
-                z = (x1 + y1 + 2.0) / 16.0
-                return z
+        }
 
-            gen = torch.Generator(device=device)
-            gen.manual_seed(13)
-            x = torch.randn([2, 3, 16, 16], generator=gen, device=device)
-            y = torch.randn([1, 3, 16, 16], generator=gen, device=device)
+        mx = SampleModule3().to(device=device)
+        mx.eval()
+        my = SampleModule3().to(device=device)
+        my.eval()
 
-            # Do a warmup compile/run.
-            with torch.no_grad():
-                _ = f(x, y)
+        @torch.compile(
+            dynamic=False,
+            backend=boo.backend(nested_backend="inductor", fusion_schema=schema),
+        )
+        def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            x1 = mx(x)
+            y1 = my(y)
+            z = (x1 + y1 + 2.0) / 16.0
+            return z
 
-            # Profile the next run.
-            with torch.no_grad() and profile(
-                activities=[ProfilerActivity.CUDA]
-            ) as prof:
-                z = f(x, y)
+        gen = torch.Generator(device=device)
+        gen.manual_seed(13)
+        x = torch.randn([2, 3, 16, 16], generator=gen, device=device)
+        y = torch.randn([1, 3, 16, 16], generator=gen, device=device)
 
-            key_averages = str(prof.key_averages())
-            assert "fused_op" in key_averages
-            assert "triton_poi_fused_add_div" in key_averages
+        # Do a warmup compile/run.
+        with torch.no_grad():
+            _ = f(x, y)
+
+        # Profile the next run.
+        with torch.no_grad() and profile(activities=[ProfilerActivity.CUDA]) as prof:
+            z = f(x, y)
+
+        key_averages = str(prof.key_averages())
+        assert "fused_op" in key_averages
+        assert "triton_poi_fused_add_div" in key_averages

--- a/tests/kernel/boo/ops/boo_conv_test.py
+++ b/tests/kernel/boo/ops/boo_conv_test.py
@@ -6,13 +6,12 @@
 
 import contextlib
 import pytest
-import tempfile
 
 from pathlib import Path
 
 import torch
 
-from iree.turbine.kernel.boo.runtime import set_cache_dir, LaunchableRuntimeCache
+from iree.turbine.kernel.boo.runtime import LaunchableRuntimeCache, use_cache_dir
 from iree.turbine.kernel.boo.ops import (
     boo_conv,
     enable_backward,
@@ -30,41 +29,37 @@ def use_backward():
 @pytest.mark.parametrize(
     ("x_grad", "w_grad"), ((False, False), (True, False), (False, True), (True, True))
 )
-def testBackwardCachePytorch(x_grad, w_grad):
+def testBackwardCachePytorch(x_grad, w_grad, boo_cache_dir: Path):
     LaunchableRuntimeCache.clear()
-    with tempfile.TemporaryDirectory() as td:
-        set_cache_dir(Path(td))
-        device = "cuda:0" if torch.cuda.is_available() else None
-        x = torch.ones(
-            [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=x_grad
-        )
-        w = torch.ones(
-            [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=w_grad
-        )
-        y = boo_conv(x, w, shared_layout="NCHW")
+    device = "cuda:0" if torch.cuda.is_available() else None
+    x = torch.ones(
+        [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=x_grad
+    )
+    w = torch.ones(
+        [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=w_grad
+    )
+    y = boo_conv(x, w, shared_layout="NCHW")
 
-        context = (
-            contextlib.nullcontext()
-            if x_grad or w_grad
-            else pytest.raises(RuntimeError)
-        )
-        with context:
-            y.sum().backward()
+    context = (
+        contextlib.nullcontext() if x_grad or w_grad else pytest.raises(RuntimeError)
+    )
+    with context:
+        y.sum().backward()
 
-        items = [x.name for x in Path(td).glob("*/")]
+    items = [x.name for x in boo_cache_dir.glob("*/")]
 
-        assert (
-            "conv_2d_float32_forward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-            in items
-        )
-        assert (
-            "conv_2d_float32_weight_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-            not in items
-        )
-        assert (
-            "conv_2d_float32_input_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-            not in items
-        )
+    assert (
+        "conv_2d_float32_forward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+        in items
+    )
+    assert (
+        "conv_2d_float32_weight_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+        not in items
+    )
+    assert (
+        "conv_2d_float32_input_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+        not in items
+    )
 
 
 def _marked_xfail(*args):
@@ -87,45 +82,41 @@ def _marked_xfail(*args):
         _marked_xfail(True, True),
     ),
 )
-def testBackwardCacheBoo(x_grad, w_grad):
+def testBackwardCacheBoo(x_grad, w_grad, boo_cache_dir: Path):
     LaunchableRuntimeCache.clear()
-    with tempfile.TemporaryDirectory() as td:
-        set_cache_dir(Path(td))
-        device = "cuda:0" if torch.cuda.is_available() else None
-        x = torch.ones(
-            [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=x_grad
-        )
-        w = torch.ones(
-            [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=w_grad
-        )
-        y = boo_conv(x, w, shared_layout="NCHW")
+    device = "cuda:0" if torch.cuda.is_available() else None
+    x = torch.ones(
+        [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=x_grad
+    )
+    w = torch.ones(
+        [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=w_grad
+    )
+    y = boo_conv(x, w, shared_layout="NCHW")
 
-        context = (
-            contextlib.nullcontext()
-            if x_grad or w_grad
-            else pytest.raises(RuntimeError)
-        )
-        with context:
-            y.sum().backward()
+    context = (
+        contextlib.nullcontext() if x_grad or w_grad else pytest.raises(RuntimeError)
+    )
+    with context:
+        y.sum().backward()
 
-        items = [x.name for x in Path(td).glob("*/")]
+    items = [x.name for x in boo_cache_dir.glob("*/")]
 
-        assert (
-            "conv_2d_float32_forward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-            in items
-        )
+    assert (
+        "conv_2d_float32_forward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+        in items
+    )
 
-        _validate = lambda name, expected: (
-            (name in items) if expected else (name not in items)
-        )
-        assert _validate(
-            "conv_2d_float32_weight_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g",
-            w_grad,
-        )
-        assert _validate(
-            "conv_2d_float32_input_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g",
-            x_grad,
-        )
+    _validate = lambda name, expected: (
+        (name in items) if expected else (name not in items)
+    )
+    assert _validate(
+        "conv_2d_float32_weight_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+        w_grad,
+    )
+    assert _validate(
+        "conv_2d_float32_input_backward_1x1x16x16_nchw_1x1x2x2_fchw_nfhw_1x1s_0x0p_1x1d_1g",
+        x_grad,
+    )
 
 
 @pytest.mark.usefixtures("use_backward")
@@ -136,54 +127,48 @@ class TestBooConv:
         LaunchableRuntimeCache.set_cache_limit(0)
 
     def testBooConvNonDefault(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            device = "cuda:0" if torch.cuda.is_available() else None
-            x = torch.ones([2, 16, 16, 3], dtype=torch.float32, device=device)
-            w = torch.ones([4, 2, 2, 3], dtype=torch.float32, device=device)
-            y = boo_conv(x, w, shared_layout="NHWC", stride=2, dilation=2)
-            y_exp = torch.ones_like(y, device=device) * 12.0
-            assert (
-                round(torch.abs(y - y_exp).sum().item(), ndigits=7) == 0.0
-            ), f"Expected output to be close to splat 12.0 tensor. Got {y}"
+        device = "cuda:0" if torch.cuda.is_available() else None
+        x = torch.ones([2, 16, 16, 3], dtype=torch.float32, device=device)
+        w = torch.ones([4, 2, 2, 3], dtype=torch.float32, device=device)
+        y = boo_conv(x, w, shared_layout="NHWC", stride=2, dilation=2)
+        y_exp = torch.ones_like(y, device=device) * 12.0
+        assert (
+            round(torch.abs(y - y_exp).sum().item(), ndigits=7) == 0.0
+        ), f"Expected output to be close to splat 12.0 tensor. Got {y}"
 
     @pytest.mark.xfail(
         condition=not torch.cuda.is_available(),
         reason="CPU backward compile failure. Remove when #998 is resolved.",
     )
     def testBooConvBackwardDefault(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            device = "cuda:0" if torch.cuda.is_available() else None
-            x = torch.ones(
-                [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=True
-            )
-            w = torch.ones(
-                [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=True
-            )
-            torch.autograd.gradcheck(boo_conv, (x, w), atol=1e-5, eps=1e-3)
+        device = "cuda:0" if torch.cuda.is_available() else None
+        x = torch.ones(
+            [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=True
+        )
+        w = torch.ones(
+            [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=True
+        )
+        torch.autograd.gradcheck(boo_conv, (x, w), atol=1e-5, eps=1e-3)
 
     @pytest.mark.xfail(
         condition=not torch.cuda.is_available(),
         reason="CPU backward compile failure. Remove when #998 is resolved.",
     )
     def testBooConvBackwardsWithBias(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            device = "cuda:0" if torch.cuda.is_available() else None
-            x = torch.ones(
-                [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=True
-            )
-            w = torch.ones(
-                [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=True
-            )
-            b = torch.ones([1], dtype=torch.float32, device=device, requires_grad=True)
-            torch.autograd.gradcheck(boo_conv, (x, w, b), atol=1e-5, eps=1e-3)
+        device = "cuda:0" if torch.cuda.is_available() else None
+        x = torch.ones(
+            [1, 1, 16, 16], dtype=torch.float32, device=device, requires_grad=True
+        )
+        w = torch.ones(
+            [1, 1, 2, 2], dtype=torch.float32, device=device, requires_grad=True
+        )
+        b = torch.ones([1], dtype=torch.float32, device=device, requires_grad=True)
+        torch.autograd.gradcheck(boo_conv, (x, w, b), atol=1e-5, eps=1e-3)
 
     @pytest.mark.xfail(
         reason="CPU backward compile failure. Remove when #998 is resolved."
     )
-    def testBooConvBackwardsAmpContextCPU(self):
+    def testBooConvBackwardsAmpContextCPU(self, tmp_path: Path):
         """We expect this to not perform autocasting."""
 
         device = None
@@ -194,16 +179,14 @@ class TestBooConv:
             [1, 1, 4, 4], dtype=torch.float32, device=device, requires_grad=True
         )
 
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-
+        with use_cache_dir(tmp_path / "boo_cache_0") as boo_cache_0:
             with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
                 y = boo_conv(x, w, shared_layout="NCHW")
                 loss = y.sum()
 
             loss.backward()
 
-            items = [x.name for x in Path(td).glob("*/")]
+            items = [x.name for x in boo_cache_0.glob("*/")]
             expected_dtype_str = "float32"
             unexpected_dtype_str = "bfloat16"
             assert (
@@ -228,16 +211,14 @@ class TestBooConv:
             assert w.grad.dtype == torch.float32
             assert w.dtype == torch.float32
 
-        with tempfile.TemporaryDirectory() as td_0:
-            set_cache_dir(Path(td_0))
-
+        with use_cache_dir(tmp_path / "boo_cache_1") as boo_cache_1:
             with torch.amp.autocast(device_type="cpu", dtype=torch.bfloat16):
                 y = boo_conv(x, w, shared_layout="NCHW")
                 loss = y.sum()
 
             loss.backward()
 
-            items = [x.name for x in Path(td_0).glob("*/")]
+            items = [x.name for x in boo_cache_1.glob("*/")]
             expected_dtype_str = "bfloat16"
             unexpected_dtype_str = "float32"
             assert (
@@ -263,42 +244,40 @@ class TestBooConv:
             assert w.dtype == torch.float32
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU to test.")
-    def testBooConvBackwardsAmpContextCUDA(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-            device = "cuda:0"
-            x = torch.ones(
-                [1, 1, 32, 32], dtype=torch.float32, device=device, requires_grad=True
-            )
-            w = torch.ones(
-                [1, 1, 4, 4], dtype=torch.float32, device=device, requires_grad=True
-            )
-            with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
-                y = boo_conv(x, w, shared_layout="NCHW")
-                loss = y.sum()
+    def testBooConvBackwardsAmpContextCUDA(self, boo_cache_dir: Path):
+        device = "cuda:0"
+        x = torch.ones(
+            [1, 1, 32, 32], dtype=torch.float32, device=device, requires_grad=True
+        )
+        w = torch.ones(
+            [1, 1, 4, 4], dtype=torch.float32, device=device, requires_grad=True
+        )
+        with torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16):
+            y = boo_conv(x, w, shared_layout="NCHW")
+            loss = y.sum()
 
-            loss.backward()
-            items = [x.name for x in Path(td).glob("*/")]
-            expected_dtype_str = "bfloat16"
-            unexpected_dtype_str = "float32"
-            assert (
-                f"conv_2d_{unexpected_dtype_str}_forward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-                not in items
-            )
-            assert (
-                f"conv_2d_{expected_dtype_str}_forward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-                in items
-            )
-            assert (
-                f"conv_2d_{expected_dtype_str}_weight_backward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-                in items
-            )
-            assert (
-                f"conv_2d_{expected_dtype_str}_input_backward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
-                in items
-            )
-            # Make sure we got back the correct original dtypes.
-            assert y.dtype == torch.bfloat16
-            assert x.grad.dtype == torch.float32
-            assert w.grad.dtype == torch.float32
-            assert w.dtype == torch.float32
+        loss.backward()
+        items = [x.name for x in boo_cache_dir.glob("*/")]
+        expected_dtype_str = "bfloat16"
+        unexpected_dtype_str = "float32"
+        assert (
+            f"conv_2d_{unexpected_dtype_str}_forward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+            not in items
+        )
+        assert (
+            f"conv_2d_{expected_dtype_str}_forward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+            in items
+        )
+        assert (
+            f"conv_2d_{expected_dtype_str}_weight_backward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+            in items
+        )
+        assert (
+            f"conv_2d_{expected_dtype_str}_input_backward_1x1x32x32_nchw_1x1x4x4_fchw_nfhw_1x1s_0x0p_1x1d_1g"
+            in items
+        )
+        # Make sure we got back the correct original dtypes.
+        assert y.dtype == torch.bfloat16
+        assert x.grad.dtype == torch.float32
+        assert w.grad.dtype == torch.float32
+        assert w.dtype == torch.float32

--- a/tests/kernel/boo/ops/graph_ops_test.py
+++ b/tests/kernel/boo/ops/graph_ops_test.py
@@ -4,7 +4,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import tempfile
 import pytest
 
 from pathlib import Path
@@ -12,7 +11,7 @@ from pathlib import Path
 import torch
 
 from iree.turbine.kernel.boo.ops import get_custom_graph_op
-from iree.turbine.kernel.boo.runtime import set_cache_dir, LaunchableRuntimeCache
+from iree.turbine.kernel.boo.runtime import LaunchableRuntimeCache
 
 
 class SampleModule(torch.nn.Module):
@@ -53,51 +52,43 @@ class TestGraphOps:
         LaunchableRuntimeCache.set_cache_limit(0)
 
     def testLongPathName(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
+        m = LongFusionSample(16, 32, 10)
+        x = torch.ones([3, 3, 16, 16])
 
-            m = LongFusionSample(16, 32, 10)
-            x = torch.ones([3, 3, 16, 16])
-
-            with torch.no_grad():
-                exported = torch.export.export(m, args=(x,))
-
-            gm = exported.graph_module
-
-            # Get a graph op (note, model params are pytree flattened as args).
-            graph_op = get_custom_graph_op(gm)
-            assert len(graph_op._qualified_op_name) < 256 - len(
-                ".mlir"
-            ), f"Name: '{graph_op._qualified_op_name}' is too long."
-
-    def testForwardOnlyOp(self):
-        with tempfile.TemporaryDirectory() as td:
-            set_cache_dir(Path(td))
-
-            m = SampleModule(16, 32)
-            x = torch.ones([3, 3, 16, 16])
-
-            # Export a graph.
+        with torch.no_grad():
             exported = torch.export.export(m, args=(x,))
-            gm = exported.graph_module
 
-            # Get a graph op (note, model params are pytree flattened as args).
-            graph_op = get_custom_graph_op(gm)
+        gm = exported.graph_module
 
-            # Apply the graph op.
-            y = graph_op(m.linear.weight, m.linear.bias, x)
-            assert list(y.shape) == [3, 3, 16, 32]
-            # Since we exported with static dims, applying to an input with a different shape should throw an error.
-            new_x = torch.ones([4, 3, 32, 16])
-            with pytest.raises(
-                ValueError, match=r"INVALID_ARGUMENT; tensor shape dimension 0 mismatch"
-            ):
-                new_y = graph_op(m.linear.weight, m.linear.bias, new_x)
+        # Get a graph op (note, model params are pytree flattened as args).
+        graph_op = get_custom_graph_op(gm)
+        assert len(graph_op._qualified_op_name) < 256 - len(
+            ".mlir"
+        ), f"Name: '{graph_op._qualified_op_name}' is too long."
 
-            # Verify caching.
-            op_name = graph_op._qualified_op_name.split("::")[-1]
-            cache_subdir_names = [p.name for p in Path(td).glob("*/")]
-            expected_dir_name_0 = (
-                op_name + "_32x16xfloat32_32xfloat32_3x3x16x16xfloat32"
-            )
-            assert expected_dir_name_0 in cache_subdir_names
+    def testForwardOnlyOp(self, boo_cache_dir: Path):
+        m = SampleModule(16, 32)
+        x = torch.ones([3, 3, 16, 16])
+
+        # Export a graph.
+        exported = torch.export.export(m, args=(x,))
+        gm = exported.graph_module
+
+        # Get a graph op (note, model params are pytree flattened as args).
+        graph_op = get_custom_graph_op(gm)
+
+        # Apply the graph op.
+        y = graph_op(m.linear.weight, m.linear.bias, x)
+        assert list(y.shape) == [3, 3, 16, 32]
+        # Since we exported with static dims, applying to an input with a different shape should throw an error.
+        new_x = torch.ones([4, 3, 32, 16])
+        with pytest.raises(
+            ValueError, match=r"INVALID_ARGUMENT; tensor shape dimension 0 mismatch"
+        ):
+            new_y = graph_op(m.linear.weight, m.linear.bias, new_x)
+
+        # Verify caching.
+        op_name = graph_op._qualified_op_name.split("::")[-1]
+        cache_subdir_names = [p.name for p in boo_cache_dir.glob("*/")]
+        expected_dir_name_0 = op_name + "_32x16xfloat32_32xfloat32_3x3x16x16xfloat32"
+        assert expected_dir_name_0 in cache_subdir_names


### PR DESCRIPTION
This adds a `boo_cache_dir` pytest fixture, which enables the file cache in a test-local directory for the duration of the test, and returns the path so that the test can inspect the contents. This avoids each test needing to set up its own temporary directory. A following change will turn off the file cache by default, so only tests that explicitly request `boo_cache_dir` (or turn on the cache internally) will have file caching enabled.

A change in behaviour here is that the cache is left intact after test execution finishes, which allows for easier debugging. By default pytest dumps test files under `/tmp/pytest-of-$USER/pytest-current/`

This also adds an `autouse` fixture which sets the BOO cache directory to a test-local directory, in order to isolate tests from each other.