### PR TITLE
Pytorch 2.9 compatability fix

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -548,7 +548,7 @@ def _device_import_torch_tensor_cuda_hip(
     # The None passed to tensor.__dlpack__ indicates we are doing no stream synchronization here.
     # We launch kernels through IREE runtime on the same stream as pytorch. If using multiple
     # streams, the user is expected to properly manage stream synchronization.
-    capsule = t.__dlpack__(None)
+    capsule = t.__dlpack__(stream=None)
     bv = device.hal_device.from_dlpack_capsule(capsule)
     return bv
 


### PR DESCRIPTION
I'm doing some initial testing of pytorch 2.9, and the `stream` argument to `Tensor.__dlpack__` is now keyword-only.