### PR TITLE
Use `--iree-rocm-target` instead of `--iree-hip-target`

### DIFF
--- a/iree/turbine/runtime/device.py
+++ b/iree/turbine/runtime/device.py
@@ -768,7 +768,7 @@ def _create_hip_device(torch_device: torch.device, props) -> Optional[Device]:
         hip_target = hip_sku
     if device:
         device.compile_target_flags = device.compile_target_flags + (
-            f"--iree-hip-target={hip_target}",
+            f"--iree-rocm-target={hip_target}",
         )
         device._recompute_target_keys()
     return device


### PR DESCRIPTION
Use `--iree-rocm-target` instead of `--iree-hip-target` to match the upstream IREE rename (https://github.com/iree-org/iree/pull/23420).