### PR TITLE
[BOO] Make new sample inputs during `get_launchable` for graph ops

### DIFF
--- a/iree/turbine/kernel/boo/ops/graph.py
+++ b/iree/turbine/kernel/boo/ops/graph.py
@@ -187,7 +187,7 @@ def _define_custom_graph_op(
                 output_mem_format_perms=output_mem_format_perms,
                 source_module=gm,
             ),
-            lambda: handled_inputs,
+            lambda: tuple([torch.empty_like(h_out) for h_out in handled_inputs]),
             func_name=spec_name,
             force_single_dispatch=force_single_dispatch,
         )


### PR DESCRIPTION
This is to protect against certain metadata from getting attached to the subgraph inputs.

I haven't been able to reproduce this issue outside of running a real model yet, so writing a test is proving difficult. 

The issue happens because one of the inputs for the `torch.export` call ends up having some metadata saying it's a parameter of the module, but `LayoutManagedModuleForAOTExport` doesn't have any params. It throws a `KeyError` when trying to rename the missing parameter.

This change will simply sterilize any sample inputs for the export process. I'll try to isolate a test for this in a follow up PR.