### PR TITLE
Add support for tensor transfers in eager to allow for multi-device execution

### DIFF
--- a/iree/turbine/aot/tensor_traits.py
+++ b/iree/turbine/aot/tensor_traits.py
@@ -17,17 +17,12 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True)
 class DeviceAffinity:
     """This is used to provide device affinities to exported function arguments."""
 
-    def __init__(self, ordinal: int, queues: Optional[list] = None):
-        self.ordinal = ordinal
-        self.queues = queues
-
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, DeviceAffinity):
-            return False
-        return self.ordinal == other.ordinal and self.queues == other.queues
+    ordinal: int
+    queues: Optional[list] = None
 
     def __repr__(self) -> str:
         if self.queues is None:

--- a/iree/turbine/ops/iree.py
+++ b/iree/turbine/ops/iree.py
@@ -5,10 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Custom ops for built-in IREE functionality."""
-from typing import cast
+from contextlib import AbstractContextManager
+from copy import deepcopy
+from typing import cast, TYPE_CHECKING
 import numpy as np
 import os
 import torch.fx
+
 
 from ..support.ir_imports import (
     Attribute,
@@ -18,6 +21,7 @@ from ..support.ir_imports import (
     flow_d,
     tensor_d,
 )
+from ..support.torch import torch_device_equal
 
 from ..runtime.op_reg import (
     CustomOp,
@@ -26,6 +30,9 @@ from ..runtime.op_reg import (
     AttrArg,
     def_library,
 )
+
+if TYPE_CHECKING:
+    from ..aot import DeviceAffinity
 
 from ..support import debugging
 
@@ -113,8 +120,17 @@ class transfer_to_logical_device(CustomOp):
         ta.specialize_dims(*spec)
         ksel.return_tensor(ta.t).specialize_dims(*spec)
 
-    def eager_execute(self, device_moniker, tensor):
-        return tensor.clone()
+    def eager_execute(self, device_moniker: str, tensor: torch.Tensor):
+        if iree_device_moniker_to_torch_device_map is None:
+            # Clone to match the semantics in eager.
+            # When transferring the result is a new tensor.
+            return tensor.clone()
+
+        target_torch_device = iree_device_moniker_to_torch_device_map[device_moniker]
+        if torch_device_equal(tensor.device, target_torch_device):
+            return tensor.clone()
+        else:
+            return tensor.to(device=target_torch_device)
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         moniker = cast(AttrArg, ksel.arg_descs[0]).v
@@ -149,6 +165,53 @@ class barrier_on_logical_device(CustomOp):
         target = Attribute.parse(f'#hal.device.promise<@"__device_{moniker}">')
         result = flow_d.TensorBarrierOp(t, dynamic_dims, target).result
         kb.yield_results(result)
+
+
+################################################################################
+# IREE device affinity to torch device map
+################################################################################
+
+iree_device_moniker_to_torch_device_map: dict[str, torch.device] | None = None
+
+
+def set_iree_device_affinity_to_torch_device_map(
+    map: dict["DeviceAffinity", torch.device] | None = None,
+):
+    moniker_map = None
+    if map is not None:
+        moniker_map = {str(k.ordinal): v for k, v in map.items()}
+    global iree_device_moniker_to_torch_device_map
+    iree_device_moniker_to_torch_device_map = moniker_map
+
+
+class IreeDeviceAffinityToTorchDevice(AbstractContextManager):
+    """Allows for tensor transfers between devices in eager mode.
+
+    Example:
+
+    .. code-block:: Python
+
+        t = torch.tensor([1, 2], device="cuda:2")
+        with IreeDeviceAffinityToTorchDevice({
+            DeviceAffinity(0): torch.device("cuda:2"),
+            DeviceAffinity(1): torch.device("cuda:3")
+        }):
+            t2 = transfer_to_logical_device("1", t) # move to cuda:3
+            t3 = transfer_to_logical_device("0", t2) # move back to cuda:2
+    """
+
+    def __init__(self, map: dict["DeviceAffinity", torch.device] | None):
+        self.map = deepcopy(map)
+        self._old_map: list[dict[str, torch.device] | None] = []
+
+    def __enter__(self):
+        global iree_device_moniker_to_torch_device_map
+        self._old_map.append(iree_device_moniker_to_torch_device_map)
+        set_iree_device_affinity_to_torch_device_map(self.map)
+
+    def __exit__(self, *excinfo):
+        global iree_device_moniker_to_torch_device_map
+        iree_device_moniker_to_torch_device_map = self._old_map.pop()
 
 
 ################################################################################

--- a/iree/turbine/support/torch.py
+++ b/iree/turbine/support/torch.py
@@ -1,0 +1,35 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+
+
+def has_torch_device(d: str) -> bool:
+    device = torch.device(d)
+    if device.type == "cpu":
+        return True
+    if (
+        device.type == "cuda"
+        and torch.cuda.is_available()
+        and (device.index is None or device.index < torch.cuda.device_count())
+    ):
+        return True
+
+    return False
+
+
+def torch_device_equal(d1: torch.device, d2: torch.device) -> bool:
+    if d1.type == "cuda":
+        # Somehow torch considers "cuda" and "cuda:0" different devices.
+        # Even when the default device is "cuda:0".
+        default_device = torch.get_default_device()
+        default_cuda_index = 0
+        if default_device.type == "cuda" and default_device.index is not None:
+            default_cuda_index = default_device.index
+        i1 = d1.index if d1.index is not None else default_cuda_index
+        i2 = d2.index if d2.index is not None else default_cuda_index
+        return d1.type == d2.type and i1 == i2
+    return d1 == d2


### PR DESCRIPTION
Currently we only issue device transfer ops when exporting. With this change a new export-device-affinity-to-torch-device configuration map is introduced that allows us to do actual transfers in eager.

```
t = torch.tensor([1, 2], device="cuda:2")
with IreeDeviceAffinityToTorchDevice({
    DeviceAffinity(0): torch.device("cuda:2"),
    DeviceAffinity(1): torch.device("cuda:3")
}):
    t2 = transfer_to_logical_device("1", t) # transfer to cuda:3
    t3 = transfer_to_logical_device("0", t2) # transfer back to cuda:2
```