### PR TITLE
Added support for post-replacement replace_getitem_users calls

### DIFF
--- a/iree/turbine/kernel/boo/fusion/replacement.py
+++ b/iree/turbine/kernel/boo/fusion/replacement.py
@@ -5,6 +5,7 @@ from operator import getitem
 import torch
 from torch import fx
 from torch.fx.node import Target, Node
+from torch.fx.passes.shape_prop import TensorMetadata
 
 from ..op_exports.conv import DEFAULT_LAYOUTS
 from iree.turbine.kernel.boo import ops as boo_ops
@@ -149,12 +150,55 @@ def replace_getitem_users(
         _perm = permutations[index]
         with graph.inserting_before(use):
             new_output = graph.call_function(getitem, args=(replacement_node, index))
-            new_output.meta = (
-                use.meta
-                if _perm is None
-                else permute_metadata(use, (_perm.permutation,))
-            )
-            replacement = _apply_perms(new_output, _perm, forward_perm=False)
+            # Handle metadata: if getitem node doesn't have metadata (common after decomposition),
+            # derive it from the parent node's multi-output metadata.
+            new_output.meta = use.meta
+            replacement = new_output
+            if _perm:
+                # Check if use has valid metadata, otherwise derive or synthesize it.
+                use_meta = use.meta.get("tensor_meta")
+                use_val = use.meta.get("val")
+
+                def _synthesize_tensor_metadata(val: torch.Tensor) -> TensorMetadata:
+                    return TensorMetadata(
+                        shape=val.shape,
+                        dtype=val.dtype,
+                        requires_grad=val.requires_grad,
+                        stride=val.stride(),
+                        memory_format=torch.contiguous_format,
+                        is_quantized=False,
+                        qparams={},
+                    )
+
+                if use_meta is None and isinstance(use_val, torch.Tensor):
+                    use_meta = _synthesize_tensor_metadata(use_val)
+                    use.meta = {"tensor_meta": use_meta, "val": use_val}
+
+                if use_meta is None and use_val is None:
+                    # Metadata missing - derive from parent node's multi-output metadata.
+                    og_vals = og_node.meta.get("val")
+                    if isinstance(og_vals, tuple) and index < len(og_vals):
+                        og_val = og_vals[index]
+                        if og_val is None:
+                            # Parent node has None at this index (output is masked out).
+                            # Keep the default metadata, skip permutations.
+                            use_meta = None
+                        else:
+                            assert isinstance(
+                                og_val, torch.Tensor
+                            ), f"Expected tensor at index {index}, got {type(og_val)}"
+                            use_meta = _synthesize_tensor_metadata(og_val)
+                            use.meta = {"tensor_meta": use_meta, "val": og_val}
+                    else:
+                        raise ValueError(
+                            f"Cannot derive metadata for getitem node {use} (index {index}) from "
+                            f"parent node {og_node}. Parent node metadata: {og_node.meta}"
+                        )
+
+                if use_meta is not None:
+                    new_output.meta = permute_metadata(use, (_perm.permutation,))
+                    replacement = _apply_perms(new_output, _perm, forward_perm=False)
+
             use.replace_all_uses_with(replace_with=replacement)
             graph.erase_node(use)
 


### PR DESCRIPTION
After adding support for POST_DECOMPOSITION replacements (https://github.com/iree-org/iree-turbine/pull/1224): 
- Decomposition captures the dispatcher's actual selections
- Graph manipulation preserves our desired ops without re-execution

Changes in this patch:
- Changing metadata derivation for decomposed `getitem` nodes to support replacements after decomposition. 
- Skip permutations when the parent reported None. This keeps multi-output replacements stable after we moved decomposition ahead of replacements.

If a replacement creates ops that need decomposition, doing replacement first would let decomposition handle them. But:
- Current replacements don't create such ops
- If needed, you can add those ops to the decomposition table

For any future replacement policies written, this patch would come in handy.