### PR TITLE
[runtime] advance timeline after a failed invocation

### DIFF
--- a/iree/turbine/runtime/invoke.py
+++ b/iree/turbine/runtime/invoke.py
@@ -59,7 +59,15 @@ def invoke_vm_function(
 
     # Invoke.
     start = timer()
-    vm_context.invoke(vm_function, arg_list, ret_list)
+    try:
+        vm_context.invoke(vm_function, arg_list, ret_list)
+    except:
+        if is_async:
+            # For testing, we may not want to abort a thread after a failed launch.
+            # Signaling here will allow the main timeline to progress.
+            signal_fence.signal()
+            device.finalize_iree_action(external_timepoint)
+        raise
 
     if is_async:
         device.finalize_iree_action(external_timepoint)

--- a/iree/turbine/runtime/op_reg/eager.py
+++ b/iree/turbine/runtime/op_reg/eager.py
@@ -100,9 +100,8 @@ def eager_dispatch(ksel: KernelSelection):
 
     # Compile.
     # TODO: We can do compilation asynchronously with the device movement
-    # TODO: Investigate issues with calling async directly on CPU. See discussion at https://github.com/iree-org/iree-turbine/pull/1110
     vm_context, vm_f, config = compile_standalone_kernel(
-        device, ksel, async_invocations=not device.sync
+        device, ksel, async_invocations=True
     )
 
     # Build the concrete args, issuing device movement as necessary.

--- a/tests/kernel/boo/ops/graph_ops_test.py
+++ b/tests/kernel/boo/ops/graph_ops_test.py
@@ -81,6 +81,9 @@ class TestGraphOps:
         ):
             new_y = graph_op(m.linear.weight, m.linear.bias, new_x)
 
+        # Verify timeline progressed after failure.
+        y = graph_op(m.linear.weight, m.linear.bias, x)
+
         # Verify caching.
         op_name = graph_op._qualified_op_name.split("::")[-1]
         cache_subdir_names = [p.name for p in boo_cache_dir.glob("*/")]


### PR DESCRIPTION
PR #1110 resulted in test hangs for CPU launches. 

I found out this was because of an expected failed launch in one of our tests, which prevented progress on the main timeline.

This change enables progressing the main timeline before raising an exception due to a failed launch.