### PR TITLE
Fix `test_build_release` CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,7 @@ types-decorator==5.2.0.20251101
 typing_extensions
 wheel
 
-# It is expected that you have installed a PyTorch version/variant specific
-# to your needs, so we only include a minimum version spec.
-torch>=2.5
+torch>=2.5,<=2.9
 torchaudio
 torchvision
 


### PR DESCRIPTION
The `build_release` script installs `pytorch-cpu-requirements.txt` followed by `requirements.txt`: https://github.com/iree-org/iree-turbine/blob/8685fa88a1e68568577391e42b9dad220039ce93/build_tools/build_release.py#L176-L179

Since they both contain `torch` requirements we need make sure the constraints match exactly, to ensure the torch install actually gets reused. Now that torch 2.9.1 has been released, `pytorch-cpu-requirements.txt` is currently installing `torch==2.9.0+cpu`, while `requirements.txt` will uninstall the existing torch, and install `torch==2.9.1` instead.