### PR TITLE
[boo driver] Trim allocations between benchmark runs

### DIFF
--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -22,6 +22,7 @@ from iree.turbine.kernel.boo.exports.signature import OpSignature
 from iree.turbine.kernel.boo.driver.launch import get_launchable
 from iree.turbine.kernel.boo.op_exports.registry import BooOpRegistry
 from iree.turbine.kernel.boo.driver.utils import get_timing_parser
+from iree.turbine.runtime.device import get_device_from_torch
 
 ZoneData = dict[str, list[float]]
 
@@ -247,6 +248,10 @@ def run(
     verbose: bool,
 ) -> None:
     """Distributes `iter`-many applications of `func` to `per_device_args`."""
+    # HIP backend caches allocations by default and can OOM if not explicitly cleared.
+    for device in devices:
+        get_device_from_torch(device).hal_device.allocator.trim()
+
     num_devices = len(per_device_args)
     iter_per_device = iter // num_devices
     rem_iter = iter % num_devices


### PR DESCRIPTION
This resolves OOM issues I've been hitting when doing large benchmarking runs, by clearing IREE's allocation cache. The HIP backend keeps a cache of allocations, and never frees entries in the cache. If a program continuously allocates memory of different sizes (like our driver does when benchmarking different configs), it'll eventually run out of memory.

A longer term fix would be to disable IREE's async caching in turbine, but that currently causes performance regressions.