### PR TITLE
[boo] Use channels-last layout for custom conv op with 3D convs

### DIFF
--- a/iree/turbine/kernel/boo/fusion/replacement.py
+++ b/iree/turbine/kernel/boo/fusion/replacement.py
@@ -55,7 +55,7 @@ def replace_aten_convolution(args: tuple[Argument, ...], meta: dict[str, object]
     assert isinstance(example_out, torch.Tensor)
     output_is_channels_last = example_out.is_contiguous(
         memory_format=torch.channels_last
-    )
+    ) or example_out.is_contiguous(memory_format=torch.channels_last_3d)
     return boo_ops.convolution_replacement, (
         input,
         weight,


### PR DESCRIPTION
The missing check here was causing 3D NDHWC convs to have IR emitted with a separate transpose on the output, rather than the conv directly computing a channels-last output layout.

With this change, performance for 3D convs is the same on both `iree_boo_legacy` and `iree_boo_experimental` backends.