### PR TITLE
[boo] report unknown op-specific arguments

### DIFF
--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -21,6 +21,7 @@ from torch.profiler import DeviceType, ProfilerActivity, profile
 from iree.turbine.kernel.boo.exports.signature import OpSignature
 from iree.turbine.kernel.boo.driver.launch import get_launchable
 from iree.turbine.kernel.boo.op_exports.registry import BooOpRegistry
+from iree.turbine.kernel.boo.driver.utils import get_timing_parser
 
 ZoneData = dict[str, list[float]]
 
@@ -93,16 +94,6 @@ command-line arguments are appended to the arguments from the file.
     return parser
 
 
-def _get_timing_parser() -> argparse.ArgumentParser:
-    """This parser separates out timing-specific args from miopen commands."""
-    timing_parser = argparse.ArgumentParser()
-    timing_parser.add_argument("--time", "-t", type=int, help="Enable timing")
-    timing_parser.add_argument(
-        "--iter", type=int, help="Number of iterations to run", default=100
-    )
-    return timing_parser
-
-
 def main():
     # Parse input cli args into global driver args and miopen-style commands.
     driver_parser = _get_main_driver_parser()
@@ -135,7 +126,7 @@ def main():
             csv_headers.extend([f"{b} {stat}"])
     csv_file.write(",".join(csv_headers) + "\n")
 
-    timing_parser = _get_timing_parser()
+    timing_parser = get_timing_parser()
 
     devices = _get_devices(meta_args.gpu_id)
     testCount = 0

--- a/iree/turbine/kernel/boo/driver/utils.py
+++ b/iree/turbine/kernel/boo/driver/utils.py
@@ -5,8 +5,19 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from pathlib import Path
+import argparse
 
 from iree.turbine.kernel.boo.op_exports.registry import BooOpRegistry
+
+
+def get_timing_parser() -> argparse.ArgumentParser:
+    """This parser separates out timing-specific args from MIOpen commands."""
+    timing_parser = argparse.ArgumentParser()
+    timing_parser.add_argument("--time", "-t", type=int, help="Enable timing")
+    timing_parser.add_argument(
+        "--iter", type=int, help="Number of iterations to run", default=100
+    )
+    return timing_parser
 
 
 def load_commands(commands_file: str) -> list[str]:

--- a/iree/turbine/kernel/boo/exports/parser.py
+++ b/iree/turbine/kernel/boo/exports/parser.py
@@ -27,7 +27,7 @@ class OpCLIParser(ABC):
     def command_to_signature(cls, command: str) -> OpSignature:
         """Convert a textual command to signature by parsing it."""
         parser = cls.get_miopen_parser()
-        args, _ = parser.parse_known_args(command.split())
+        args = parser.parse_args(command.split())
         return cls.get_signature(args)
 
     @classmethod


### PR DESCRIPTION
Don't ignore failure to parse certain arguments in the op-specific parser, report them instead. This may help cathing misspelled or otherwise incorrect arguments being passed to the driver. This parser runs last so all other arguments must have been consumed already.