### PR TITLE
[aot] Use flow.parameter.named instead of stream.parameter.named

### DIFF
--- a/iree/turbine/aot/support/ir_utils.py
+++ b/iree/turbine/aot/support/ir_utils.py
@@ -320,7 +320,7 @@ class ModuleBuilder:
                 external_name_attr = StringAttr.get(external_name)
                 # TODO: Have real Python builders for this.
                 ir_attrs["initial_value"] = Attribute.parse(
-                    f"#stream.parameter.named<{external_scope_attr}::{external_name_attr}> : {tensor_type}"
+                    f"#flow.parameter.named<{external_scope_attr}::{external_name_attr}> : {tensor_type}"
                 )
             elif attrs.uninitialized:
                 # Emit unitialized initial_value to signal that the memory

--- a/iree/turbine/transforms/general/rename_parameters.py
+++ b/iree/turbine/transforms/general/rename_parameters.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""This pass will rename any #stream.parameter.named<> attributes on globals.
+"""This pass will rename any #flow.parameter.named<> attributes on globals.
 
 It can either be used as-is or by sub-classing (i.e. in a model specific
 subclass that renames from A->B, etc).
@@ -50,7 +50,7 @@ class RenameParametersPass(Pass):
             # Make a prototype named parameter attribute so we can get its
             # typeid.
             self.parameter_attr_typeid = Attribute.parse(
-                '#stream.parameter.named<""::"">'
+                '#flow.parameter.named<""::"">'
             ).typeid
 
     def run(self):
@@ -89,13 +89,13 @@ class RenameParametersPass(Pass):
             if scoped_name[0] is None:
                 name = StringAttr.get(scoped_name[1])
                 return Attribute.parse(
-                    f"#stream.parameter.named<{name}> : {parameter_attr.type}"
+                    f"#flow.parameter.named<{name}> : {parameter_attr.type}"
                 )
             else:
                 scope = StringAttr.get(scoped_name[0])
                 name = StringAttr.get(scoped_name[1])
                 return Attribute.parse(
-                    f"#stream.parameter.named<{scope}::{name}> : {parameter_attr.type}"
+                    f"#flow.parameter.named<{scope}::{name}> : {parameter_attr.type}"
                 )
 
         # Check the rename map.
@@ -125,7 +125,7 @@ def _parse_parameter_attr(attr: Attribute) -> Optional[List[str]]:
     # vs string parsing them.
     # TODO: The parameter attribute correctly parses C escapes but prints unescaped :(
     asm = str(attr)
-    PREFIX = "#stream.parameter.named<"
+    PREFIX = "#flow.parameter.named<"
     STR_PATTERN = re.compile(r'"(.*?)(?!\\)"')
     if asm.startswith(PREFIX):
         asm = asm[len(PREFIX) :]

--- a/iree/turbine/transforms/quantization/mm_group_quant.py
+++ b/iree/turbine/transforms/quantization/mm_group_quant.py
@@ -70,9 +70,9 @@ class TransposedMMMatcher(NamedOpMatcher[TransposedMMResult]):
 # TODO (ian): Make more generalizable using RenameParametersPass. Currently hardcoded for brevitas quantization
 GROUP_MATMUL_TEMPLATE = r"""
 module {{
-  util.global private @{param_name} {{noinline}} = #stream.parameter.named<"model"::"{param_name}"> : tensor<{k}x{n_div}xi8>
-  util.global private @{param_name}.quant.scale {{noinline}} = #stream.parameter.named<"model"::"{param_name}_scale"> : tensor<{k}x{group0}x{element_type}>
-  util.global private @{param_name}.quant.zero_point {{noinline}} = #stream.parameter.named<"model"::"{param_name}_zp"> : tensor<{k}x{group0}x{element_type}>
+  util.global private @{param_name} {{noinline}} = #flow.parameter.named<"model"::"{param_name}"> : tensor<{k}x{n_div}xi8>
+  util.global private @{param_name}.quant.scale {{noinline}} = #flow.parameter.named<"model"::"{param_name}_scale"> : tensor<{k}x{group0}x{element_type}>
+  util.global private @{param_name}.quant.zero_point {{noinline}} = #flow.parameter.named<"model"::"{param_name}_zp"> : tensor<{k}x{group0}x{element_type}>
 
   func.func private @compute_mm_group_quant(%a : tensor<{m}x{n}x{element_type}>) -> tensor<{m}x{k}x{element_type}> {{
     %c0 = arith.constant 0 : index

--- a/tests/aot/api_test.py
+++ b/tests/aot/api_test.py
@@ -108,11 +108,11 @@ class ExportAPI(unittest.TestCase):
         asm = str(exported.mlir_module)
         self.assertNotIn("dense_resource", asm)
         self.assertIn(
-            'util.global private @__auto.classifier.weight = #stream.parameter.named<"model"::"classifier.weight">',
+            'util.global private @__auto.classifier.weight = #flow.parameter.named<"model"::"classifier.weight">',
             asm,
         )
         self.assertIn(
-            'util.global private @__auto.classifier.bias = #stream.parameter.named<"model"::"classifier.bias">',
+            'util.global private @__auto.classifier.bias = #flow.parameter.named<"model"::"classifier.bias">',
             asm,
         )
 

--- a/tests/aot/globals_test.py
+++ b/tests/aot/globals_test.py
@@ -332,11 +332,11 @@ class GlobalsTest(unittest.TestCase):
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
-            '#stream.parameter.named<"model"::"params.classifier.weight"> : tensor<30x20xf32>',
+            '#flow.parameter.named<"model"::"params.classifier.weight"> : tensor<30x20xf32>',
             module_str,
         )
         self.assertIn(
-            '#stream.parameter.named<"model"::"params.classifier.bias"> : tensor<30xf32>',
+            '#flow.parameter.named<"model"::"params.classifier.bias"> : tensor<30xf32>',
             module_str,
         )
 
@@ -358,11 +358,11 @@ class GlobalsTest(unittest.TestCase):
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
-            '#stream.parameter.named<"foo"::"PARAMS.CLASSIFIER.WEIGHT"> : tensor<30x20xf32>',
+            '#flow.parameter.named<"foo"::"PARAMS.CLASSIFIER.WEIGHT"> : tensor<30x20xf32>',
             module_str,
         )
         self.assertIn(
-            '#stream.parameter.named<"foo"::"PARAMS.CLASSIFIER.BIAS"> : tensor<30xf32>',
+            '#flow.parameter.named<"foo"::"PARAMS.CLASSIFIER.BIAS"> : tensor<30xf32>',
             module_str,
         )
 
@@ -387,11 +387,11 @@ class GlobalsTest(unittest.TestCase):
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
-            '#stream.parameter.named<"foo"::"WEIGHT"> : tensor<30x20xf32>',
+            '#flow.parameter.named<"foo"::"WEIGHT"> : tensor<30x20xf32>',
             module_str,
         )
         self.assertIn(
-            '#stream.parameter.named<"foo"::"params.classifier.bias"> : tensor<30xf32>',
+            '#flow.parameter.named<"foo"::"params.classifier.bias"> : tensor<30xf32>',
             module_str,
         )
 

--- a/tests/aot/params_test.py
+++ b/tests/aot/params_test.py
@@ -97,11 +97,11 @@ class ParamsTest(unittest.TestCase):
         output = export(m, args=(torch.empty([128, 20]),))
         asm = str(output.mlir_module)
         self.assertIn(
-            'util.global private @__auto.classifier.weight = #stream.parameter.named<"model"::"classifier.weight">',
+            'util.global private @__auto.classifier.weight = #flow.parameter.named<"model"::"classifier.weight">',
             asm,
         )
         self.assertIn(
-            'util.global private @__auto.classifier.bias = #stream.parameter.named<"model"::"classifier.bias">',
+            'util.global private @__auto.classifier.bias = #flow.parameter.named<"model"::"classifier.bias">',
             asm,
         )
         # Verify that the small tensor is inlined.

--- a/tests/runtime/launch_test.py
+++ b/tests/runtime/launch_test.py
@@ -35,7 +35,7 @@ func.func @main(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi32> {
 
 MLIR_PARAMS_ASM = r"""
 module @test_module {
-util.global private @param = #stream.parameter.named<"param"> : tensor<4xi32>
+util.global private @param = #flow.parameter.named<"param"> : tensor<4xi32>
 func.func @main(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi32> {
     %0 = arith.muli %arg0, %arg1 : tensor<4xi32>
     %param = util.global.load @param : tensor<4xi32>

--- a/tests/transforms/general/rename_parameters_test.py
+++ b/tests/transforms/general/rename_parameters_test.py
@@ -19,9 +19,9 @@ from iree.turbine.transforms.general import rename_parameters
 
 SIMPLE_GLOBALS_ASM = r"""
 module {
-    util.global private @_params.classifier.default {noinline} = #stream.parameter.named<"default"> : tensor<30xf32>
-    util.global private @_params.classifier.weight {noinline} = #stream.parameter.named<"foo"::"WEIGHT"> : tensor<30x20xf32>
-    util.global private @_params.classifier.bias {noinline} = #stream.parameter.named<"foo"::"params.classifier.bias"> : tensor<30xf32>
+    util.global private @_params.classifier.default {noinline} = #flow.parameter.named<"default"> : tensor<30xf32>
+    util.global private @_params.classifier.weight {noinline} = #flow.parameter.named<"foo"::"WEIGHT"> : tensor<30x20xf32>
+    util.global private @_params.classifier.bias {noinline} = #flow.parameter.named<"foo"::"params.classifier.bias"> : tensor<30xf32>
     util.global private @_params.classifier.other {noinline} = dense<0.0> : tensor<30xf32>
     util.global private @_uninitialized {noinline} : tensor<30xf32>
 }
@@ -45,15 +45,15 @@ class RenameTest(unittest.TestCase):
             module_asm = str(module_op)
             print(module_asm)
             self.assertIn(
-                '@_params.classifier.default {noinline} = #stream.parameter.named<"XXX"::"YYY"> : tensor<30xf32>',
+                '@_params.classifier.default {noinline} = #flow.parameter.named<"XXX"::"YYY"> : tensor<30xf32>',
                 module_asm,
             )
             self.assertIn(
-                '@_params.classifier.weight {noinline} = #stream.parameter.named<"foo"::"weight"> : tensor<30x20xf32>',
+                '@_params.classifier.weight {noinline} = #flow.parameter.named<"foo"::"weight"> : tensor<30x20xf32>',
                 module_asm,
             )
             self.assertIn(
-                '@_params.classifier.bias {noinline} = #stream.parameter.named<"bar"::"BIAS"> : tensor<30xf32>',
+                '@_params.classifier.bias {noinline} = #flow.parameter.named<"bar"::"BIAS"> : tensor<30xf32>',
                 module_asm,
             )
 


### PR DESCRIPTION
Frontends should not emit stream.parameter.named since https://github.com/iree-org/iree/pull/17303#issuecomment-2099354883