### PR TITLE
[boo driver] Add support for tsv command files

### DIFF
--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -117,12 +117,10 @@ def main():
     extra_cli_args = [a for arg in extra_cli_args for a in arg.split("\t")]
     commands_file: str | None = meta_args.commands_file
     if commands_file:
+        splitter: Callable[[str], list[str]] = lambda s: (
+            s.strip().split("\t") if commands_file.endswith(".tsv") else shlex.split(s)
+        )
         with open(commands_file) as f:
-            splitter: Callable[[str], list[str]]
-            if commands_file.endswith(".tsv"):
-                splitter = lambda s: s.strip().split("\t")
-            else:
-                splitter = shlex.split
             mio_args = [
                 splitter(s) + extra_cli_args
                 for s in f.readlines()


### PR DESCRIPTION
This adds support for consuming tab-separated commands on the command-line and from `.tsv` command files.

For example,
```
$ iree-boo-driver "aten::mm	((3840, 4352), (4352, 3840))	('c10::BFloat16', 'c10::BFloat16')	((1, 3840), (3840, 1))	('', '')"
```
and
```
$ iree-boo-driver --commands-file commands.tsv
```
```tsv
# commands.tsv
aten::mm	((3840, 4352), (4352, 3840))	('c10::BFloat16', 'c10::BFloat16')	((1, 3840), (3840, 1))	('', '')
```
are now equivalent to
```
$ iree-boo-driver aten::mm "((3840, 4352), (4352, 3840))" "('c10::BFloat16', 'c10::BFloat16')" "((1, 3840), (3840, 1))" "('', '')"
```

This is a convenience feature for working with excel sheets that have driver arguments split into columns. Copying from these results in tab-separated values.