### PR TITLE
[BOO] Temporary soft revert on inplace invocations

### DIFF
--- a/iree/turbine/kernel/boo/ops/graph.py
+++ b/iree/turbine/kernel/boo/ops/graph.py
@@ -238,7 +238,7 @@ def get_custom_graph_op(
     src_gm: GraphModule,
     *,
     force_single_dispatch: bool = False,
-    inplace_convert: bool = True,
+    inplace_convert: bool = False,
 ) -> torch._ops.OpOverloadPacket:
     """Converts a graph module into a custom operator.
 
@@ -405,7 +405,7 @@ def _define_custom_graph_op(
     output_mem_format_perms: Sequence[MemoryFormatPermutation | None],
     *,
     force_single_dispatch: bool = False,
-    inplace_convert: bool = True,
+    inplace_convert: bool = False,
 ):
     """Defines a custom op from the graph module with given op_name in the boo library."""
     inputs, outputs = _get_io_from_gm(gm)


### PR DESCRIPTION
I noticed some memcopies being introduced in the driver after landing https://github.com/iree-org/iree-turbine/commit/30a5ed29f2937d8ccb12aad0b945c8149b8e27a7


I have a fix in flight, but I wanted to quickly disable while I work on properly guarding against this kind of regression in the future. 