### PR TITLE
[BOO] Add flag to run transpose filter preprocessing pipeline

### DIFF
--- a/iree/turbine/kernel/boo/runtime/launch.py
+++ b/iree/turbine/kernel/boo/runtime/launch.py
@@ -231,6 +231,9 @@ def default_compiler_flags_callback(device: Device, cache_dir: Path) -> list[str
         flags.append(
             "--iree-dispatch-creation-enable-fuse-padding-into-linalg-consumer-ops"
         )
+        flags.append(
+            "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-filter-pipeline)"
+        )
         if BOO_TUNING_SPEC_PATH != "":
             assert Path(
                 BOO_TUNING_SPEC_PATH

--- a/iree/turbine/kernel/boo/runtime/launch.py
+++ b/iree/turbine/kernel/boo/runtime/launch.py
@@ -232,7 +232,7 @@ def default_compiler_flags_callback(device: Device, cache_dir: Path) -> list[str
             "--iree-dispatch-creation-enable-fuse-padding-into-linalg-consumer-ops"
         )
         flags.append(
-            "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-filter-pipeline)"
+            "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-convert-conv-filter-to-channels-last)"
         )
         if BOO_TUNING_SPEC_PATH != "":
             assert Path(


### PR DESCRIPTION
This flag is applied together with https://github.com/iree-org/iree/pull/22100 to transpose the convolution filter layout for input backward convolutions.