### PR TITLE
[boo driver] Enable timing by default

### DIFF
--- a/iree/turbine/kernel/boo/driver/utils.py
+++ b/iree/turbine/kernel/boo/driver/utils.py
@@ -13,7 +13,9 @@ from iree.turbine.kernel.boo.op_exports.registry import BooOpRegistry
 def get_timing_parser() -> argparse.ArgumentParser:
     """This parser separates out timing-specific args from MIOpen commands."""
     timing_parser = argparse.ArgumentParser()
-    timing_parser.add_argument("--time", "-t", type=int, help="Enable timing")
+    timing_parser.add_argument(
+        "--time", "-t", type=int, help="Enable timing", default=1
+    )
     timing_parser.add_argument(
         "--iter", type=int, help="Number of iterations to run", default=100
     )


### PR DESCRIPTION
This is the main purpose of the tool, so it makes sense to have it enabled by default; especially since we no longer require any additional setup (tracy etc.) to use it.