### PR TITLE
[runtime][rocm] ensure we do not sync streams during dlpack handoff

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -548,9 +548,9 @@ def _device_import_torch_tensor_cuda_hip(
     # No explicit synchronization is made during the pointer handoff to IREE.
     # We launch kernels through IREE runtime on the same stream as pytorch. If using multiple
     # streams, the user is expected to properly manage stream synchronization.
-    # The lower level `_C._to_dlpack` is used to bypass redundant checks in `Tensor.__dlpack__`.
+    # The direct call to `torch.to_dlpack` is used to bypass redundant checks in `Tensor.__dlpack__`.
     # E.g., we know `t`` has a strided layout since we force it to be continuous.
-    capsule = torch._C._to_dlpack(t)
+    capsule = torch.to_dlpack(t)
     bv = device.hal_device.from_dlpack_capsule(capsule)
     return bv
 


### PR DESCRIPTION
Recently, the meaning of `stream=None` has been changed to mean that we are synchronizing with the default stream (see https://github.com/pytorch/pytorch/commit/1d526fe78fcb8e6185f25d4b4340599b35f6a6d9 ).

We could pass `t.__dlpack__(stream=-1)`, but recently added checks in this method will actually error out if the `torch.cuda.current_device` doesn't match that of `t` (this is likely to ensure the "default" stream is appropriate, but we aren't doing any stream synchronization here). Also, things like checking `t.layout == torch.strided_layout` are automatic from our contiguous check. Therefore, I'm opting to bypass `Tensor.__dlpack__` entirely, as all checks in this function are completely redundant for us.

This change results in a reduction of a whopping 25us of CPU overhead *per-pointer* on recent (nightly) pytorch versions.