### PR TITLE
[boo] Remove OpSignature.get_output_size()

### DIFF
--- a/iree/turbine/kernel/boo/exports/signature.py
+++ b/iree/turbine/kernel/boo/exports/signature.py
@@ -61,11 +61,6 @@ class OpSignature(ABC):
         """Generates a PyTorch neural network module containing this operation."""
         ...
 
-    @abstractmethod
-    def get_output_size(self) -> int:
-        """Returns the size of this operation outputs in bytes."""
-        ...
-
     @property
     @abstractmethod
     def is_forward(self) -> bool:

--- a/iree/turbine/kernel/boo/op_exports/conv.py
+++ b/iree/turbine/kernel/boo/op_exports/conv.py
@@ -414,27 +414,6 @@ class ConvSignature(OpSignature):
             return ConvCustomBackward(self)
         return ConvBackward(self)
 
-    def get_output_size(self) -> int:
-        numel = 0
-        dtype_bytes = int(self.dtype.itemsize)
-        mask = self.backward_mask
-        if not any(mask):
-            numel = math.prod(self.output_shape)
-            return numel * dtype_bytes
-        for m, shape in zip(
-            mask,
-            [
-                self.input_shape,
-                self.kernel_shape,
-                [self.kernel_shape[self.kernel_layout.find("N")]],
-            ],
-            strict=True,
-        ):
-            if not m:
-                continue
-            numel += math.prod(shape)
-        return numel * dtype_bytes
-
 
 class ConvForward(torch.nn.Module):
     def __init__(self, sig: ConvSignature):

--- a/iree/turbine/kernel/boo/op_exports/gemm.py
+++ b/iree/turbine/kernel/boo/op_exports/gemm.py
@@ -52,12 +52,6 @@ class GEMMSignature(OpSignature):
         self.dtype = dtype
         self.mode = mode
 
-    def get_output_size(self) -> int:
-        """Returns the size of the output tensor in bytes."""
-        m = self.a_shape[0]
-        n = self.b_shape[1]
-        return math.prod([m, n]) * self.dtype.itemsize
-
     def get_nn_module(self, **kwargs) -> torch.nn.Module:
         if self.mode == Mode.FORWARD:
             return GEMMForward(self)

--- a/iree/turbine/kernel/boo/op_exports/layer_norm.py
+++ b/iree/turbine/kernel/boo/op_exports/layer_norm.py
@@ -190,27 +190,6 @@ class LayerNormSignature(OpSignature):
             "use_aten": self.use_aten,
         }
 
-    def get_output_size(self) -> int:
-        def get_output_size(mode: Mode) -> int:
-            if mode == Mode.FORWARD:
-                return (
-                    math.prod(self.output_shape) + 2 * math.prod(self.aggregate_shape)
-                ) * int(self.dtype.itemsize)
-            if mode == Mode.INPUT_BACKWARD:
-                return math.prod(self.output_shape) * int(self.dtype.itemsize)
-            if mode == Mode.BIAS_BACKWARD or mode == Mode.WEIGHT_BACKWARD:
-                return math.prod(self.normalized_shape) * int(self.dtype.itemsize)
-            if mode == Mode.FULL_BACKWARD:
-                return sum(
-                    map(
-                        get_output_size,
-                        (Mode.INPUT_BACKWARD, Mode.BIAS_BACKWARD, Mode.WEIGHT_BACKWARD),
-                    )
-                )
-            raise AssertionError(f"Unhandled mode {mode}")
-
-        return get_output_size(self.mode)
-
     def get_nn_module(self, **kwargs) -> torch.nn.Module:
         # TODO: this is specific to conv and may need to be refactored further
         # Note: `use_custom` kwarg is intentionally ignored, since no custom impl is provided.


### PR DESCRIPTION
This simplifies the interface by using actual results to determine output size.