### PR TITLE
[BOO] Remove alias for `--verbose` in driver

### DIFF
--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -84,7 +84,6 @@ command-line arguments are appended to the arguments from the file.
         help="Use a splat value for inputs (defaults to random values).",
     )
     parser.add_argument(
-        "-v",
         "--verbose",
         action="store_true",
         default=False,


### PR DESCRIPTION
There is a conflict with `-v` in the conv parser, so we can't use this. Removing this alias should resolve #1147