### PR TITLE
[runtime] Relax check on hip library matching pytorch

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -740,18 +740,6 @@ def _align_hip_library_with_torch() -> None:
         # Whether we were successful or not, don't try again.
         _CURRENT_THREAD.hip_dylib_set = True
     hip_dylib_path = str(rocm_sdk.find_libraries("amdhip64")[0].absolute())  # type: ignore
-    loaded_library = ctypes.CDLL(hip_dylib_path)
-    torch_gpu_library = torch.cuda._utils._get_gpu_runtime_library()._handle  # type: ignore
-    if loaded_library._handle != torch_gpu_library:
-        raise RuntimeError(
-            """Runtime library inconsistency found between pytorch and IREE.\n
-
-            Please consider updating to a newer version of pytorch+rocm, or following the
-            recommendations in the following documentation for your project:\n
-
-            https://github.com/ROCm/TheRock/blob/main/docs/packaging/python_packaging.md
-            """
-        )
     parse_flags(f"--hip_dylib_path=file:{hip_dylib_path}")
     logger.debug("Successfully set hip_dylib_path to:\n\t%s", hip_dylib_path)
 

--- a/tests/runtime/device_test.py
+++ b/tests/runtime/device_test.py
@@ -69,13 +69,6 @@ def test_hip_dylib_path_iree(hip_dylib_path: str):
     ), "Inconsistent dylib paths between hal device and rocm_sdk library."
 
 
-def test_hip_dylib_pytorch(hip_dylib_path: str):
-    # It is annoying to extract the file path from a CDLL, so we compare handles instead.
-    torch_hip_lib = torch.cuda._utils._get_gpu_runtime_library()
-    hip_lib = ctypes.CDLL(hip_dylib_path)
-    assert torch_hip_lib._handle == hip_lib._handle
-
-
 class DeviceTest(unittest.TestCase):
     def test_create(self):
         d = Device("local-task")


### PR DESCRIPTION
The library retrieved as a result of `torch.cuda._utils._get_gpu_runtime_library()` is not actually important for us, as this is only used for creating a custom `_CudaKernel`.

This particular path was also incorrect up until recently (see https://github.com/pytorch/pytorch/commit/b4c8cee0db8f7528b68c08473e16193e79a22dfb), and doesn't reflect the actual hip library pytorch is built against. This causes us to report a false `RuntimeError` for incompatible libraries in some nightly builds coming from TheRock.

As long as the `torch` install matches the `rocm_sdk` install, this should be fine. We shouldn't need to guard explicitly against users with invalid torch+rocm installs. 