### PR TITLE
remove split and split_with_sizes from decomp lists

### DIFF
--- a/iree/turbine/dynamo/decompositions.py
+++ b/iree/turbine/dynamo/decompositions.py
@@ -80,8 +80,6 @@ def _get_default_decomposition_ops() -> DecompositionOpsList:
         aten.norm.ScalarOpt_dim,
         aten.native_group_norm,
         aten.upsample_bilinear2d.vec,
-        aten.split.Tensor,
-        aten.split_with_sizes,
         aten.native_layer_norm,
         aten.masked_fill.Tensor,
         aten.masked_fill.Scalar,


### PR DESCRIPTION
See https://github.com/llvm/torch-mlir/issues/4339 for more context.

We need to remove `split.tensor` and `split_with_sizes` from the decomp list so we don't further decompose to `as_strided`, which is problematic as described in the issue above.