### PR TITLE
Add py.typed file to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,10 @@ setup(
     include_package_data=True,
     package_data={
         "iree.turbine": [
-            "ops/templates/*.mlir",
+            "py.typed",
+            "ops/templates/*.mlir",  # Include MLIR templates
             "kernel/boo/runtime/tuning_specs.mlir",
-        ],  # Include MLIR templates
+        ],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
It turns out this is needed for the wheels created by CI, but not for wheels I create locally. `setuptools` includes this automatically, but only in newer versions:
> Added in version v69.0.0: setuptools will attempt to include type information files by default in the distribution (.pyi and py.typed, as specified in PEP 561), as long as they are contained inside of a package directory (for the time being there is no automatic support for top-level .pyi files).
https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html

I've run the package building workflow on this branch and verified it actually has the `py.typed` file: https://github.com/iree-org/iree-turbine/actions/runs/18415728605