### PR TITLE
Bump PyTorch version pin to 2.11 and ROCm to 7.2

### DIFF
--- a/iree/turbine/kernel/boo/ops/utils.py
+++ b/iree/turbine/kernel/boo/ops/utils.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import contextlib
 import os
 import math
 
@@ -15,6 +16,20 @@ from iree.compiler.extras.fx_importer import FxImporter
 from ....support.logging import runtime_logger as logger
 from ....support.ir_imports import Operation, PassManager, Context
 from ....transforms.general.custom_op_expansion import ExpandCustomOpsPass
+
+
+@contextlib.contextmanager
+def enable_predispatch_key():
+    """
+    Temporarily un-exclude the PreDispatch TLS dispatch key. This is required
+    when using 'torch.export.export' within 'torch.compile'.
+    """
+    with torch._C._PreserveDispatchKeyGuard():
+        torch._C._dispatch_tls_set_dispatch_key_excluded(
+            torch._C.DispatchKey.PreDispatch, False
+        )
+        yield
+
 
 __all__ = [
     "is_boo_backward_enabled",
@@ -221,7 +236,8 @@ def generate_custom_op_compatible_ir(
     The provided torch.nn.Module is imported as an mlir function which can be inlined during ExpandCustomOpsPass.
     """
     importer = FxImporter(context=context)
-    e = torch.export.export(module, args=args)
+    with enable_predispatch_key():
+        e = torch.export.export(module, args=args)
     importer.import_program(e, func_name=func_name, func_visibility="private")
     module_op = importer.module_op
     expansion_pass = ExpandCustomOpsPass(module_op)

--- a/iree/turbine/kernel/boo/ops/utils.py
+++ b/iree/turbine/kernel/boo/ops/utils.py
@@ -23,6 +23,8 @@ def enable_predispatch_key():
     """
     Temporarily un-exclude the PreDispatch TLS dispatch key. This is required
     when using 'torch.export.export' within 'torch.compile'.
+
+    This is a workaround for an issue encountered with pytorch 2.11: https://github.com/iree-org/iree-turbine/issues/1338
     """
     with torch._C._PreserveDispatchKeyGuard():
         torch._C._dispatch_tls_set_dispatch_key_excluded(

--- a/iree/turbine/kernel/boo/runtime/launch.py
+++ b/iree/turbine/kernel/boo/runtime/launch.py
@@ -22,6 +22,7 @@ from ....support.ir_imports import PassManager, Context
 from ....transforms.general.custom_op_expansion import ExpandCustomOpsPass
 
 from .cache import OpCacheFiles, is_cache_enabled, LaunchableRuntimeCache
+from ..ops.utils import enable_predispatch_key
 from ....aot import export
 from ....importers.ir import Attribute, MLIRError
 from ....runtime import Launchable, Device
@@ -93,11 +94,12 @@ def get_module_asm(
         logger.debug("Loading cached mlir file at %s", str(mlir_path))
         return mlir_path.read_text()
 
-    e = export(
-        module_factory(),
-        args=tuple(arg_factory()),
-        function_name=func_name,
-    )
+    with enable_predispatch_key():
+        e = export(
+            module_factory(),
+            args=tuple(arg_factory()),
+            function_name=func_name,
+        )
 
     e.import_to("full")
 

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,4 +1,4 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=2.5,<=2.10.0
+torch>=2.5,<=2.11.0
 torchaudio
 torchvision

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,4 +1,4 @@
---index-url https://download.pytorch.org/whl/rocm7.1
-torch>=2.5,<=2.10.0
+--index-url https://download.pytorch.org/whl/rocm7.2
+torch>=2.5,<=2.11.0
 torchaudio
 torchvision


### PR DESCRIPTION
Bump the PyTorch version upper bound from 2.10 to 2.11 and update the ROCm
index from 7.1 to 7.2.

Torch 2.11 enables `_AnalyzeCustomOpInputOutputMode` by default
([pytorch/pytorch@b777c6b](https://github.com/pytorch/pytorch/commit/b777c6bfd615eaa712515c899c1b5cc0092594d4)),
which excludes the `PreDispatch` dispatch key from TLS during custom op
dispatch. This breaks BOO ops that call `torch.export.export` during op
expansion; export traces via `PreDispatch`, so excluding it causes export
to constant-fold instead of tracing, crashing fx_importer.

The fix here is to temporarily un-exclude `PreDispatch` around the `torch.export.export`
calls in BOO op expansion.

Fixes #1338
