### PR TITLE
[boo driver] Set `PYTORCH_MIOPEN_SUGGEST_NHWC=1`

### DIFF
--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -347,29 +347,22 @@ def run(
     for i, result in enumerate(results):
         if verbose:
             print(
-                f">>>\tresult #{i} shape: {result.shape}; dtype: {result.dtype}; device type: {result.device.type}"
+                f">>>\tresult #{i} shape: {list(result.shape)}; stride: {list(result.stride())}; dtype: {result.dtype}; device type: {result.device.type}"
             )
     return prof if timing_args.time else None
-
-
-def get_torch_compiled_module(signature: OpSignature, backend: str) -> Callable:
-    """Returns the module defined by the signature compiled using the specified
-    backend."""
-    mod = signature.get_nn_module(use_custom=False)
-    return torch.compile(mod, dynamic=False, backend=backend)
 
 
 DEFAULT_BACKEND = "iree_boo_legacy"
 BACKEND_TO_FUNC_GENERATOR: dict[str, Callable[[OpSignature], Callable]] = {
     "torch": (lambda signature: signature.get_nn_module(use_custom=False)),
-    "inductor": partial(get_torch_compiled_module, backend="inductor"),
+    "inductor": (lambda signature: signature.get_compiled_module(backend="inductor")),
     "iree_boo_legacy": get_launchable,
-    "iree_boo": partial(get_torch_compiled_module, backend="iree_boo"),
-    "iree_boo_experimental": partial(
-        get_torch_compiled_module, backend="iree_boo_experimental"
+    "iree_boo": (lambda signature: signature.get_compiled_module(backend="iree_boo")),
+    "iree_boo_experimental": (
+        lambda signature: signature.get_compiled_module(backend="iree_boo_experimental")
     ),
-    "iree_boo_inductor": partial(
-        get_torch_compiled_module, backend="iree_boo_inductor"
+    "iree_boo_inductor": (
+        lambda signature: signature.get_compiled_module(backend="iree_boo_inductor")
     ),
 }
 

--- a/iree/turbine/kernel/boo/driver/numerics.py
+++ b/iree/turbine/kernel/boo/driver/numerics.py
@@ -115,9 +115,7 @@ def _run(
             raise ValueError(f"Failed parsing a command: {c}.")
 
         reference_module = sig.get_nn_module(use_custom=False)
-        boo_module = torch.compile(
-            reference_module, dynamic=False, backend="iree_boo_experimental"
-        )
+        boo_module = sig.get_compiled_module(backend="iree_boo_experimental")
         sample_args = sig.get_sample_args(device=cpu, seed=seed)
         arg_tensors = {
             "cpu": sample_args,

--- a/tests/kernel/boo/op_exports/conv_backward_impl_test.py
+++ b/tests/kernel/boo/op_exports/conv_backward_impl_test.py
@@ -19,7 +19,7 @@ from iree.turbine.kernel.boo.op_exports.conv import Mode, ConvSignature
 @pytest.mark.parametrize("W", [16])
 @pytest.mark.parametrize("KH", [2, 3])
 @pytest.mark.parametrize("KW", [1])
-@pytest.mark.parametrize("layout", ["NHWC", "NCHW"])
+@pytest.mark.parametrize("layout", ["NHWC", "WCHN"])
 @pytest.mark.parametrize("dilation", [1, 2])
 @pytest.mark.parametrize("padding", [0, 2])
 @pytest.mark.parametrize("stride", [1, 3])
@@ -105,7 +105,7 @@ def test_conv_invalid_layout():
         output_layout="NCHW",
         dtype=torch.float32,
     )
-    module = torch.compile(sig.get_nn_module(), backend="iree_boo")
+    module = sig.get_compiled_module(backend="iree_boo")
     args = sig.get_sample_args(seed=10)
 
     # Pytorch infers an NHWC output layout, which doesn't match the requested layout (NCHW).


### PR DESCRIPTION
This is necessary for getting NHWC outputs for convolutions when using the `iree_boo_experimental` backend. I've also added some checks so that we get an error when we can't get the requested output layout, for example now `--in_layout NHWC --out_layout NCHW --backend iree_boo_experimental` gives:
```
$ iree-boo-driver convbfp16 -n 128 -c 384 -H 24 -W 48 -k 384 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --iter 100 --in_layout NHWC --out_layout NCHW --fil_layout NHWC --backend iree_boo_experimental

>>> convbfp16 -n 128 -c 384 -H 24 -W 48 -k 384 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 --iter 100 --in_layout NHWC --out_layout NCHW --fil_layout NHWC

Traceback (most recent call last):
  File "/home/rkayaith/repos/iree-turbine/iree/turbine/kernel/boo/driver/driver.py", line 188, in main
    prof = run(
           ^^^^
  File "/home/rkayaith/repos/iree-turbine/iree/turbine/kernel/boo/driver/driver.py", line 274, in run
    example_results = func(*per_device_args[0])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rkayaith/repos/iree-turbine/iree/turbine/kernel/boo/exports/signature.py", line 77, in run_and_verify
    self._verify_outputs(result)
  File "/home/rkayaith/repos/iree-turbine/iree/turbine/kernel/boo/op_exports/conv.py", line 425, in _verify_outputs
    raise ValueError(
ValueError: Inferred output layout is not contiguous in requested layout: self.output_layout='NCHW', output.stride()=(442368, 1, 18432, 384)
```