### PR TITLE
[BOO] Swapped strides and dilations in ConvWGrad ctor

### DIFF
--- a/iree/turbine/kernel/boo/op_exports/conv.py
+++ b/iree/turbine/kernel/boo/op_exports/conv.py
@@ -706,8 +706,8 @@ class ConvBackwardWeightCustomGeneric(torch.nn.Module):
             raise NotImplementedError(
                 "unimplemented weight grad decomposition: transposed conv"
             )
-        self.stride = sig.dilation
-        self.dilation = sig.stride
+        self.stride = sig.stride
+        self.dilation = sig.dilation
         self.groups = sig.groups
         self.dtype = sig.dtype
         # Note: need to swap reduction dim to N


### PR DESCRIPTION
Swapped values for initializations of stride and dilation in constructor of custom `ConvBackwardWeightCustomGeneric`.