### PR TITLE
[boo driver] Allow skipping default backend

### DIFF
--- a/iree/turbine/kernel/boo/driver/README.md
+++ b/iree/turbine/kernel/boo/driver/README.md
@@ -44,8 +44,8 @@ time is reported, including memory and other operations not necessarily included
 in the kernel itself. Note: you can output statistics to a csv file with
 `--csv=results.csv`.
 
-BOO operations can be compared against a set of reference backends by providing
-one or more `--reference-backend` flags. Currently supported backends include:
+The BOO driver can execute using alternative backends by providing one or more
+`--backend` flags. Currently supported backends include:
 
 - `torch`: Eager Pytorch.
 - `inductor`: Pytorch Inductor (`torch.compile` default).

--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -60,13 +60,14 @@ list of arguments.
     )
     parser.add_argument("--commands-file", type=str, help="read commands from file")
     parser.add_argument(
-        "--reference-backend",
+        "--backend",
+        dest="backends",
         type=str,
-        choices=[k for k in BACKEND_TO_FUNC_GENERATOR.keys() if k != DEFAULT_BACKEND],
+        choices=list(BACKEND_TO_FUNC_GENERATOR.keys()),
         action="append",
         default=[],
         required=False,
-        help="Choose reference backends to compare performance against.",
+        help=f"Choose backends to run. Can be specified multiple times (defaults to '{DEFAULT_BACKEND}')",
     )
     parser.add_argument(
         "--csv",
@@ -130,12 +131,9 @@ def main():
     else:
         mio_args = [extra_cli_args]  # use CLI arguments
 
-    # Check the reference backend
-    ref_backends = meta_args.reference_backend
-
     # Setup a csv output file with headers.
     csv_stats = ALL_STATS
-    backends = [DEFAULT_BACKEND] + ref_backends
+    backends: list[str] = meta_args.backends or [DEFAULT_BACKEND]
     csv_file = csv.writer(
         open(
             meta_args.csv if meta_args.csv is not None else os.devnull, "w", newline=""


### PR DESCRIPTION
This renames `--reference-backend` to `--backend` and changes the behaviour slightly; the default backend will only be run if no backends are specified. This allows running an alternative backend without having to also run the default one.