### PR TITLE
[boo driver] Set default backend to iree_boo_experimental

### DIFF
--- a/iree/turbine/kernel/boo/driver/driver.py
+++ b/iree/turbine/kernel/boo/driver/driver.py
@@ -352,7 +352,7 @@ def run(
     return prof if timing_args.time else None
 
 
-DEFAULT_BACKEND = "iree_boo_legacy"
+DEFAULT_BACKEND = "iree_boo_experimental"
 BACKEND_TO_FUNC_GENERATOR: dict[str, Callable[[OpSignature], Callable]] = {
     "torch": (lambda signature: signature.get_nn_module(use_custom=False)),
     "inductor": (lambda signature: signature.get_compiled_module(backend="inductor")),


### PR DESCRIPTION
When using pytorch 2.9, the new path through `torch.compile` now has performance parity with the legacy path, allowing us to switch the default.