### PR TITLE
Add iree_tensor_ext.barrier ops to turbine

### DIFF
--- a/iree/turbine/support/ir_imports.py
+++ b/iree/turbine/support/ir_imports.py
@@ -63,6 +63,7 @@ from iree.compiler.dialects import (
     builtin as builtin_d,
     flow as flow_d,
     func as func_d,
+    iree_tensor_ext as iree_tensor_ext_d,
     util as util_d,
     arith as arith_d,
     tensor as tensor_d,


### PR DESCRIPTION
This exposes the IREE barrier ops as turbine custom ops. These are intended to be used as part of the custom lowering of batch norm in BOO.